### PR TITLE
fix: FILES-27 FILES-71 FILES-115 - Fix findNodes and sorting

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -25,6 +25,7 @@ import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SearchBu
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import io.ebean.Query;
 import io.ebean.annotation.Transactional;
+import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -138,7 +139,11 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("LOWER(name)", ">", node.getFullName().toLowerCase()))
+              Optional.of(new ImmutableTriple(
+                MessageFormat.format("LOWER({0})", Db.Node.NAME),
+                ">",
+                node.getFullName().toLowerCase())
+              )
             )
           );
           break;
@@ -147,7 +152,11 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("LOWER(name)", "<", node.getFullName().toLowerCase()))
+              Optional.of(new ImmutableTriple(
+                MessageFormat.format("LOWER({0})", Db.Node.NAME),
+                "<",
+                node.getFullName().toLowerCase())
+              )
             )
           );
           break;
@@ -157,7 +166,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               node.getNodeCategory(),
               node.getId(),
               Optional.of(
-                new ImmutableTriple("updated_timestamp", ">", String.valueOf(node.getUpdatedAt()))
+                new ImmutableTriple(Db.Node.UPDATED_AT, ">", String.valueOf(node.getUpdatedAt()))
               )
             )
           );
@@ -168,7 +177,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               node.getNodeCategory(),
               node.getId(),
               Optional.of(
-                new ImmutableTriple("updated_timestamp", "<", String.valueOf(node.getUpdatedAt()))
+                new ImmutableTriple(Db.Node.UPDATED_AT, "<", String.valueOf(node.getUpdatedAt()))
               )
             )
           );
@@ -179,7 +188,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               node.getNodeCategory(),
               node.getId(),
               Optional.of(
-                new ImmutableTriple("creation_timestamp", ">", String.valueOf(node.getCreatedAt()))
+                new ImmutableTriple(Db.Node.CREATED_AT, ">", String.valueOf(node.getCreatedAt()))
               )
             )
           );
@@ -190,7 +199,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               node.getNodeCategory(),
               node.getId(),
               Optional.of(
-                new ImmutableTriple("creation_timestamp", "<", String.valueOf(node.getCreatedAt()))
+                new ImmutableTriple(Db.Node.CREATED_AT, "<", String.valueOf(node.getCreatedAt()))
               )
             )
           );
@@ -200,7 +209,7 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("size", "<", String.valueOf(node.getSize())))
+              Optional.of(new ImmutableTriple(Db.Node.SIZE, "<", String.valueOf(node.getSize())))
             )
           );
           break;
@@ -209,7 +218,7 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("size", ">", String.valueOf(node.getSize())))
+              Optional.of(new ImmutableTriple(Db.Node.SIZE, ">", String.valueOf(node.getSize())))
             )
           );
           break;

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -156,7 +156,9 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("updated_timestamp", ">", node.getUpdatedAt()))
+              Optional.of(
+                new ImmutableTriple("updated_timestamp", ">", String.valueOf(node.getUpdatedAt()))
+              )
             )
           );
           break;
@@ -165,7 +167,9 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("updated_timestamp", "<", node.getUpdatedAt()))
+              Optional.of(
+                new ImmutableTriple("updated_timestamp", "<", String.valueOf(node.getUpdatedAt()))
+              )
             )
           );
           break;
@@ -174,7 +178,9 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("creation_timestamp", ">", node.getCreatedAt()))
+              Optional.of(
+                new ImmutableTriple("creation_timestamp", ">", String.valueOf(node.getCreatedAt()))
+              )
             )
           );
           break;
@@ -183,7 +189,9 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("creation_timestamp", "<", node.getCreatedAt()))
+              Optional.of(
+                new ImmutableTriple("creation_timestamp", "<", String.valueOf(node.getCreatedAt()))
+              )
             )
           );
           break;
@@ -192,7 +200,7 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("size", "<", node.getSize()))
+              Optional.of(new ImmutableTriple("size", "<", String.valueOf(node.getSize())))
             )
           );
           break;
@@ -201,7 +209,7 @@ public class NodeRepositoryEbean implements NodeRepository {
             buildKeyset(
               node.getNodeCategory(),
               node.getId(),
-              Optional.of(new ImmutableTriple("size", ">", node.getSize()))
+              Optional.of(new ImmutableTriple("size", ">", String.valueOf(node.getSize())))
             )
           );
           break;
@@ -511,7 +519,8 @@ public class NodeRepositoryEbean implements NodeRepository {
         .eq(Db.Node.OWNER_ID, userId.get());
     }
 
