### PR TITLE
feat: FILES-214 - Update carbonio-storages-sdk

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/clients/ServiceDiscoverHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/ServiceDiscoverHttpClient.java
@@ -6,7 +6,7 @@ package com.zextras.carbonio.files.clients;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zextras.carbonio.usermanagement.exceptions.InternalServerError;
-import com.zextras.carbonio.usermanagement.exceptions.Unauthorized;
+import com.zextras.carbonio.usermanagement.exceptions.UnAuthorized;
 import io.vavr.control.Try;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,7 +54,7 @@ public class ServiceDiscoverHttpClient {
 
         return Try.success(valueDecoded);
       }
-      return Try.failure(new Unauthorized());
+      return Try.failure(new UnAuthorized());
     } catch (IOException exception) {
       return Try.failure(new InternalServerError(exception));
     }

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -1395,8 +1395,8 @@ public class NodeDataFetcher {
             copiedBlobResponse = StoragesClient.atUrl("http://127.78.0.2:20002/")
               .uploadPost(
                 FilesIdentifier.of(createdNode.getId(), 1, requesterId),
-                blobResponses.get()
-                  .getBlobStream()
+                blobResponses.get().getBlobStream(),
+                blobResponses.get().getSize()
               );
 
           } else {
@@ -1856,8 +1856,8 @@ public class NodeDataFetcher {
                 copiedBlobResponse = StoragesClient.atUrl("http://127.78.0.2:20002/")
                   .uploadPost(
                     FilesIdentifier.of(node.getId(), newVersion, requesterId),
-                    blobResponses.get()
-                      .getBlobStream()
+                    blobResponses.get().getBlobStream(),
+                    blobResponses.get().getSize()
                   );
 
               } else {

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -313,6 +313,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     String description = Optional
       .ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_DESCRIPTION))
       .orElse("");
+    long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
     String encodedFilename = httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_FILENAME);
     String decodedFilename =
       encodedFilename == null || !Base64.isBase64(encodedFilename)
@@ -340,6 +341,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
           blobService.uploadFile(
             requester,
             context.channel().attr(fileStreamReader).get(),
+            blobLength,
             parentId,
             decodedFilename,
             description
@@ -385,6 +387,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     boolean overwrite = Boolean.parseBoolean(
       httpRequest.headers().getAsString(Headers.UPLOAD_OVERWRITE_VERSION)
     );
+    long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
     String decodedFilename =
       encodedFilename == null || !Base64.isBase64(encodedFilename)
@@ -413,6 +416,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
           blobService.uploadFileVersion(
             requester,
             context.channel().attr(fileStreamReader).get(),
+            blobLength,
             nodeId,
             decodedFilename,
             overwrite

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -123,6 +123,7 @@ public class BlobService {
   public Try<String> uploadFile(
     User requester,
     BufferInputStream bufferInputStream,
+    long blobLength,
     String folderId,
     String filename,
     String description
@@ -152,7 +153,11 @@ public class BlobService {
       try {
         uploadResponse = StoragesClient
           .atUrl(storageUrl)
-          .uploadPost(FilesIdentifier.of(nodeId, 1, requester.getUuid()), bufferInputStream);
+          .uploadPost(
+            FilesIdentifier.of(nodeId, 1, requester.getUuid()),
+            bufferInputStream,
+            blobLength
+          );
 
         System.out.println(uploadResponse.getDigest());
         System.out.println(uploadResponse.getSize());
@@ -208,6 +213,7 @@ public class BlobService {
   public Try<Integer> uploadFileVersion(
     User requester,
     BufferInputStream bufferInputStream,
+    long blobLength,
     String nodeId,
     String filename,
     boolean overwrite
@@ -234,7 +240,8 @@ public class BlobService {
             .atUrl(storageUrl)
             .uploadPut(
               FilesIdentifier.of(nodeId, newVersion, requester.getUuid()),
-              bufferInputStream
+              bufferInputStream,
+              blobLength
             );
 
         } else {
@@ -242,7 +249,8 @@ public class BlobService {
             .atUrl(storageUrl)
             .uploadPost(
               FilesIdentifier.of(nodeId, newVersion, requester.getUuid()),
-              bufferInputStream
+              bufferInputStream,
+              blobLength
             );
         }
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.2.0"
-pkgrel="2"
+pkgver="0.3.0"
+pkgrel="1"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <caffeine.version>3.0.4</caffeine.version>
     <carbonio-storages-ce.version>0.0.10-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-sdk.version>0.1.0</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.1.3</carbonio-user-management-sdk.version>
     <carbonio-preview-sdk.version>0.2.3</carbonio-preview-sdk.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-validator.version>1.7</commons-validator.version>


### PR DESCRIPTION
With the new version of the carbonio-storages-sdk we need to pass the
size of the blob to upload. To do that the system captures the Content-Length 
header parameter in the upload and upload-version APIs.