### PR TITLE
fix: FILES-221 - Fix download and public link permissions

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -76,10 +76,16 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
 
     if (Endpoints.DOWNLOAD_FILE.matcher(request.uri()).matches()
       || Endpoints.UPLOAD_FILE.matcher(request.uri()).matches()
-      || Endpoints.UPLOAD_FILE_VERSION.matcher(request.uri()).matches()
-      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+      || Endpoints.UPLOAD_FILE_VERSION.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("auth-handler", authenticationHandler)
+        .addLast("rest-handler", blobController);
+      context.fireChannelRead(request);
+      return;
+    }
+
+    if (Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+      context.pipeline()
         .addLast("rest-handler", blobController);
       context.fireChannelRead(request);
       return;


### PR DESCRIPTION
Checked if the requester has the READ_ONLY permissions when it tries to
download a node.

Removed the cookies check when an user tries to download a node via a
public link

Updated the Jenkinsfile in order to upload the package on the develop
branch