### PR TITLE
feat: FILES-198 - Implement health, health/ready, health/live endpoints

### DIFF
--- a/boot/src/main/java/com/zextras/carbonio/files/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/Boot.java
@@ -34,8 +34,7 @@ public class Boot {
     );
     Injector injector = Guice.createInjector(new FilesModule());
 
-    FilesConfig filesConfig = injector.getInstance(FilesConfig.class);
-    filesConfig.loadConfig();
+    injector.getInstance(FilesConfig.class);
 
     EbeanDatabaseManager ebeanDatabaseManager = injector.getInstance(EbeanDatabaseManager.class);
     ebeanDatabaseManager.start();

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -512,7 +512,9 @@ public interface Files {
     interface Endpoints {
 
       String  SERVICE             = "/";
-      Pattern HEALTH              = Pattern.compile(SERVICE + "health/?$");
+      Pattern HEALTH              = Pattern.compile(SERVICE + "health/?(live|ready)?/?$");
+      Pattern HEALTH_LIVE         = Pattern.compile(SERVICE + "health/live/?$");
+      Pattern HEALTH_READY        = Pattern.compile(SERVICE + "health/ready/?$");
       Pattern GRAPHQL             = Pattern.compile(SERVICE + "graphql/?$");
       Pattern UPLOAD_FILE         = Pattern.compile(SERVICE + "upload/?$");
       Pattern UPLOAD_FILE_VERSION = Pattern.compile(SERVICE + "upload-version/?$");

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -5,9 +5,15 @@
 package com.zextras.carbonio.files.config;
 
 import com.google.inject.Singleton;
+import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.preview.PreviewClient;
+import com.zextras.carbonio.usermanagement.UserManagementClient;
+import com.zextras.filestore.api.Filestore;
+import com.zextras.storages.api.StoragesClient;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +25,13 @@ public class FilesConfig {
 
   private final Properties properties;
 
+  private String userManagementURL;
+  private String fileStoreURL;
+  private String previewURL;
+
   public FilesConfig() {
     properties = new Properties();
+    loadConfig();
   }
 
   public void loadConfig() {
@@ -36,9 +47,39 @@ public class FilesConfig {
     } catch (IOException exception) {
       logger.error("Fail to load the configuration file");
     }
+
+    userManagementURL = MessageFormat.format(
+      "http://{0}:{1}",
+      properties.getProperty(Files.Config.UserManagement.URL, "127.78.0.2"),
+      properties.getProperty(Files.Config.UserManagement.PORT, "20001")
+    );
+
+    fileStoreURL = MessageFormat.format(
+      "http://{0}:{1}/",
+      properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+      properties.getProperty(Files.Config.Storages.PORT, "20002")
+    );
+
+    previewURL = MessageFormat.format(
+      "http://{0}:{1}",
+      properties.getProperty(Files.Config.Preview.URL, "127.78.0.2"),
+      properties.getProperty(Files.Config.Preview.PORT, "20003")
+    );
   }
 
   public Properties getProperties() {
     return properties;
+  }
+
+  public UserManagementClient getUserManagementClient() {
+    return UserManagementClient.atURL(userManagementURL);
+  }
+
+  public Filestore getFileStoreClient() {
+    return StoragesClient.atUrl(fileStoreURL);
+  }
+
+  public PreviewClient getPreviewClient() {
+    return PreviewClient.atURL(previewURL);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files.API.Endpoints;
+import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import com.zextras.carbonio.files.rest.services.HealthService;
+import com.zextras.carbonio.files.rest.types.health.DependencyType;
+import com.zextras.carbonio.files.rest.types.health.HealthResponse;
+import com.zextras.carbonio.files.rest.types.health.ServiceHealth;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ChannelHandler.Sharable
+public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
+
+  private final static Logger logger = LoggerFactory.getLogger(HealthController.class);
+
+  private final HealthService healthService;
+
+  @Inject
+  public HealthController(HealthService healthService) {
+    this.healthService = healthService;
+  }
+
+  @Override
+  protected void channelRead0(
+    ChannelHandlerContext context,
+    HttpRequest httpRequest
+  ) {
+
+    String uriRequest = httpRequest.uri();
+    Matcher healthMatcher = Endpoints.HEALTH.matcher(uriRequest);
+    Matcher healthLiveMatcher = Endpoints.HEALTH_LIVE.matcher(uriRequest);
+    Matcher healthReadyMatcher = Endpoints.HEALTH_READY.matcher(uriRequest);
+
+    try {
+      if (healthLiveMatcher.find()) {
+        healthLive(context, httpRequest);
+        return;
+      }
+
+      if (healthReadyMatcher.find()) {
+        healthReady(context, httpRequest);
+        return;
+      }
+
+      // This must be always the last check otherwise the health/ regex matches also the
+      // health/live and health/ready endpoints
+      if (healthMatcher.find()) {
+        health(context, httpRequest);
+        return;
+      }
+
+      context
+        .writeAndFlush(new DefaultFullHttpResponse(
+          httpRequest.protocolVersion(),
+          HttpResponseStatus.NOT_FOUND
+        ))
+        .addListener(ChannelFutureListener.CLOSE);
+
+    } catch (Exception exception) {
+      context.fireExceptionCaught(new InternalServerErrorException(exception));
+    }
+  }
+
+  /**
+   * Responds with an {@link HttpResponseStatus#OK} (200) representing the liveness of the service.
+   *
+   * @param context is a {@link ChannelHandlerContext} used to write the response.
+   * @param httpRequest is a {@link HttpRequest} representing the health/live request
+   */
+  private void healthLive(
+    ChannelHandlerContext context,
+    HttpRequest httpRequest
+  ) {
+    logger.debug("carbonio-files is live");
+    context
+      .writeAndFlush(new DefaultFullHttpResponse(
+        httpRequest.protocolVersion(),
+        HttpResponseStatus.OK)
+      )
+      .addListener(ChannelFutureListener.CLOSE);
+  }
+
+  /**
+   * Handles the /health/ready endpoint. It responds with an {@link HttpResponseStatus#OK} (200) if
+   * the following  mandatory dependencies are live:
+   * <ul>
+   *   <li>Database</li>
+   *   <li>UserManagement</li>
+   *   <li>Storages</li>
+   * </ul>
+   * If one of the dependency are not reachable it responds with an InternalServerError (500).
+   *
+   * @param context is a {@link ChannelHandlerContext} used to write the response.
+   * @param httpRequest is a {@link HttpRequest} representing the health/ready request
+   */
+  private void healthReady(
+    ChannelHandlerContext context,
+    HttpRequest httpRequest
+  ) {
+    boolean databaseIsUp = healthService.isDatabaseLive();
+    boolean userManagementIsUp = healthService.isUserManagementLive();
+    boolean fileStoreIsUp = healthService.isStoragesLive();
+
+    HttpResponseStatus responseStatus = (databaseIsUp && userManagementIsUp && fileStoreIsUp)
+      ? HttpResponseStatus.OK
+      : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+    logger.debug(MessageFormat.format("carbonio files status: {0}", responseStatus));
+
+    context
+      .writeAndFlush(new DefaultFullHttpResponse(httpRequest.protocolVersion(), responseStatus))
+      .addListener(ChannelFutureListener.CLOSE);
+  }
+
+  /**
+   * Handles the /health endpoint. It responds with an {@link HttpResponseStatus#OK} (200) if the
+   * following  mandatory dependencies are live:
+   * <ul>
+   *   <li>Database</li>
+   *   <li>UserManagement</li>
+   *   <li>Storages</li>
+   * </ul>
+   * If one of the dependency are not reachable it responds with an InternalServerError (500).
+   * <p>
+   * Unlike the /health/ready endpoint, this one returns also a json containing the status of the
+   * service and its dependencies. This is the JSON in response if everything is ok:
+   * <code>
+   *   {
+   *    "dependencies" : [
+   *       {
+   *          "live" : true,
+   *          "name" : "Files Database",
+   *          "ready" : true,
+   *          "type" : "REQUIRED"
+   *       },
+   *       {
+   *          "live" : true,
+   *          "name" : "carbonio-user-management",
+   *          "ready" : true,
+   *          "type" : "REQUIRED"
+   *       },
+   *       {
+   *          "live" : true,
+   *          "name" : "carbonio-storages",
+   *          "ready" : true,
+   *          "type" : "REQUIRED"
+   *       },
+   *       {
+   *          "live" : true,
+   *          "name" : "carbonio-preview",
+   *          "ready" : true,
+   *          "type" : "OPTIONAL"
+   *       }
+   *    ],
+   *    "ready" : true
+   * }
+   * </code>
+   *
+   * @param context is a {@link ChannelHandlerContext} used to write the response.
+   * @param httpRequest is a {@link HttpRequest} representing the health/ready request
+   */
+  private void health(
+    ChannelHandlerContext context,
+    HttpRequest httpRequest
+  ) throws JsonProcessingException {
+
+    List<ServiceHealth> dependencies = new ArrayList<>();
+    dependencies.add(healthService.getDatabaseHealth());
+    dependencies.add(healthService.getUserManagementHealth());
+    dependencies.add(healthService.getStoragesHealth());
+    dependencies.add(healthService.getPreviewHealth());
+
+    boolean filesIsReady = dependencies
+      .stream()
+      .filter(dependencyHealth -> DependencyType.REQUIRED.equals(dependencyHealth.getType()))
+      .allMatch(ServiceHealth::isReady);
+
+    HealthResponse healthResponse = new HealthResponse()
+      .setDependencies(dependencies)
+      .setReady(filesIsReady);
+
+    HttpResponseStatus responseStatus = filesIsReady
+      ? HttpResponseStatus.OK
+      : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+    String responseBody = new ObjectMapper().writeValueAsString(healthResponse);
+
+    FullHttpResponse response = new DefaultFullHttpResponse(
+      httpRequest.protocolVersion(),
+      responseStatus,
+      Unpooled.wrappedBuffer(responseBody.getBytes(StandardCharsets.UTF_8))
+    );
+    response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+    response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+
+    context
+      .writeAndFlush(response)
+      .addListener(ChannelFutureListener.CLOSE);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.services;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
+import com.zextras.carbonio.files.dal.dao.ebean.DbInfo;
+import com.zextras.carbonio.files.rest.types.health.DependencyType;
+import com.zextras.carbonio.files.rest.types.health.ServiceHealth;
+import com.zextras.filestore.api.Filestore.Liveness;
+
+public class HealthService {
+
+  private final EbeanDatabaseManager ebeanDatabaseManager;
+  private final FilesConfig          filesConfig;
+
+  @Inject
+  public HealthService(
+    EbeanDatabaseManager ebeanDatabaseManager,
+    FilesConfig filesConfig
+  ) {
+    this.ebeanDatabaseManager = ebeanDatabaseManager;
+    this.filesConfig = filesConfig;
+  }
+
+  /**
+   * @return true if the database is reachable, false otherwise.
+   */
+  public boolean isDatabaseLive() {
+    return ebeanDatabaseManager
+      .getEbeanDatabase()
+      .find(DbInfo.class)
+      .findOneOrEmpty()
+      .isPresent();
+  }
+
+  /**
+   * @return true if the carbonio-user-management service is reachable, false otherwise.
+   */
+  public boolean isUserManagementLive() {
+    return filesConfig.getUserManagementClient().healthCheck();
+  }
+
+  /**
+   * @return true if the carbonio-storages service is reachable, false otherwise.
+   */
+  public boolean isStoragesLive() {
+    return filesConfig.getFileStoreClient().checkLiveness().equals(Liveness.OK);
+  }
+
+  /**
+   * @return true if the carbonio-preview service is reachable, false otherwise.
+   */
+  public boolean isPreviewLive() {
+    return filesConfig.getPreviewClient().healthReady();
+  }
+
+  /**
+   * @return a {@link ServiceHealth} representing the status of the database service. This
+   * dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   */
+  public ServiceHealth getDatabaseHealth() {
+    boolean databaseIsLive = isDatabaseLive();
+
+    return new ServiceHealth()
+      .setName("database")
+      .setType(DependencyType.REQUIRED)
+      .setLive(databaseIsLive)
+      .setReady(databaseIsLive);
+  }
+
+  /**
+   * @return a {@link ServiceHealth} representing the status of the carbonio-user-management
+   * service. This dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   */
+  public ServiceHealth getUserManagementHealth() {
+    boolean userManagementIsLive = isUserManagementLive();
+    return new ServiceHealth()
+      .setName("carbonio-user-management")
+      .setType(DependencyType.REQUIRED)
+      .setLive(userManagementIsLive)
+      .setReady(userManagementIsLive);
+  }
+
+  /**
+   * @return a {@link ServiceHealth} representing the status of the carbonio-storages service. This
+   * dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   */
+  public ServiceHealth getStoragesHealth() {
+    boolean fileStoreIsLive = isStoragesLive();
+    return new ServiceHealth()
+      .setName("carbonio-storages")
+      .setType(DependencyType.REQUIRED)
+      .setLive(fileStoreIsLive)
+      .setReady(fileStoreIsLive);
+  }
+
+  /**
+   * @return a {@link ServiceHealth} representing the status of the carbonio-preview service. This
+   * dependency is {@link DependencyType#OPTIONAL} for carbonio-files.
+   */
+  public ServiceHealth getPreviewHealth() {
+    boolean previewIsUp = isPreviewLive();
+    return new ServiceHealth()
+      .setName("carbonio-preview")
+      .setType(DependencyType.OPTIONAL)
+      .setLive(previewIsUp)
+      .setReady(previewIsUp);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/health/DependencyType.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/health/DependencyType.java
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.types.health;
+
+public enum DependencyType {
+  OPTIONAL,
+  REQUIRED
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/health/HealthResponse.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/health/HealthResponse.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.types.health;
+
+import java.util.List;
+
+public class HealthResponse {
+
+  private boolean             ready;
+  private List<ServiceHealth> dependencies;
+
+  public boolean isReady() {
+    return ready;
+  }
+
+  public HealthResponse setReady(boolean ready) {
+    this.ready = ready;
+    return this;
+  }
+
+  public List<ServiceHealth> getDependencies() {
+    return dependencies;
+  }
+
+  public HealthResponse setDependencies(List<ServiceHealth> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/health/ServiceHealth.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/health/ServiceHealth.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.types.health;
+
+public class ServiceHealth {
+
+  private String         name;
+  private boolean        ready;
+  private boolean        live;
+  private DependencyType type;
+
+  public String getName() {
+    return name;
+  }
+
+  public ServiceHealth setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public boolean isReady() {
+    return ready;
+  }
+
+  public ServiceHealth setReady(boolean ready) {
+    this.ready = ready;
+    return this;
+  }
+
+  public boolean isLive() {
+    return live;
+  }
+
+  public ServiceHealth setLive(boolean live) {
+    this.live = live;
+    return this;
+  }
+
+  public DependencyType getType() {
+    return type;
+  }
+
+  public ServiceHealth setType(DependencyType type) {
+    this.type = type;
+    return this;
+  }
+}

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.3"
-pkgrel="1"
+pkgrel="4"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/carbonio-files.hcl
+++ b/package/carbonio-files.hcl
@@ -1,6 +1,6 @@
 services {
   check {
-    http = "http://127.78.0.2:10000/health/",
+    http = "http://127.78.0.2:10000/health/ready/",
     method = "GET",
     timeout = "1s"
     interval = "5s"


### PR DESCRIPTION
In order to know the current status of the service and its dependencies
the following health APIs have been implemented:
 - /health/: it returns 200 if the service and all its mandatory
   dependencies are reachable and returns a detailed JSON response. This
   API can be used manually when the sysadmin want to have a more detailed
   status of the dependencies.
 - /health/ready/: it returns 200 if the service and all its mandatory
   dependencies are reachable. It will be used by the service-discover.
 - /health/live/: it returns 200 if the system is reachable.

 In this feature there is also a refactor of the `FilesConfig` necessary
 to abstract how the SDK clients are initialized. This will allow to use
 the clients without worry which IP to use and without the necessity to
 construct the IP every time.