### PR TITLE
chore: FILES-322 - Update dependencies for security reasons

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-3</version>
+    <version>0.3.7-4</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-3</version>
+    <version>0.3.7-4</version>
   </parent>
 
   <properties>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.7"
-pkgrel="3"
+pkgrel="4"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,12 @@ SPDX-License-Identifier: AGPL-3.0-only
     <ebean.version>12.13.1</ebean.version>
     <graphql-java.version>17.3</graphql-java.version>
     <guice.version>5.0.1</guice.version>
-    <jackson.version>2.13.0</jackson.version>
+    <jackson.version>2.13.3</jackson.version>
     <logback-classic.version>1.3.0-alpha12</logback-classic.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <netty.version>4.1.68.Final</netty.version>
-    <postgresql.version>42.3.0</postgresql.version>
+    <netty.version>4.1.78.Final</netty.version>
+    <postgresql.version>42.3.3</postgresql.version>
   </properties>
 
   <repositories>
@@ -165,5 +165,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.3.7-3</version>
+  <version>0.3.7-4</version>
 </project>


### PR DESCRIPTION
Dependabot alert us about these vulnerabilities:

 - Deeply nested json in jackson-databind:
   https://github.com/advisories/GHSA-57j2-w4cx-62h2
 - Arbitrary File Write Vulnerability:
   https://github.com/advisories/GHSA-673j-qm5f-xpv8
 - Unchecked Class Instantiation when providing Plugin Classes:
   https://github.com/advisories/GHSA-v7wg-cpwc-24m4

We also updated the netty-all dependency to version 4.1.78.Final