### PR TITLE
fix: Fix the creation of ancestor_ids during the copy operation

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -704,10 +704,9 @@ public class NodeRepositoryEbean implements NodeRepository {
     List<String> nodesIds,
     Node destinationFolder
   ) {
-    String ancestorIds = destinationFolder
-      .getParentId()
-      .map(parentId -> destinationFolder.getAncestorIds() + "," + destinationFolder.getId())
-      .orElse(destinationFolder.getId());
+    String ancestorIds = NodeType.ROOT.equals(destinationFolder.getNodeType())
+      ? destinationFolder.getId()
+      : destinationFolder.getAncestorIds() + "," + destinationFolder.getId();
 
     int numberMovedNodes = mDB.getEbeanDatabase()
       .update(Node.class)

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -801,15 +801,13 @@ public class NodeDataFetcher {
                 });
 
             } else {
-              String parentId = parentNode.get()
-                .getId();
+              String parentId = parentNode.get().getId();
               node.setParentId(parentId);
-              String newAncestors = (parentNode.get()
-                .getAncestorIds()
-                .isEmpty())
+
+              String newAncestors = NodeType.ROOT.equals(parentNode.get().getNodeType())
                 ? parentId
-                : parentNode.get()
-                  .getAncestorIds() + "," + parentId;
+                : parentNode.get().getAncestorIds() + "," + parentId;
+
               node.setAncestorIds(newAncestors);
 
               shareRepository
@@ -1388,7 +1386,7 @@ public class NodeDataFetcher {
       sourceNode.getDescription()
         .orElse(""),
       sourceNode.getNodeType(),
-      destinationFolder.getNodeType() == NodeType.ROOT
+      NodeType.ROOT.equals(destinationFolder.getNodeType())
         ? destinationFolder.getId()
         : destinationFolder.getAncestorIds() + "," + destinationFolder.getId(),
       sourceNode.getSize()
@@ -1497,11 +1495,12 @@ public class NodeDataFetcher {
   ) {
     String effectiveName = newName.orElse(sourceFolder.getName());
 
-    String ownerId =
-      (destinationFolder.getNodeType()
-        .equals(NodeType.ROOT) || requesterId.equals(destinationFolder.getOwnerId()))
-        ? requesterId
-        : destinationFolder.getOwnerId();
+    String ownerId = (
+      destinationFolder.getNodeType().equals(NodeType.ROOT)
+        || requesterId.equals(destinationFolder.getOwnerId())
+    )
+      ? requesterId
+      : destinationFolder.getOwnerId();
 
     // Create the new folder
     return nodeRepository.createNewNode(
@@ -1514,7 +1513,9 @@ public class NodeDataFetcher {
       sourceFolder.getDescription()
         .orElse(""),
       NodeType.FOLDER,
-      destinationFolder.getAncestorIds() + "," + destinationFolder.getId(),
+      NodeType.ROOT.equals(destinationFolder.getNodeType())
+        ? destinationFolder.getId()
+        : destinationFolder.getAncestorIds() + "," + destinationFolder.getId(),
       0L
     );
   }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -175,7 +175,7 @@ public class BlobService {
         searchAlternativeName(filename.trim(), folderId, nodeOwner),
         description,
         nodeType,
-        folder.getNodeType().equals(NodeType.ROOT)
+        NodeType.ROOT.equals(folder.getNodeType())
           ? folderId
           : folder.getAncestorIds() + "," + folderId,
         uploadResponse.getSize()


### PR DESCRIPTION
Now the creation of the ancestor_ids is coherent in all the codebase.

Co-authored-by: RakuJa <daniele.giachetto@zextras.com>