### PR TITLE
fix: FILES-112 - Avoid creating folder with the same name

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -743,6 +743,12 @@ public class NodeRepositoryEbean implements NodeRepository {
       .eq(Db.Node.OWNER_ID, nodeOwner)
       .query();
 
-    return query.findOneOrEmpty();
+    // We could use query.findOneOrEmpty() but if, for some reason, there are multiple nodes
+    // with the same name the query would explode. So to be extra conservative we fetch all the
+    // resulting node and then we return the first one
+    return query
+      .findList()
+      .stream()
+      .findFirst();
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/netty/utilities/BufferInputStream.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/utilities/BufferInputStream.java
@@ -48,9 +48,6 @@ public class BufferInputStream extends InputStream {
   public void addContent(ByteBuf byteBuf) {
     lock.lock();
     try {
-
-      System.out.println(nettyChannelConfig.isAutoRead());
-
       int r = byteBuf.readableBytes();
       buffer.writeBytes(byteBuf, byteBuf.readableBytes());
       sum += r;


### PR DESCRIPTION
When a user tries to create a folder in a destination that already
contains a folder with the same name then the system changes the name of
the folder to create in order to avoid having duplicate folders.
Example:
 - The destination folder contains the folder: `test`
 - A user creates another folder with the same name
 - The system creates the folder calling it `test (1)`

Checked if the requester has the write permission on the destination
folder. If not, the system returns a  `NODE_WRITE_ERROR`.