-    sort.map(s -> {
+    sort
+      .map(s -> {
         if (s.equals(NodeSort.SIZE_ASC) || s.equals(NodeSort.SIZE_DESC)) {
           s.getOrderEbeanQuery(query);
           NodeSort.NAME_ASC.getOrderEbeanQuery(query);
@@ -519,7 +528,7 @@ public class NodeRepositoryEbean implements NodeRepository {
           NodeSort.TYPE_ASC.getOrderEbeanQuery(query);
           s.getOrderEbeanQuery(query);
         }
-        return null;
+        return s;
       })
       .orElseGet(() -> {
         NodeSort.TYPE_ASC.getOrderEbeanQuery(query);

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSort.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSort.java
@@ -17,38 +17,38 @@ import io.ebean.Query;
 public enum NodeSort implements SortingEntityEbean<Node> {
   LAST_EDITOR_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.EDITOR_ID);
+      return query.order().asc("t0." + Files.Db.Node.EDITOR_ID);
     }
   },
 
   LAST_EDITOR_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.EDITOR_ID);
+      return query.order().desc("t0." + Files.Db.Node.EDITOR_ID);
     }
   },
 
   NAME_ASC {
     @Override
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.orderBy("LOWER(" + Files.Db.Node.NAME + ") ASC");
+      return query.order().asc("t0." + Files.Db.Node.NAME);
     }
   },
 
   NAME_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.orderBy("LOWER(" + Files.Db.Node.NAME + ") DESC");
+      return query.order().desc("t0." + Files.Db.Node.NAME);
     }
   },
 
   OWNER_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.OWNER_ID);
+      return query.order().asc("t0." + Files.Db.Node.OWNER_ID);
     }
   },
 
   OWNER_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.OWNER_ID);
+      return query.order().desc("t0." + Files.Db.Node.OWNER_ID);
     }
   },
 
@@ -57,7 +57,7 @@ public enum NodeSort implements SortingEntityEbean<Node> {
    */
   TYPE_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.CATEGORY);
+      return query.order().asc("t0." + Files.Db.Node.CATEGORY);
     }
   },
 
@@ -66,43 +66,43 @@ public enum NodeSort implements SortingEntityEbean<Node> {
    */
   TYPE_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.CATEGORY);
+      return query.order().desc("t0." + Files.Db.Node.CATEGORY);
     }
   },
 
   UPDATED_AT_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.UPDATED_AT);
+      return query.order().asc("t0." + Files.Db.Node.UPDATED_AT);
     }
   },
 
   UPDATED_AT_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.UPDATED_AT);
+      return query.order().desc("t0." + Files.Db.Node.UPDATED_AT);
     }
   },
 
   CREATED_AT_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.CREATED_AT);
+      return query.order().asc("t0." + Files.Db.Node.CREATED_AT);
     }
   },
 
   CREATED_AT_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.CREATED_AT);
+      return query.order().desc("t0." + Files.Db.Node.CREATED_AT);
     }
   },
 
   SIZE_ASC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().asc(Files.Db.Node.SIZE);
+      return query.order().asc("t0." + Files.Db.Node.SIZE);
     }
   },
 
   SIZE_DESC {
     public Query<Node> getOrderEbeanQuery(Query<Node> query) {
-      return query.order().desc(Files.Db.Node.SIZE);
+      return query.order().desc("t0." + Files.Db.Node.SIZE);
     }
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
@@ -15,20 +15,28 @@ import java.util.Optional;
  */
 public class PageQuery {
 
-  Integer            limit;
-  List<String>       keywords;
-  Optional<String>   keySet;
-  Optional<NodeSort> sort;
-  Optional<Boolean>  flagged;
-  Optional<String>   folderId;
-  Optional<Boolean>  cascade;
-  Optional<Boolean>  sharedWithMe;
-  Optional<Boolean>  sharedByMe;
-  Optional<Boolean>  directShare;
+  private Integer            limit;
+  private List<String>       keywords;
+  private Optional<String>   keySet;
+  private Optional<NodeSort> sort;
+  private Optional<Boolean>  flagged;
+  private Optional<String>   folderId;
+  private Optional<Boolean>  cascade;
+  private Optional<Boolean>  sharedWithMe;
+  private Optional<Boolean>  sharedByMe;
+  private Optional<Boolean>  directShare;
 
   public PageQuery() {
     limit = Files.Config.Pagination.LIMIT;
     keywords = Collections.emptyList();
+    keySet = Optional.empty();
+    sort = Optional.empty();
+    flagged = Optional.empty();
+    folderId = Optional.empty();
+    cascade = Optional.empty();
+    sharedWithMe = Optional.empty();
+    sharedByMe = Optional.empty();
+    directShare = Optional.empty();
   }
 
   public PageQuery(

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
@@ -57,8 +57,8 @@ public class SearchBuilder {
         this.query
           .where()
           .or()
-          .contains("mName", keyword)
-          .contains("mDescription", keyword)
+          .contains("LOWER(mName)", keyword.toLowerCase())
+          .contains("LOWER(mDescription)", keyword.toLowerCase())
           .endOr();
       });
     }


### PR DESCRIPTION
**FILES-27**
findNodes API is now case in-sensitive: the fix is to lowercase
everything: the name and description attributes and each keyword in
input.

**FILES-71**
The sort by type is now working, so folders are always shown before
files except when the user sort by size descendent: in this case,
folders are shown after files.

**FILES-115**
When an user chose the updated_at sort, the system threw an exception
because PostgreSQL wants every attribute used in multiple joined tables
to be disambigued. For now we added an explicit 't0' before each attribute
but in the future a refactor of how the search query is created needs to
be done.