### PR TITLE
feat: FILES-196 - Implement upload-to API to push files in mailbox store

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -45,6 +45,12 @@ public interface Files {
       String URL      = "carbonio.preview.url";
       String PORT     = "carbonio.preview.port";
     }
+
+    interface Mailbox {
+
+      String URL      = "carbonio.mailbox.url";
+      String PORT     = "carbonio.mailbox.port";
+    }
   }
 
   interface Db {
@@ -503,6 +509,7 @@ public interface Files {
       Pattern GRAPHQL             = Pattern.compile(SERVICE + "graphql/?$");
       Pattern UPLOAD_FILE         = Pattern.compile(SERVICE + "upload/?$");
       Pattern UPLOAD_FILE_VERSION = Pattern.compile(SERVICE + "upload-version/?$");
+      Pattern UPLOAD_FILE_TO      = Pattern.compile(SERVICE + "upload-to/?$");
       Pattern DOWNLOAD_FILE       = Pattern.compile(
         SERVICE + "download/([a-f0-9\\\\-]*)/?([0-9]+)?/?$");
       Pattern PUBLIC_LINK         = Pattern.compile(SERVICE + "link/([a-zA-Z0-9]{8})/?$");

--- a/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
@@ -85,9 +85,11 @@ public class MailboxHttpClient {
           - Remove the first two elements('200', 'null')
           - Remove the ' and the \n characters
          */
-        return Arrays.stream(IOUtils
+        return Arrays
+          .stream(IOUtils
             .toString(mailboxResponse.getEntity().getContent(), StandardCharsets.UTF_8)
-            .split(","))
+            .split(",")
+          )
           .reduce((first, last) -> last)
           .map(aid -> aid.replaceAll("'", "").replaceAll("\n", ""))
           .map(Try::success)

--- a/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.clients;
+
+import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import io.vavr.control.Try;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.content.InputStreamBody;
+import org.apache.http.entity.mime.content.StringBody;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Http client to make http requests to the mailbox. The mailbox is reached via consul.
+ */
+public class MailboxHttpClient {
+
+  private final String mailboxURL;
+  private final String uploadFileEndpoint = "/service/upload?fmt=raw";
+
+  MailboxHttpClient(String mailboxURL) {
+    this.mailboxURL = mailboxURL;
+  }
+
+  public static MailboxHttpClient atURL(String mailboxURL) {
+    return new MailboxHttpClient(mailboxURL);
+  }
+
+  /**
+   * Allows to upload a file to the mailbox store. The attachment id returned should be attached to
+   * a carbonio item (e.g. an already existing mail draft). This method can be used for the
+   * following target module:
+   * <ul>
+   *   <li>{@link TargetModule#MAILS}</li>
+   *   <li>{@link TargetModule#CALENDARS}</li>
+   *   <li>{@link TargetModule#CONTACTS}</li>
+   * </ul>
+   *
+   * @param cookies is a {@link String} representing the cookies of the requesters who wants to
+   * upload the node to the mailbox.
+   * @param fullFilename is a {@link String} representing the node filename with its extension.
+   * @param mimeType is a {@link String} representing the mime-type of the node to upload.
+   * @param file is the {@link InputStream} of the node to upload.
+   *
+   * @return a {@link Try} containing a {@link String} representing the mailbox attachment id
+   * uploaded or a {@link Throwable} if something goes wrong.
+   */
+  public Try<String> uploadFile(
+    String cookies,
+    String fullFilename,
+    String mimeType,
+    InputStream file
+  ) {
+
+    try {
+      CloseableHttpClient client = HttpClients.createMinimal();
+      MultipartEntity multipartEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
+      multipartEntity.addPart("file", new InputStreamBody(file, fullFilename));
+      multipartEntity.addPart("filename", new StringBody(fullFilename));
+      multipartEntity.addPart("ct", new StringBody(mimeType));
+
+      HttpPost request = new HttpPost(mailboxURL + uploadFileEndpoint);
+      request.setHeader("Cookie", cookies);
+      request.setProtocolVersion(new ProtocolVersion("HTTP", 1, 1));
+      request.setEntity(multipartEntity);
+
+      CloseableHttpResponse mailboxResponse = client.execute(request);
+      if (mailboxResponse.getStatusLine().getStatusCode() == 200) {
+        /*
+        This is the mailbox response:
+        '200,'null','85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c'\n
+
+        To extrapolate the attachment id from it, we need to:
+          - Split the response by comma to get a String[] containing three elements
+          - Remove the first two elements('200', 'null')
+          - Remove the ' and the \n characters
+         */
+        return Arrays.stream(IOUtils
+            .toString(mailboxResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+            .split(","))
+          .reduce((first, last) -> last)
+          .map(aid -> aid.replaceAll("'", "").replaceAll("\n", ""))
+          .map(Try::success)
+          .orElseGet(() ->
+            Try.failure(new Exception("Unable to deserialize the mailbox upload response"))
+          );
+      }
+      return Try.failure(new Exception("Upload to mailbox failed: "
+        + mailboxResponse.getStatusLine().getStatusCode()
+        + " "
+        + mailboxResponse.getStatusLine().getReasonPhrase())
+      );
+
+    } catch (Exception exception) {
+      return Try.failure(exception);
+    }
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -76,7 +76,7 @@ public class EbeanDatabaseManager {
     postgresPassword = ServiceDiscoverHttpClient
       .defaultURL("carbonio-files")
       .getConfig("db-password")
-      .getOrElse("38ce42d9a2b2d2734303359fb55555e2");
+      .getOrElse("");
 
     jdbcPostgresUrl = "jdbc:postgresql://"
       + config.getProperty(Files.Config.Database.URL, "127.78.0.2")

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -76,7 +76,7 @@ public class EbeanDatabaseManager {
     postgresPassword = ServiceDiscoverHttpClient
       .defaultURL("carbonio-files")
       .getConfig("db-password")
-      .getOrElse("");
+      .getOrElse("38ce42d9a2b2d2734303359fb55555e2");
 
     jdbcPostgresUrl = "jdbc:postgresql://"
       + config.getProperty(Files.Config.Database.URL, "127.78.0.2")

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/BadRequestException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/BadRequestException.java
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class BadRequestException extends Exception {
+}

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/InternalServerErrorException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/InternalServerErrorException.java
@@ -6,6 +6,10 @@ package com.zextras.carbonio.files.exceptions;
 
 public class InternalServerErrorException extends Exception {
 
+  public InternalServerErrorException(String message) {
+    super(message);
+  }
+
   public InternalServerErrorException(Throwable cause) {
     super(cause);
   }

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/RequestEntityTooLargeException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/RequestEntityTooLargeException.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class RequestEntityTooLargeException extends Exception{
+  public RequestEntityTooLargeException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.zextras.carbonio.files.exceptions.BadRequestException;
 import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
 import com.zextras.carbonio.files.exceptions.NodeNotFoundException;
+import com.zextras.carbonio.files.exceptions.RequestEntityTooLargeException;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -26,7 +27,10 @@ public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
   ) {
     HttpResponseStatus responseStatus;
 
-    if (cause instanceof JsonProcessingException
+    if ( cause instanceof RequestEntityTooLargeException) {
+      responseStatus = HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+    }
+    else if (cause instanceof JsonProcessingException
       || cause instanceof InternalServerErrorException
     ) {
       responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;

--- a/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.netty;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import com.zextras.carbonio.files.exceptions.NodeNotFoundException;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+@Sharable
+public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
+
+  @Override
+  public void exceptionCaught(
+    ChannelHandlerContext context,
+    Throwable cause
+  ) {
+    HttpResponseStatus responseStatus;
+
+    if (cause instanceof JsonProcessingException
+      || cause instanceof InternalServerErrorException
+    ) {
+      responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+    }
+    else if( cause instanceof BadRequestException) {
+      responseStatus = HttpResponseStatus.BAD_REQUEST;
+    }
+    else if( cause instanceof NodeNotFoundException) {
+      responseStatus = HttpResponseStatus.NOT_FOUND;
+    } else {
+      responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    context
+      .writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus))
+      .addListener(ChannelFutureListener.CLOSE);
+  }
+
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -80,7 +80,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
   private Matcher downloadMatcher;
   private Matcher uploadMatcher;
   private Matcher uploadVersionMatcher;
-  private Matcher uploadToMatcher;
   private Matcher publicLinkMatcher;
   private Matcher healthMatcher;
 
@@ -129,7 +128,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         downloadMatcher = Endpoints.DOWNLOAD_FILE.matcher(uriRequest);
         uploadMatcher = Endpoints.UPLOAD_FILE.matcher(uriRequest);
         uploadVersionMatcher = Endpoints.UPLOAD_FILE_VERSION.matcher(uriRequest);
-        uploadToMatcher = Endpoints.UPLOAD_FILE_TO.matcher(uriRequest);
         publicLinkMatcher = Endpoints.PUBLIC_LINK.matcher(uriRequest);
         healthMatcher = Endpoints.HEALTH.matcher(uriRequest);
 
@@ -149,10 +147,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
 
         if (uploadVersionMatcher.find()) {
           uploadFileVersion(context, httpRequest);
-        }
-
-        if (uploadToMatcher.find()) {
-          uploadFileTo(context, httpRequest);
         }
 
         if (healthMatcher.find()) {
@@ -456,19 +450,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         context.flush().close();
         return null;
       });
-  }
-
-  public void uploadFileTo(
-    ChannelHandlerContext context,
-    HttpRequest request
-  ) {
-
-    DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(
-      HttpVersion.HTTP_1_0,
-      HttpResponseStatus.OK
-    );
-    context.write(httpResponse);
-    context.flush().close();
   }
 
   ChannelPromise writeStream(

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/ProcedureController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/ProcedureController.java
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files.API.ContextAttribute;
+import com.zextras.carbonio.files.Files.API.Endpoints;
+import com.zextras.carbonio.files.dal.dao.User;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import com.zextras.carbonio.files.exceptions.NodeNotFoundException;
+import com.zextras.carbonio.files.netty.ExceptionsHandler;
+import com.zextras.carbonio.files.rest.services.ProcedureService;
+import com.zextras.carbonio.files.rest.types.UploadAttachmentResponse;
+import com.zextras.carbonio.files.rest.types.UploadToRequest;
+import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import com.zextras.carbonio.files.utilities.PermissionsChecker;
+import com.zextras.carbonio.usermanagement.exceptions.BadRequest;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.AttributeKey;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Sharable
+public class ProcedureController extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+  private static Logger logger = LoggerFactory.getLogger(ProcedureController.class);
+
+  private final ProcedureService   procedureService;
+  private final PermissionsChecker permissionsChecker;
+
+  @Inject
+  public ProcedureController(
+    ProcedureService procedureService,
+    PermissionsChecker permissionsChecker
+  ) {
+    this.procedureService = procedureService;
+    this.permissionsChecker = permissionsChecker;
+  }
+
+  @Override
+  protected void channelRead0(
+    ChannelHandlerContext context,
+    FullHttpRequest httpRequest
+  ) {
+    if (Endpoints.UPLOAD_FILE_TO.matcher(httpRequest.uri()).find()
+      && HttpMethod.POST.equals(httpRequest.method())
+    ) {
+      uploadToModule(context, httpRequest);
+      return;
+    }
+    logger.error(httpRequest.method() + " " + httpRequest.uri() + ": bad request");
+    context.fireExceptionCaught(new BadRequest());
+  }
+
+  /**
+   * Allows to upload a specific file to a specific {@link TargetModule} module. All the exceptions
+   * are handled by the {@link ExceptionsHandler} handler.
+   *
+   * @param context is the {@link ChannelHandlerContext}
+   * @param httpRequest is the {@link FullHttpRequest}
+   */
+  private void uploadToModule(
+    ChannelHandlerContext context,
+    FullHttpRequest httpRequest
+  ) {
+
+    final User requester = (User) context
+      .channel()
+      .attr(AttributeKey.valueOf(ContextAttribute.REQUESTER))
+      .get();
+
+    final String requesterCookies = (String) context
+      .channel()
+      .attr(AttributeKey.valueOf(ContextAttribute.COOKIES))
+      .get();
+
+    UploadToRequest bodyRequest;
+    try {
+      bodyRequest = new ObjectMapper().readValue(
+        httpRequest.content().toString(StandardCharsets.UTF_8),
+        UploadToRequest.class
+      );
+    } catch (JsonProcessingException exception) {
+      logger.error(httpRequest.uri() + " Unable to deserialize upload-to body request");
+      logger.error(exception.getMessage());
+      context.fireExceptionCaught(exception);
+      return;
+    }
+
+    if (permissionsChecker
+      .getPermissions(bodyRequest.getNodeId().toString(), requester.getUuid())
+      .has(SharePermission.READ_ONLY)
+    ) {
+      procedureService
+        .uploadToModule(
+          bodyRequest.getNodeId(),
+          bodyRequest.getTargetModule(),
+          requester,
+          requesterCookies
+        ).onSuccess(attachmentId -> {
+            try {
+              UploadAttachmentResponse bodyResponse = new UploadAttachmentResponse(attachmentId);
+
+              HttpHeaders headers = new DefaultHttpHeaders(true);
+              headers.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+              headers.add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+
+              HttpResponse httpResponse = new DefaultFullHttpResponse(
+                httpRequest.protocolVersion(),
+                HttpResponseStatus.OK,
+                Unpooled.wrappedBuffer(new ObjectMapper().writeValueAsBytes(bodyResponse)),
+                headers,
+                new DefaultHttpHeaders()
+              );
+
+              logger.info(httpRequest.uri()
+                + ": Uploaded node "
+                + bodyRequest.getNodeId()
+                + " to "
+                + bodyRequest.getTargetModule()
+                + ". The attachment id is: "
+                + attachmentId
+              );
+
+              context
+                .writeAndFlush(httpResponse)
+                .addListener(ChannelFutureListener.CLOSE);
+
+            } catch (JsonProcessingException exception) {
+              logger.error("Unable to serialize upload-to response: " + exception);
+              context.fireExceptionCaught(new InternalServerErrorException(exception));
+            }
+          }
+        ).onFailure(failure -> {
+            logger.error("Unable to upload the blob "
+              + bodyRequest.getNodeId()
+              + " to "
+              + bodyRequest.getTargetModule()
+            );
+            logger.error(failure.getMessage());
+            context.fireExceptionCaught(new InternalServerErrorException(failure));
+          }
+        );
+    } else {
+      logger.error(httpRequest.uri() + " Node " + bodyRequest.getNodeId() + " to upload not found");
+      context.fireExceptionCaught(new NodeNotFoundException());
+    }
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.services;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files.Config.Mailbox;
+import com.zextras.carbonio.files.Files.Config.Storages;
+import com.zextras.carbonio.files.clients.MailboxHttpClient;
+import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.dal.dao.User;
+import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import com.zextras.filestore.model.FilesIdentifier;
+import com.zextras.storages.api.StoragesClient;
+import io.vavr.control.Try;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles all the procedures to perform on external services.
+ */
+public class ProcedureService {
+
+  private final static Logger logger = LoggerFactory.getLogger(ProcedureService.class);
+
+  private final NodeRepository        nodeRepository;
+  private final FileVersionRepository fileVersionRepository;
+  private final String mailboxUrl;
+  private final String storagesUrl;
+
+  @Inject
+  public ProcedureService(
+    NodeRepository nodeRepository,
+    FileVersionRepository fileVersionRepository,
+    FilesConfig filesConfig
+  ) {
+    this.nodeRepository = nodeRepository;
+    this.fileVersionRepository = fileVersionRepository;
+
+    Properties properties = filesConfig.getProperties();
+    mailboxUrl = "http"
+      + properties.getProperty(Mailbox.URL, "127.78.0.2")
+      + properties.getProperty(Mailbox.PORT, "20004");
+    storagesUrl = "http"
+      + properties.getProperty(Storages.URL, "127.78.0.2")
+      + properties.getProperty(Storages.PORT, "20002")
+      + "/";
+  }
+
+  /**
+   * Allows to upload the {@param nodeId} to the carbonio mailbox store. These are the target module
+   * supported:
+   * <ul>
+   *   <li>{@link TargetModule#MAILS}</li>
+   *   <li>{@link TargetModule#CALENDARS}</li>
+   *   <li>{@link TargetModule#CONTACTS}</li>
+   * </ul>
+   *
+   * @param nodeId is a {@link String} of the node id to upload.
+   * @param targetModule is a {@link TargetModule} representing the module to upload.
+   * @param requester is a {@link User} representing the requester of this operation.
+   * @param cookiesRequester is a {@link String} representing the requester cookies necessary to
+   * perform the upload operation.
+   *
+   * @return a {@link Try} containing a {@link String} representing the mailbox attachment id
+   * uploaded or a {@link Throwable} if something goes wrong. These are the possible failures:
+   * <ul>
+   *   <li>{@link BadRequestException} when the node is not a file</li>
+   *   <li>{@link Exception} when the download of the blob to upload fails</li>
+   *   <li>{@link Exception} when the {@link TargetModule} is {@link TargetModule#CHATS} because,
+   *   for now, it is not supported</li>
+   * </ul>
+   */
+  public Try<String> uploadToModule(
+    UUID nodeId,
+    TargetModule targetModule,
+    User requester,
+    String cookiesRequester
+  ) {
+
+    if (!targetModule.equals(TargetModule.CHATS)) {
+      Node nodeToUpload = nodeRepository.getNode(nodeId.toString()).get();
+
+      if (!nodeToUpload.getNodeType().equals(NodeType.FOLDER)) {
+        FileVersion fileVersion = fileVersionRepository.getLastFileVersion(nodeId.toString()).get();
+        InputStream blob;
+        try {
+          blob = StoragesClient
+            .atUrl(storagesUrl)
+            .download(FilesIdentifier.of(
+              nodeId.toString(),
+              nodeToUpload.getCurrentVersion(),
+              requester.getUuid())
+            );
+        } catch (Exception exception) {
+          logger.error("Failed to download the node: " + nodeId);
+          return Try.failure(exception);
+        }
+
+        return MailboxHttpClient
+          .atURL(mailboxUrl)
+          .uploadFile(
+            cookiesRequester,
+            nodeToUpload.getFullName(),
+            fileVersion.getMimeType(),
+            blob
+          );
+      }
+      logger.error("Folder cannot be uploaded to: " + targetModule + " store");
+      return Try.failure(new BadRequestException());
+    }
+    return Try.failure(new Exception(TargetModule.CHATS + " not supported"));
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
@@ -48,11 +48,13 @@ public class ProcedureService {
     this.fileVersionRepository = fileVersionRepository;
 
     Properties properties = filesConfig.getProperties();
-    mailboxUrl = "http"
+    mailboxUrl = "http://"
       + properties.getProperty(Mailbox.URL, "127.78.0.2")
+      + ":"
       + properties.getProperty(Mailbox.PORT, "20004");
-    storagesUrl = "http"
+    storagesUrl = "http://"
       + properties.getProperty(Storages.URL, "127.78.0.2")
+      + ":"
       + properties.getProperty(Storages.PORT, "20002")
       + "/";
   }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
@@ -124,8 +124,9 @@ public class ProcedureService {
       return Try.failure(new BadRequestException());
     }
 
-    return Try.failure(
-      new InternalServerErrorException(MessageFormat.format("{0} not supported", TargetModule.CHATS))
+    return Try.failure(new InternalServerErrorException(
+        MessageFormat.format("{0} not supported", TargetModule.CHATS)
+      )
     );
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadAttachmentResponse.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadAttachmentResponse.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.types;
+
+public class UploadAttachmentResponse {
+
+  private String attachmentId;
+
+  public UploadAttachmentResponse(String attachmentId) {
+    this.attachmentId = attachmentId;
+  }
+
+  public String getAttachmentId() {
+    return attachmentId;
+  }
+
+  public void setAttachmentId(String attachmentId) {
+    this.attachmentId = attachmentId;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadToRequest.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadToRequest.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.types;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class UploadToRequest {
+
+  private UUID         nodeId;
+  private TargetModule targetModule;
+
+  public UUID getNodeId() {
+    return nodeId;
+  }
+
+  public void setNodeId(UUID nodeId) {
+    this.nodeId = nodeId;
+  }
+
+  public TargetModule getTargetModule() {
+    return targetModule;
+  }
+
+  public void setTargetModule(TargetModule targetModule) {
+    this.targetModule = targetModule;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UploadToRequest that = (UploadToRequest) o;
+    return Objects.equals(nodeId, that.nodeId) && targetModule == that.targetModule;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodeId, targetModule);
+  }
+
+  public enum TargetModule {
+    MAILS,
+    CALENDARS,
+    CONTACTS,
+    CHATS
+  }
+}

--- a/core/src/main/resources/carbonio-files.properties
+++ b/core/src/main/resources/carbonio-files.properties
@@ -13,3 +13,6 @@ carbonio.storages.port=20002
 # Carbonio Preview
 carbonio.preview.url=127.78.0.2
 carbonio.preview.port=20003
+# Carbonio Mailbox
+carbonio.mailbox.url=127.78.0.2
+carbonio.mailbox.port=20004

--- a/package/carbonio-files.hcl
+++ b/package/carbonio-files.hcl
@@ -29,6 +29,11 @@ services {
             destination_name = "carbonio-preview"
             local_bind_address = "127.78.0.2"
             local_bind_port = 20003
+          },
+          {
+            destination_name = "carbonio-mailbox"
+            local_bind_address = "127.78.0.2"
+            local_bind_port = 20004
           }
         ]
       }


### PR DESCRIPTION
The upload-to API allows to upload a specific file to the carbonio
mailbox store. It returns an attachment id that can be attached to a
carbonio item (e.g. a carbonio mail draft).

The MailboxHttpClient has been implemented in order to execute the upload.

The ExceptionsHandler has been implemented to handle the exceptions in
one place. It has been attached as the last handler of the netty
channel. For now it is used only for this API but in the future it can
be used by every APIs.