### PR TITLE
feat: FILES-320 - Align pom version to package version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,15 @@ repos:
     rev: v0.14.0
     hooks:
       - id: reuse
+
+  - repo: local
+    hooks:
+      - id: check-if-version-is-bumped
+        name: check-if-version-is-bumped
+        entry: bash -c '
+          if [[ -z $(git diff develop --staged -G"pkgver|pkgrel" package/PKGBUILD) ]] &&
+             [[ -z $(git diff develop..HEAD -G"pkgver|pkgrel" package/PKGBUILD) ]];
+          then
+            exit 1;
+          fi'
+        language: system

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.2.0</version>
+    <version>0.3.7-3</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -72,11 +72,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <artifactId>filestore-sdk-common</artifactId>
-      <groupId>com.zextras</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>storages-ce-sdk</artifactId>
       <groupId>com.zextras</groupId>
     </dependency>
@@ -137,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.2.0</version>
+    <version>0.3.7-3</version>
   </parent>
 
   <properties>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.7"
-pkgrel="1"
+pkgrel="3"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <artifactId>filestore-sdk-common</artifactId>
-        <groupId>com.zextras</groupId>
-        <version>${carbonio-storages-ce.version}</version>
-      </dependency>
-
-      <dependency>
         <artifactId>storages-ce-sdk</artifactId>
         <groupId>com.zextras</groupId>
         <version>${carbonio-storages-ce.version}</version>
@@ -171,5 +165,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.2.0</version>
+  <version>0.3.7-3</version>
 </project>


### PR DESCRIPTION
Now each pom has the same version of the final package defined in the
package/PKGBUILD file.

Implemented a pre-commit hook to check if the package version is bumped.