### PR TITLE
feat: FILES-187 - Update carbonio-preview-sdk

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,7 +88,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
     <dependency>
       <groupId>com.zextras.carbonio.preview</groupId>
-      <artifactId>carbonio-preview-ce-sdk</artifactId>
+      <artifactId>carbonio-preview-sdk</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
       <dependency>
         <groupId>com.zextras.carbonio.preview</groupId>
-        <artifactId>carbonio-preview-ce-sdk</artifactId>
-        <version>${carbonio-preview-ce-sdk.version}</version>
+        <artifactId>carbonio-preview-sdk</artifactId>
+        <version>${carbonio-preview-sdk.version}</version>
       </dependency>
 
       <dependency>
@@ -146,7 +146,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <caffeine.version>3.0.4</caffeine.version>
     <carbonio-storages-ce.version>0.0.10-SNAPSHOT</carbonio-storages-ce.version>
     <carbonio-user-management-sdk.version>0.1.0</carbonio-user-management-sdk.version>
-    <carbonio-preview-ce-sdk.version>0.2.0</carbonio-preview-ce-sdk.version>
+    <carbonio-preview-sdk.version>0.2.3</carbonio-preview-sdk.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-validator.version>1.7</commons-validator.version>
     <ebean.version>12.13.1</ebean.version>


### PR DESCRIPTION
With the new version of the carbonio-preview-sdk is necessary to specify
the ownerId of the node to be previewed. This allows the preview
functionality to work in carbonio-advanced on a multiserver scenario.