### PR TITLE
fix: FILES-218 - setup log configuration

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -65,11 +65,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <artifactId>slf4j-api</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>logback-classic</artifactId>
       <groupId>ch.qos.logback</groupId>
     </dependency>

--- a/boot/src/main/java/com/zextras/carbonio/files/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/Boot.java
@@ -10,7 +10,6 @@ import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.config.FilesModule;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.tasks.PurgeService;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/boot/src/main/java/com/zextras/carbonio/files/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/Boot.java
@@ -10,18 +10,28 @@ import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.config.FilesModule;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.tasks.PurgeService;
-import org.slf4j.Logger;
+import ch.qos.logback.classic.Logger;
 import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.Level;
 
 public class Boot {
 
-  private static final Logger logger = LoggerFactory.getLogger(Boot.class);
+  private static final Logger logger = (Logger) LoggerFactory.getLogger(Boot.class);
 
   public static void main(String[] args) {
     new Boot().boot();
   }
 
   public void boot() {
+    // Set configuration level
+    String logLevel = System.getenv("FILES_LOG_LEVEL");
+    logger.setLevel(
+      Level.toLevel(
+        logLevel == null
+          ? "warn"
+          : logLevel
+      )
+    );
     Injector injector = Guice.createInjector(new FilesModule());
 
     FilesConfig filesConfig = injector.getInstance(FilesConfig.class);

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -16,18 +16,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>/var/log/carbonio/files/files.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/carbonio/files/files.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <timeBasedFileNamingAndTriggeringPolicy
-        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-        <!-- or whenever the file size reaches 50MB -->
-        <maxFileSize>50MB</maxFileSize>
-      </timeBasedFileNamingAndTriggeringPolicy>
+      <!-- each file should be at most 10MB-->
+      <maxFileSize>10MB</maxFileSize>
       <!-- keep 30 days' worth of history -->
       <maxHistory>30</maxHistory>
+      <!-- Keep at maximum 1GB of logs -->
+      <totalSizeCap>1GB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
@@ -41,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <!-- <logger name="io.ebean" level="TRACE"/> -->
 
   <root level="INFO">
-    <appender-ref ref="FILE" />
+    <appender-ref ref="ROLLING" />
     <appender-ref ref="STDOUT" />
   </root>
 

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -16,12 +16,22 @@ SPDX-License-Identifier: AGPL-3.0-only
     </encoder>
   </appender>
 
-  <appender class="ch.qos.logback.core.FileAppender" name="FILE">
-    <append>true</append>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/var/log/carbonio/files/files.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <!-- daily rollover -->
+      <fileNamePattern>/var/log/carbonio/files/files.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy
+        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <!-- or whenever the file size reaches 50MB -->
+        <maxFileSize>50MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <!-- keep 30 days' worth of history -->
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
-    <file>/var/log/carbonio/files/files.log</file>
   </appender>
 
   <!-- To log generated queries-->

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -8,10 +8,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <configuration>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <appender class="ch.qos.logback.core.FileAppender" name="FILE">
     <append>true</append>
     <encoder>
-      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
     <file>/var/log/carbonio/files/carbonio-files.log</file>
   </appender>
@@ -23,7 +31,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <!-- <logger name="io.ebean" level="TRACE"/> -->
 
   <root level="INFO">
-    <appender-ref ref="FILE"/>
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
   </root>
 
 </configuration>

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
-    <file>/var/log/carbonio/files/carbonio-files.log</file>
+    <file>/var/log/carbonio/files/files.log</file>
   </appender>
 
   <!-- To log generated queries-->

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -23,10 +23,10 @@ SPDX-License-Identifier: AGPL-3.0-only
       <fileNamePattern>/var/log/carbonio/files/files.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <!-- each file should be at most 10MB-->
       <maxFileSize>10MB</maxFileSize>
-      <!-- keep 30 days' worth of history -->
-      <maxHistory>30</maxHistory>
-      <!-- Keep at maximum 1GB of logs -->
-      <totalSizeCap>1GB</totalSizeCap>
+      <!-- keep 50 days' worth of history -->
+      <maxHistory>50</maxHistory>
+      <!-- Keep at maximum 500MB of logs -->
+      <totalSizeCap>500MB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,16 +92,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <artifactId>slf4j-api</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>slf4j-simple</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>logback-classic</artifactId>
       <groupId>ch.qos.logback</groupId>
     </dependency>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.3.0"
+pkgver="0.3.1"
 pkgrel="1"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
@@ -68,6 +68,9 @@ postinst() {
     groupadd -r 'carbonio-files'
   getent passwd 'carbonio-files' >/dev/null ||
     useradd -r -M -g 'carbonio-files' -s /sbin/nologin 'carbonio-files'
+
+  mkdir -p "/var/log/carbonio/files/"
+  chown carbonio-files:carbonio-files "/var/log/carbonio/files"
 
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :

--- a/package/carbonio-files.service
+++ b/package/carbonio-files.service
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zextras/common/bin/java -Djava.net.preferIPv4Stack=true -jar /usr/bin/carbonio/files/carbonio-files.jar
+ExecStart=/opt/zextras/common/bin/java -Djava.net.preferIPv4Stack=true -DFILES_LOG_LEVEL=warn -jar /usr/bin/carbonio/files/carbonio-files.jar
 User=carbonio-files
 Group=carbonio-files
 Restart=on-failure

--- a/pom.xml
+++ b/pom.xml
@@ -81,18 +81,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <artifactId>slf4j-api</artifactId>
-        <groupId>org.slf4j</groupId>
-        <version>${slf4j-api.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>slf4j-simple</artifactId>
-        <groupId>org.slf4j</groupId>
-        <version>${slf4j-api.version}</version>
-      </dependency>
-
-      <dependency>
         <artifactId>logback-classic</artifactId>
         <groupId>ch.qos.logback</groupId>
         <version>${logback-classic.version}</version>
@@ -158,7 +146,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven.compiler.target>11</maven.compiler.target>
     <netty.version>4.1.68.Final</netty.version>
     <postgresql.version>42.3.0</postgresql.version>
-    <slf4j-api.version>1.7.32</slf4j-api.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
logback was not correctly initialized because there were wrong dependencies, mainly sl4j was overriding logback. 
Now logs can print to console and to file 