### PR TITLE
feat: FILES-290 - Implement getAccountsByEmail API

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -246,6 +246,7 @@ public interface Files {
       String GET_VERSIONS         = "getVersions";
       String GET_LINKS            = "getLinks";
       String GET_ACCOUNT_BY_EMAIL = "getAccountByEmail";
+      String GET_ACCOUNTS_BY_EMAIL = "getAccountsByEmail";
       String GET_CONFIGS          = "getConfigs";
     }
 
@@ -387,6 +388,11 @@ public interface Files {
 
         String USER_ID = "user_id";
         String EMAIL   = "email";
+      }
+
+      interface GetAccountsByEmail {
+
+        String EMAILS = "emails";
       }
     }
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -165,6 +165,10 @@ public class GraphQLProvider {
       .addRule(
         ResultPath.parse("/" + Files.GraphQL.Queries.GET_ACCOUNT_BY_EMAIL),
         inputFieldsController.getAccountByEmailValidation()
+      )
+      .addRule(
+        ResultPath.parse("/" + Files.GraphQL.Queries.GET_ACCOUNTS_BY_EMAIL),
+        inputFieldsController.getAccountsByEmailValidation()
       );
 
     return new FieldValidationInstrumentation(fieldValidation);
@@ -205,6 +209,10 @@ public class GraphQLProvider {
         .dataFetcher(
           Files.GraphQL.Queries.GET_ACCOUNT_BY_EMAIL,
           userDataFetcher.getAccountByEmailFetcher()
+        )
+        .dataFetcher(
+          Files.GraphQL.Queries.GET_ACCOUNTS_BY_EMAIL,
+          userDataFetcher.getAccountsByEmailFetcher()
         )
         .dataFetcher(Files.GraphQL.Queries.GET_LINKS, linkDataFetcher.getLinks())
         .dataFetcher(Files.GraphQL.Queries.GET_CONFIGS, configDataFetcher.getConfigs())

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/validators/GenericControllerEvaluator.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/validators/GenericControllerEvaluator.java
@@ -64,6 +64,33 @@ public class GenericControllerEvaluator {
   }
 
   /**
+   * Checks if the list of given emails are valid. It builds a {@link Parameter} containing the
+   * implementation of the related {@link Function} necessary to check the value.
+   *
+   * @param emailsKey is a {@link String} representing the input key mapping the value of the email
+   * list
+   *
+   * @return the {@link GenericControllerEvaluator} to allow the possibility to chain multiple
+   * checks to select.
+   */
+  public GenericControllerEvaluator checkEmails(String emailsKey) {
+    inputsToCheckWithRelativeFunctions.add(Parameter.build(
+      emailsKey,
+      (key) -> {
+        List<String> emails = fieldAndArguments.getArgumentValue(key);
+        return Optional.of(emails
+          .stream()
+          .map(this::validateEmail)
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .collect(Collectors.joining("\n"))
+        );
+      }
+    ));
+    return this;
+  }
+
+  /**
    * Checks if the node id is valid and creates the related error message if it is invalid. It
    * builds a {@link Parameter} containing the implementation of the related {@link Function}
    * necessary to check the value.

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/validators/InputFieldsController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/validators/InputFieldsController.java
@@ -12,17 +12,18 @@ import graphql.GraphQL;
 import graphql.GraphQLError;
 import graphql.execution.instrumentation.fieldvalidation.FieldAndArguments;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationEnvironment;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
 /**
  * <p>This class contains the implementations of all input validation rules necessary to check if
- * specific inputs values of a GraphQL request are correct. Each method builds a {@link
- * GenericControllerEvaluator} specific for the related inputs to check and returns an
+ * specific inputs values of a GraphQL request are correct. Each method builds a
+ * {@link GenericControllerEvaluator} specific for the related inputs to check and returns an
  * implementation of a {@link BiFunction} having the {@link FieldValidationEnvironment} and the
  * {@link FieldAndArguments} objects as input and an {@link Optional} of {@link GraphQLError} as
- * output. These methods are used during the creation of the {@link GraphQL} instance (see {@link
- * GraphQLProvider}
+ * output. These methods are used during the creation of the {@link GraphQL} instance (see
+ * {@link GraphQLProvider}
  * <code>buildValidationInstrumentation()</code> method).</p>
  */
 public class InputFieldsController {
@@ -168,8 +169,8 @@ public class InputFieldsController {
   }
 
   /**
-   * @return a {@link BiFunction} rule bound with the queries and mutations related to the {@link
-   * Files.GraphQL.Types#SHARE} type check if the node id and the target user id in input are
+   * @return a {@link BiFunction} rule bound with the queries and mutations related to the
+   * {@link Files.GraphQL.Types#SHARE} type check if the node id and the target user id in input are
    * valid.
    * @see GenericControllerEvaluator#checkNodeId(String)
    * @see GenericControllerEvaluator#checkUserId(String)
@@ -261,8 +262,8 @@ public class InputFieldsController {
   }
 
   /**
-   * @return a {@link BiFunction} rule bound with the {@link Files.GraphQL.Queries#GET_ACCOUNT_BY_EMAIL}
-   * to check if the email in input is valid.
+   * @return a {@link BiFunction} rule bound with the
+   * {@link Files.GraphQL.Queries#GET_ACCOUNT_BY_EMAIL} to check if the email in input is valid.
    * @see GenericControllerEvaluator#checkEmail(String)
    */
   public BiFunction<FieldAndArguments, FieldValidationEnvironment, Optional<GraphQLError>> getAccountByEmailValidation() {
@@ -272,5 +273,18 @@ public class InputFieldsController {
         .checkEmail(Files.GraphQL.InputParameters.EMAIL)
         .evaluate();
     };
+  }
+
+  /**
+   * @return a {@link BiFunction} rule bound with the
+   * {@link Files.GraphQL.Queries#GET_ACCOUNTS_BY_EMAIL} to check if the list of emails in input are
+   * valid.
+   * @see GenericControllerEvaluator#checkEmails(String)
+   */
+  public BiFunction<FieldAndArguments, FieldValidationEnvironment, Optional<GraphQLError>> getAccountsByEmailValidation() {
+    return (fieldAndArguments, environment) ->
+      mGenericControllerEvaluatorFactory.create(fieldAndArguments, environment)
+        .checkEmails(Files.GraphQL.InputParameters.GetAccountsByEmail.EMAILS)
+        .evaluate();
   }
 }

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -469,6 +469,11 @@ type Query {
         email: String!
     ) : Account
 
+    getAccountsByEmail(
+        # The list of emails of the user or distribution list to retrieve (required)
+        emails: [String!]!
+    ) : [Account]!
+
     # Returns the attributes of the specified share
     getShare(
         # The unique identifier of the shared node (mandatory)

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.7"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"


### PR DESCRIPTION
The getAccountsByEmail API allows to fetch a list of GraphQL Accounts in
batch given their email. If an email is not associated to a Carbonio user then
the system returns an Account valued at null.

Implemented the getAccountsByeEmailValidation method to validate the
emails in input and returns an error if some of them are not valid.