### PR TITLE
fix: Return 404 when the preview is not available

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
@@ -521,9 +521,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
 
     HttpResponseStatus statusCode = (failure instanceof BadRequestException)
       ? HttpResponseStatus.BAD_REQUEST
-      : (failure instanceof NodeNotFoundException)
-        ? HttpResponseStatus.NOT_FOUND
-        : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+      : HttpResponseStatus.NOT_FOUND;
 
     context
       .writeAndFlush(new DefaultFullHttpResponse(httpRequest.protocolVersion(), statusCode))

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.3.5"
+pkgver="0.3.6"
 pkgrel="1"
 pkgdesc="Carbonio Files"
 pkgdesclong=(


### PR DESCRIPTION
When the preview dependency is not available all the preview/thumbnail requests fails.
Instead of returning a 500, the system must return 404 otherwise the service-discover
blocks all the other requests for about 1 minute.