### PR TITLE
fix: FILES-229 - Fix NullPointer when a search is paginated

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,6 +107,11 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+    </dependency>
+
+    <dependency>
       <artifactId>commons-lang3</artifactId>
       <groupId>org.apache.commons</groupId>
     </dependency>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files;
 
 
+import com.zextras.carbonio.files.Files.Config.Pagination;
 import java.util.regex.Pattern;
 
 /**
@@ -18,38 +19,42 @@ public interface Files {
 
     interface Service {
 
-      String URL      = "service.url";
-      String PORT     = "service.port";
+      String URL  = "service.url";
+      String PORT = "service.port";
     }
 
     interface Database {
 
-      String URL      = "db.postgresql.url";
-      String PORT     = "db.postgresql.port";
+      String URL  = "db.postgresql.url";
+      String PORT = "db.postgresql.port";
     }
 
     interface UserManagement {
 
-      String URL      = "carbonio.user-management.url";
-      String PORT     = "carbonio.user-management.port";
+      String URL  = "carbonio.user-management.url";
+      String PORT = "carbonio.user-management.port";
     }
 
     interface Storages {
 
-      String URL      = "carbonio.storages.url";
-      String PORT     = "carbonio.storages.port";
+      String URL  = "carbonio.storages.url";
+      String PORT = "carbonio.storages.port";
     }
 
     interface Preview {
 
-      String URL      = "carbonio.preview.url";
-      String PORT     = "carbonio.preview.port";
+      String URL  = "carbonio.preview.url";
+      String PORT = "carbonio.preview.port";
     }
 
     interface Mailbox {
 
-      String URL      = "carbonio.mailbox.url";
-      String PORT     = "carbonio.mailbox.port";
+      String URL  = "carbonio.mailbox.url";
+      String PORT = "carbonio.mailbox.port";
+    }
+
+    interface Pagination {
+      int LIMIT = 50;
     }
   }
 
@@ -195,7 +200,7 @@ public interface Files {
 
   interface GraphQL {
 
-    int    LIMIT_ELEMENTS_FOR_PAGE = 50;
+    int    LIMIT_ELEMENTS_FOR_PAGE = Pagination.LIMIT;
     String ENTITY_TYPE             = "type";
 
     interface Context {
@@ -516,24 +521,24 @@ public interface Files {
 
       String PUBLIC_LINK_URL = "/services/files/link/";
 
-      Pattern PREVIEW         = Pattern.compile(SERVICE + "preview/(.*)");
-      Pattern PREVIEW_IMAGE   = Pattern.compile(
+      Pattern PREVIEW            = Pattern.compile(SERVICE + "preview/(.*)");
+      Pattern PREVIEW_IMAGE      = Pattern.compile(
         SERVICE
           + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_IMAGE = Pattern.compile(
+      Pattern THUMBNAIL_IMAGE    = Pattern.compile(
         SERVICE + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
-      Pattern PREVIEW_PDF     = Pattern.compile(
+      Pattern PREVIEW_PDF        = Pattern.compile(
         SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_PDF   = Pattern.compile(
+      Pattern THUMBNAIL_PDF      = Pattern.compile(
         SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
-      Pattern PREVIEW_DOCUMENT     = Pattern.compile(
+      Pattern PREVIEW_DOCUMENT   = Pattern.compile(
         SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
-      Pattern THUMBNAIL_DOCUMENT   = Pattern.compile(
+      Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
         SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
       );
     }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
@@ -4,6 +4,8 @@
 
 package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
 
+import com.zextras.carbonio.files.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,8 +15,9 @@ import java.util.Optional;
  */
 public class PageQuery {
 
-  String             keySet;
   Integer            limit;
+  List<String>       keywords;
+  Optional<String>   keySet;
   Optional<NodeSort> sort;
   Optional<Boolean>  flagged;
   Optional<String>   folderId;
@@ -22,12 +25,14 @@ public class PageQuery {
   Optional<Boolean>  sharedWithMe;
   Optional<Boolean>  sharedByMe;
   Optional<Boolean>  directShare;
-  List<String>       keywords;
 
-  public PageQuery() {}
+  public PageQuery() {
+    limit = Files.Config.Pagination.LIMIT;
+    keywords = Collections.emptyList();
+  }
 
   public PageQuery(
-    String keyset,
+    String keySet,
     Integer limit,
     String sort,
     Boolean flagged,
@@ -38,7 +43,7 @@ public class PageQuery {
     Boolean directShare,
     List<String> keywords
   ) {
-    setKeyset(keyset);
+    setKeySet(keySet);
     setLimit(limit);
     setSort(sort);
     setFlagged(flagged);
@@ -50,70 +55,86 @@ public class PageQuery {
     setKeywords(keywords);
   }
 
-  public String getKeyset() {
+  public Optional<String> getKeySet() {
     return keySet;
   }
 
-  public void setKeyset(String keyset) {
-    this.keySet = keyset;
+  public PageQuery setKeySet(String keySet) {
+    this.keySet = Optional.of(keySet);
+    return this;
   }
 
   public Integer getLimit() {
     return limit;
   }
 
-  public void setLimit(Integer limit) {
+  public PageQuery setLimit(Integer limit) {
     this.limit = limit;
+    return this;
   }
 
-  public String getSort() {
-    return sort.map(sort -> sort.toString()).orElse(null);
+  public Optional<String> getSort() {
+    return sort.map(Enum::toString);
   }
 
   public void setSort(String sort) {
     this.sort = Optional.ofNullable(sort).map(NodeSort::valueOf);
   }
 
-  public Boolean getFlagged() {
-    return flagged.orElse(null);
+  public Optional<Boolean> getFlagged() {
+    return flagged;
   }
 
   public void setFlagged(Boolean flagged) {
     this.flagged = Optional.ofNullable(flagged);
   }
 
-  public String getFolderId() {
-    return folderId.orElse(null);
+  public Optional<String> getFolderId() {
+    return folderId;
   }
 
   public void setFolderId(String folderId) {
     this.folderId = Optional.ofNullable(folderId);
   }
 
-  public Boolean getCascade() {return cascade.orElse(null);}
+  public Optional<Boolean> getCascade() {
+    return cascade;
+  }
 
   public void setCascade(Boolean cascade) {
     this.cascade = Optional.ofNullable(cascade);
   }
 
-  public Boolean getSharedWithMe() {return sharedWithMe.orElse(null);}
+  public Optional<Boolean> getSharedWithMe() {
+    return sharedWithMe;
+  }
 
   public void setSharedWithMe(Boolean sharedWithMe) {
     this.sharedWithMe = Optional.ofNullable(sharedWithMe);
   }
 
-  public Boolean getSharedByMe() {return sharedByMe.orElse(null);}
+  public Optional<Boolean> getSharedByMe() {
+    return sharedByMe;
+  }
 
-  public void setSharedByMe(Boolean sharedByMe) {this.sharedByMe = Optional.ofNullable(sharedByMe);}
+  public void setSharedByMe(Boolean sharedByMe) {
+    this.sharedByMe = Optional.ofNullable(sharedByMe);
+  }
 
-  public Boolean getDirectShare() {return directShare.orElse(null);}
+  public Optional<Boolean> getDirectShare() {
+    return directShare;
+  }
 
   public void setDirectShare(Boolean directShare) {
     this.directShare = Optional.ofNullable(directShare);
   }
 
-  public List<String> getKeywords() {return keywords;}
+  public List<String> getKeywords() {
+    return keywords;
+  }
 
-  public void setKeywords(List<String> keywords) {this.keywords = keywords;}
+  public void setKeywords(List<String> keywords) {
+    this.keywords = keywords;
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
         <artifactId>commons-lang3</artifactId>
         <groupId>org.apache.commons</groupId>
         <version>${commons-lang3.version}</version>


### PR DESCRIPTION
Fixed pagination token creation. Now, when a client performs a search
that contains multiple pages, the system creates and returns the token
for the next page without throwing exception.