### PR TITLE
feat: FILES-247 - Expose service discover configs with GraphQL

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -561,15 +561,18 @@ public interface Files {
     }
   }
 
-  interface Consul {
+  interface ServiceDiscover {
 
     String SERVICE_NAME = "carbonio-files";
 
     interface Config {
 
-      String MAX_VERSIONS = "max-number-of-versions";
-
-      String DEFAULT_MAX_VERSIONS = "30";
+      String MAX_VERSIONS                          = "max-number-of-versions";
+      int    DEFAULT_MAX_VERSIONS                  = 30;
+      String MAX_KEEP_VERSIONS                     = "max-number-of-keep-versions";
+      int    DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION = 2;
+      int    DEFAULT_MAX_KEEP_VERSIONS             =
+        DEFAULT_MAX_VERSIONS - DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION;
     }
 
   }

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -18,38 +18,38 @@ public interface Files {
 
     interface Service {
 
-      String URL      = "service.url";
-      String PORT     = "service.port";
+      String URL  = "service.url";
+      String PORT = "service.port";
     }
 
     interface Database {
 
-      String URL      = "db.postgresql.url";
-      String PORT     = "db.postgresql.port";
+      String URL  = "db.postgresql.url";
+      String PORT = "db.postgresql.port";
     }
 
     interface UserManagement {
 
-      String URL      = "carbonio.user-management.url";
-      String PORT     = "carbonio.user-management.port";
+      String URL  = "carbonio.user-management.url";
+      String PORT = "carbonio.user-management.port";
     }
 
     interface Storages {
 
-      String URL      = "carbonio.storages.url";
-      String PORT     = "carbonio.storages.port";
+      String URL  = "carbonio.storages.url";
+      String PORT = "carbonio.storages.port";
     }
 
     interface Preview {
 
-      String URL      = "carbonio.preview.url";
-      String PORT     = "carbonio.preview.port";
+      String URL  = "carbonio.preview.url";
+      String PORT = "carbonio.preview.port";
     }
 
     interface Mailbox {
 
-      String URL      = "carbonio.mailbox.url";
-      String PORT     = "carbonio.mailbox.port";
+      String URL  = "carbonio.mailbox.url";
+      String PORT = "carbonio.mailbox.port";
     }
   }
 
@@ -239,6 +239,7 @@ public interface Files {
       String GET_VERSIONS         = "getVersions";
       String GET_LINKS            = "getLinks";
       String GET_ACCOUNT_BY_EMAIL = "getAccountByEmail";
+      String GET_CONFIGS          = "getConfigs";
     }
 
     /**
@@ -498,6 +499,12 @@ public interface Files {
       String EXPIRES_AT  = "expires_at";
       String DESCRIPTION = "description";
     }
+
+    interface Config {
+
+      String NAME  = "name";
+      String VALUE = "value";
+    }
   }
 
   interface API {
@@ -516,24 +523,24 @@ public interface Files {
 
       String PUBLIC_LINK_URL = "/services/files/link/";
 
-      Pattern PREVIEW         = Pattern.compile(SERVICE + "preview/(.*)");
-      Pattern PREVIEW_IMAGE   = Pattern.compile(
+      Pattern PREVIEW            = Pattern.compile(SERVICE + "preview/(.*)");
+      Pattern PREVIEW_IMAGE      = Pattern.compile(
         SERVICE
           + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_IMAGE = Pattern.compile(
+      Pattern THUMBNAIL_IMAGE    = Pattern.compile(
         SERVICE + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
-      Pattern PREVIEW_PDF     = Pattern.compile(
+      Pattern PREVIEW_PDF        = Pattern.compile(
         SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_PDF   = Pattern.compile(
+      Pattern THUMBNAIL_PDF      = Pattern.compile(
         SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
-      Pattern PREVIEW_DOCUMENT     = Pattern.compile(
+      Pattern PREVIEW_DOCUMENT   = Pattern.compile(
         SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_DOCUMENT   = Pattern.compile(
+      Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
         SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
     }
@@ -553,4 +560,18 @@ public interface Files {
       String COOKIES   = "cookies";
     }
   }
+
+  interface Consul {
+
+    String SERVICE_NAME = "carbonio-files";
+
+    interface Config {
+
+      String MAX_VERSIONS = "max-number-of-versions";
+
+      String DEFAULT_MAX_VERSIONS = "30";
+    }
+
+  }
+
 }

--- a/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
@@ -24,7 +24,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 /**
- * Http client to make http requests to the mailbox. The mailbox is reached via consul.
+ * Http client to make http requests to the mailbox. The mailbox is reached via service discover.
  */
 public class MailboxHttpClient {
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -8,6 +8,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.graphql.datafetchers.ConfigDataFetcher;
 import com.zextras.carbonio.files.graphql.datafetchers.DateTimeScalar;
 import com.zextras.carbonio.files.graphql.datafetchers.LinkDataFetcher;
 import com.zextras.carbonio.files.graphql.datafetchers.NodeDataFetcher;
@@ -49,6 +50,7 @@ public class GraphQLProvider {
   private final UserDataFetcher       userDataFetcher;
   private final ShareDataFetcher      shareDataFetcher;
   private final LinkDataFetcher       linkDataFetcher;
+  private final ConfigDataFetcher     configDataFetcher;
 
   @Inject
   public GraphQLProvider(
@@ -56,13 +58,15 @@ public class GraphQLProvider {
     NodeDataFetcher nodeDataFetcher,
     UserDataFetcher userDataFetcher,
     ShareDataFetcher shareDataFetcher,
-    LinkDataFetcher linkDataFetcher
+    LinkDataFetcher linkDataFetcher,
+    ConfigDataFetcher configDataFetcher
   ) {
     this.inputFieldsController = inputFieldsController;
     this.nodeDataFetcher = nodeDataFetcher;
     this.userDataFetcher = userDataFetcher;
     this.shareDataFetcher = shareDataFetcher;
     this.linkDataFetcher = linkDataFetcher;
+    this.configDataFetcher = configDataFetcher;
     graphQL = this.setup();
   }
 
@@ -203,6 +207,7 @@ public class GraphQLProvider {
           userDataFetcher.getAccountByEmailFetcher()
         )
         .dataFetcher(Files.GraphQL.Queries.GET_LINKS, linkDataFetcher.getLinks())
+        .dataFetcher(Files.GraphQL.Queries.GET_CONFIGS, configDataFetcher.getConfigs())
       )
       .type(newTypeWiring("Mutation")
         .dataFetcher(Files.GraphQL.Mutations.CREATE_FOLDER, nodeDataFetcher.createFolderFetcher())

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
@@ -2,8 +2,8 @@ package com.zextras.carbonio.files.graphql.datafetchers;
 
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
-import com.zextras.carbonio.files.Files.Consul;
-import com.zextras.carbonio.files.Files.Consul.Config;
+import com.zextras.carbonio.files.Files.ServiceDiscover;
+import com.zextras.carbonio.files.Files.ServiceDiscover.Config;
 import com.zextras.carbonio.files.Files.GraphQL;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.files.graphql.GraphQLProvider;
@@ -18,24 +18,26 @@ import java.util.concurrent.CompletableFuture;
 /**
  * <p>Contains all the implementations of {@link DataFetcher}s for all the queries and mutations
  * defined in the GraphQL schema that are related to the {@link Files.GraphQL.Config} type.</p>
- * <p>Each {@link DataFetcher} implementation is asynchronous and returns a {@link List} of {@link HashMap}
- * containing the data fetched from consul.</p>
+ * <p>Each {@link DataFetcher} implementation is asynchronous and returns a {@link List} of
+ * {@link HashMap} containing the data fetched from service discover.</p>
  * <p>These {@link DataFetcher}s will be used in the {@link GraphQLProvider} where they are bound
  * with the related queries, mutations and composed attributes.</p>
  */
 public class ConfigDataFetcher {
 
   private final Map<String, String> configMap;
+  private       String              maxKeepVersionsValue;
 
   /**
    * <p> This constructor initializes the map of config keys which values will be
-   * requested at consul.
-   * The value is initialized at the default value of every specific configuration</p>
+   * requested at service discover. The value is initialized at the default value of every specific
+   * configuration</p>
    */
   @Inject
   public ConfigDataFetcher() {
     configMap = new HashMap<>();
-    configMap.put(Config.MAX_VERSIONS, Config.DEFAULT_MAX_VERSIONS);
+    configMap.put(Config.MAX_VERSIONS, String.valueOf(Config.DEFAULT_MAX_VERSIONS));
+    maxKeepVersionsValue = String.valueOf(Config.DEFAULT_MAX_KEEP_VERSIONS);
   }
 
   /**
@@ -43,34 +45,49 @@ public class ConfigDataFetcher {
    * query.</p>
    * <p>The request does not need any parameters in input.</p>
    * <h2>Behaviour:</h2>
-   * <p>It fetches the configs from consul, if one of the configs is not found it will return the
-   * default value for that config. </p>
+   * <p>It fetches the configs from service discover, if one of the configs is not found it will
+   * return the default value for that config. </p>
    *
-   * @return an asynchronous {@link DataFetcher} containing a {@link List} with a
-   * {@link  Map} in every entry.
+   * @return an asynchronous {@link DataFetcher} containing a {@link List} with a {@link  Map} in
+   * every entry.
    */
   public DataFetcher<CompletableFuture<List<DataFetcherResult<Map<String, String>>>>> getConfigs() {
     return environment -> CompletableFuture.supplyAsync(() -> {
       List<DataFetcherResult<Map<String, String>>> result = new ArrayList<>();
       configMap.forEach((key, value) -> {
-        Map<String, String> resultMap = new HashMap<>();
-        resultMap.put(
-          GraphQL.Config.NAME,
-          key
-        );
-        resultMap.put(
-          GraphQL.Config.VALUE,
-          ServiceDiscoverHttpClient
-            .defaultURL(Consul.SERVICE_NAME)
-            .getConfig(key)
-            .getOrElse(value)
-        );
-        result.add(DataFetcherResult
-          .<Map<String, String>>newResult()
-          .data(resultMap)
-          .build());
+        String currValue = ServiceDiscoverHttpClient
+          .defaultURL(ServiceDiscover.SERVICE_NAME)
+          .getConfig(key)
+          .getOrElse(value);
+        result.add(convertConfigToGraphQLMap(key, currValue));
       });
+      result.add(convertConfigToGraphQLMap(Config.MAX_KEEP_VERSIONS, maxKeepVersionsValue));
       return result;
     });
+  }
+
+  private DataFetcherResult<Map<String, String>> convertConfigToGraphQLMap(
+    String key,
+    String value
+  ) {
+    Map<String, String> resultMap = new HashMap<>();
+    resultMap.put(
+      GraphQL.Config.NAME,
+      key
+    );
+    resultMap.put(
+      GraphQL.Config.VALUE,
+      value
+    );
+    // TODO: Federico, FIX ME PLEASE
+    if (Config.MAX_VERSIONS.equals(key)) {
+      maxKeepVersionsValue = Integer.parseInt(value) <= Config.DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION
+        ? "0"
+        : String.valueOf(Integer.parseInt(value) - Config.DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION);
+    }
+    return DataFetcherResult
+      .<Map<String, String>>newResult()
+      .data(resultMap)
+      .build();
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
@@ -1,0 +1,76 @@
+package com.zextras.carbonio.files.graphql.datafetchers;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.Consul;
+import com.zextras.carbonio.files.Files.Consul.Config;
+import com.zextras.carbonio.files.Files.GraphQL;
+import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
+import com.zextras.carbonio.files.graphql.GraphQLProvider;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * <p>Contains all the implementations of {@link DataFetcher}s for all the queries and mutations
+ * defined in the GraphQL schema that are related to the {@link Files.GraphQL.Config} type.</p>
+ * <p>Each {@link DataFetcher} implementation is asynchronous and returns a {@link List} of {@link HashMap}
+ * containing the data fetched from consul.</p>
+ * <p>These {@link DataFetcher}s will be used in the {@link GraphQLProvider} where they are bound
+ * with the related queries, mutations and composed attributes.</p>
+ */
+public class ConfigDataFetcher {
+
+  private final Map<String, String> configMap;
+
+  /**
+   * <p> This constructor initializes the map of config keys which values will be
+   * requested at consul.
+   * The value is initialized at the default value of every specific configuration</p>
+   */
+  @Inject
+  public ConfigDataFetcher() {
+    configMap = new HashMap<>();
+    configMap.put(Config.MAX_VERSIONS, Config.DEFAULT_MAX_VERSIONS);
+  }
+
+  /**
+   * <p>This {@link DataFetcher} must be used for the {@link Files.GraphQL.Queries#GET_CONFIGS}
+   * query.</p>
+   * <p>The request does not need any parameters in input.</p>
+   * <h2>Behaviour:</h2>
+   * <p>It fetches the configs from consul, if one of the configs is not found it will return the
+   * default value for that config. </p>
+   *
+   * @return an asynchronous {@link DataFetcher} containing a {@link List} with a
+   * {@link  Map} in every entry.
+   */
+  public DataFetcher<CompletableFuture<List<DataFetcherResult<Map<String, String>>>>> getConfigs() {
+    return environment -> CompletableFuture.supplyAsync(() -> {
+      List<DataFetcherResult<Map<String, String>>> result = new ArrayList<>();
+      configMap.forEach((key, value) -> {
+        Map<String, String> resultMap = new HashMap<>();
+        resultMap.put(
+          GraphQL.Config.NAME,
+          key
+        );
+        resultMap.put(
+          GraphQL.Config.VALUE,
+          ServiceDiscoverHttpClient
+            .defaultURL(Consul.SERVICE_NAME)
+            .getConfig(key)
+            .getOrElse(value)
+        );
+        result.add(DataFetcherResult
+          .<Map<String, String>>newResult()
+          .data(resultMap)
+          .build());
+      });
+      return result;
+    });
+  }
+}

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -19,6 +19,11 @@ type User {
     full_name: String!
 }
 
+type Config {
+    name: String!
+    value: String!
+}
+
 type DistributionList {
     id: ID!
 
@@ -481,6 +486,8 @@ type Query {
 
     # Returns the list of all root folders
     getRootsList: [Root]!
+
+    getConfigs: [Config]!
 }
 
 type Mutation {


### PR DESCRIPTION
Expose consul config to GraphQL call like:

POST: https://sw-s04.demo.zextras.io/services/files/graphql

BODY:
```graphql
query {
    getConfigs{
        name
        value
    }
}
```
