### PR TITLE
fix: FILES-263 - Fix preview/thumbnail requests in bulk

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.files.graphql.datafetchers;
 
 import com.google.inject.Inject;

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.3"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"


### PR DESCRIPTION
When a client makes many thumbnail requests at the same time, the system
returns mismatched images. The cause of this bug is that there is only one shared 
PreviewController instance for all requests (it is a @ChannelHandler.Sharable). 
This fix removes the state of the PreviewController so there isn't the possibility that 
a new request will overwrite the parameters of the previous one.

The same fix is made to the BlobController class.