### PR TITLE
feat: FILES-194 - Reduce response latencies of GraphQL APIs

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-4</version>
+    <version>0.4.0-1</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-4</version>
+    <version>0.4.0-1</version>
   </parent>
 
   <properties>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -188,7 +188,7 @@ public interface Files {
 
   interface Cache {
 
-    long DEFAULT_ITEM_LIFETIME_IN_MILLISEC = 10_000;
+    long DEFAULT_ITEM_LIFETIME_IN_MILLISEC = 60_000;
     long DEFAULT_SIZE                      = 1000;
 
     /**
@@ -198,6 +198,7 @@ public interface Files {
     String FILE_VERSION = "FileVersion";
     String SHARE        = "Share";
     String LINK         = "Link";
+    String USER         = "User";
   }
 
   interface GraphQL {

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -234,6 +234,14 @@ public interface Files {
     }
 
     /**
+     * Names of GraphQL data laoders
+     */
+    interface DataLoaders {
+
+      String NODE_BATCH_LOADER = "NodeBatchLoader";
+    }
+
+    /**
      * Names of queries
      */
     interface Queries {

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -239,6 +239,7 @@ public interface Files {
     interface DataLoaders {
 
       String NODE_BATCH_LOADER = "NodeBatchLoader";
+      String SHARE_BATCH_LOADER = "ShareBatchLoader";
     }
 
     /**

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -238,7 +238,7 @@ public interface Files {
      */
     interface DataLoaders {
 
-      String NODE_BATCH_LOADER = "NodeBatchLoader";
+      String NODE_BATCH_LOADER  = "NodeBatchLoader";
       String SHARE_BATCH_LOADER = "ShareBatchLoader";
     }
 
@@ -247,17 +247,17 @@ public interface Files {
      */
     interface Queries {
 
-      String GET_NODE             = "getNode";
-      String GET_USER             = "getUser";
-      String GET_SHARE            = "getShare";
-      String GET_ROOTS_LIST       = "getRootsList";
-      String GET_PATH             = "getPath";
-      String FIND_NODES           = "findNodes";
-      String GET_VERSIONS         = "getVersions";
-      String GET_LINKS            = "getLinks";
-      String GET_ACCOUNT_BY_EMAIL = "getAccountByEmail";
+      String GET_NODE              = "getNode";
+      String GET_USER              = "getUser";
+      String GET_SHARE             = "getShare";
+      String GET_ROOTS_LIST        = "getRootsList";
+      String GET_PATH              = "getPath";
+      String FIND_NODES            = "findNodes";
+      String GET_VERSIONS          = "getVersions";
+      String GET_LINKS             = "getLinks";
+      String GET_ACCOUNT_BY_EMAIL  = "getAccountByEmail";
       String GET_ACCOUNTS_BY_EMAIL = "getAccountsByEmail";
-      String GET_CONFIGS          = "getConfigs";
+      String GET_CONFIGS           = "getConfigs";
     }
 
     /**
@@ -289,11 +289,12 @@ public interface Files {
      */
     interface InputParameters {
 
-      String NODE_ID = "node_id";
-      String LIMIT   = "limit";
-      String CURSOR  = "cursor";
-      String SORT    = "sort";
-      String EMAIL   = "email";
+      String NODE_ID    = "node_id";
+      String LIMIT      = "limit";
+      String CURSOR     = "cursor";
+      String SORT       = "sort";
+      String EMAIL      = "email";
+      String PAGE_TOKEN = "page_token";
 
       interface CreateFolder {
 

--- a/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandler.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.cache;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.dal.dao.User;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,11 +60,25 @@ public class CacheHandler {
         Files.Cache.DEFAULT_ITEM_LIFETIME_IN_MILLISEC
       )
     );
+
+    /* Creation of the cache that will contain user elements */
+    caches.put(
+      Files.Cache.USER,
+      this.cacheHandlerFactory.createUserCache(
+        Files.Cache.USER,
+        Files.Cache.DEFAULT_SIZE,
+        Files.Cache.DEFAULT_ITEM_LIFETIME_IN_MILLISEC
+      )
+    );
   }
 
   public Optional<Cache> getCache(String name) {
     return (caches.containsKey(name))
       ? Optional.of(caches.get(name))
       : Optional.empty();
+  }
+
+  public Cache<User> getUserCache() {
+    return caches.get(Files.Cache.USER);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandler.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.dal.dao.User;
+import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -31,31 +31,11 @@ public class CacheHandler {
     caches = new ConcurrentHashMap<>();
     this.cacheHandlerFactory = cacheHandlerFactory;
 
-    /* Creation of the cache that will contain node elements */
-    caches.put(
-      Files.Cache.NODE,
-      this.cacheHandlerFactory.createNodeCache(
-        Files.Cache.NODE,
-        Files.Cache.DEFAULT_SIZE,
-        Files.Cache.DEFAULT_ITEM_LIFETIME_IN_MILLISEC
-      )
-    );
-
     /* Creation of the cache that will contain file version elements */
     caches.put(
       Files.Cache.FILE_VERSION,
       this.cacheHandlerFactory.createFileVersionCache(
         Files.Cache.FILE_VERSION,
-        Files.Cache.DEFAULT_SIZE,
-        Files.Cache.DEFAULT_ITEM_LIFETIME_IN_MILLISEC
-      )
-    );
-
-    /* Creation of the cache that will contain share elements */
-    caches.put(
-      Files.Cache.SHARE,
-      this.cacheHandlerFactory.createShareCache(
-        Files.Cache.SHARE,
         Files.Cache.DEFAULT_SIZE,
         Files.Cache.DEFAULT_ITEM_LIFETIME_IN_MILLISEC
       )
@@ -72,13 +52,11 @@ public class CacheHandler {
     );
   }
 
-  public Optional<Cache> getCache(String name) {
-    return (caches.containsKey(name))
-      ? Optional.of(caches.get(name))
-      : Optional.empty();
-  }
-
   public Cache<User> getUserCache() {
     return caches.get(Files.Cache.USER);
+  }
+
+  public Cache<FileVersion> getFileVersionCache() {
+    return caches.get(Files.Cache.FILE_VERSION);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandlerFactory.java
+++ b/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandlerFactory.java
@@ -28,4 +28,10 @@ public interface CacheHandlerFactory {
     @Assisted("defaultCacheSize") long defaultCacheSize,
     @Assisted("defaultItemLifetimeInMillis") long defaultItemLifetimeInMillis
   );
+
+  LocalCacheAdapter<Share> createUserCache(
+    String cacheName,
+    @Assisted("defaultCacheSize") long defaultCacheSize,
+    @Assisted("defaultItemLifetimeInMillis") long defaultItemLifetimeInMillis
+  );
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -149,6 +149,9 @@ public class EbeanDatabaseManager {
     serverConfig.setDataSource(dataSource);
     serverConfig.setDefaultServer(true);
     serverConfig.addAll(entityList);
+    serverConfig.setCacheMaxSize(100_000);
+    serverConfig.setCacheMaxTimeToLive(300);
+    serverConfig.setCacheMaxIdleTime(300);
 
     ebeanDatabase = DatabaseFactory.createWithContextClassLoader(
       serverConfig,

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/FileVersion.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/FileVersion.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
@@ -53,6 +55,10 @@ public class FileVersion {
   @Column(name = Db.FileVersion.CLONED_FROM_VERSION, nullable = true)
   private Integer clonedFromVersion;
 
+  @ManyToOne
+  @JoinColumn(name = Files.Db.NodeCustomAttributes.NODE_ID, referencedColumnName = Files.Db.Node.ID, insertable = false, updatable = false)
+  private Node node;
+
   public FileVersion(
     String nodeId,
     String lastEditorId,
@@ -73,7 +79,6 @@ public class FileVersion {
     isKeptForever = false;
     mVersion = version;
   }
-
 
   public String getNodeId() {
     return mComposedId.getNodeId()

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.dal.dao.ebean;
 import static com.zextras.carbonio.files.dal.dao.ebean.NodeType.FOLDER;
 import static com.zextras.carbonio.files.dal.dao.ebean.NodeType.ROOT;
 import com.zextras.carbonio.files.Files;
+import io.ebean.annotation.Cache;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ import javax.persistence.Table;
  * input are valid or not because, when these methods are called, these controls
  * <strong>must</strong> be already done.</p>
  */
+@Cache
 @Entity
 @Table(name = Files.Db.Tables.NODE)
 public

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
@@ -81,13 +81,17 @@ class Node {
   @Column(name = Files.Db.Node.SIZE, nullable = false)
   private Long mSize;
 
-  @OneToMany(fetch = FetchType.LAZY)
+  @OneToMany(fetch = FetchType.EAGER)
   @JoinColumn(name = Files.Db.Node.ID, referencedColumnName = Files.Db.NodeCustomAttributes.NODE_ID, insertable = false, updatable = false)
   private List<NodeCustomAttributes> mCustomAttributes;
 
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = Files.Db.Node.ID, referencedColumnName = Files.Db.Share.NODE_ID, insertable = false, updatable = false)
   private List<Share> mShares;
+
+  @OneToMany(fetch = FetchType.LAZY)
+  @JoinColumn(name = Files.Db.Node.ID, referencedColumnName = Files.Db.FileVersion.NODE_ID, insertable = false, updatable = false)
+  private List<FileVersion> fileVersions;
 
   public Node(
     String nodeId,
@@ -265,4 +269,11 @@ class Node {
     return this;
   }
 
+  public List<NodeCustomAttributes> getCustomAttributes() {
+    return mCustomAttributes;
+  }
+
+  public List<FileVersion> getFileVersions() {
+    return fileVersions;
+  }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Share.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Share.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files.dal.dao.ebean;
 
 import com.zextras.carbonio.files.Files;
+import io.ebean.annotation.Cache;
 import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
@@ -20,6 +21,7 @@ import javax.persistence.Table;
  * input are valid or not because, when these methods are called, these controls
  * <strong>must</strong> be already done.</p>
  */
+@Cache
 @Entity
 @Table(name = Files.Db.Tables.SHARE)
 public class Share {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/ShareRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/ShareRepositoryEbean.java
@@ -7,8 +7,6 @@ package com.zextras.carbonio.files.dal.repositories.impl.ebean;
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Db;
-import com.zextras.carbonio.files.cache.Cache;
-import com.zextras.carbonio.files.cache.CacheHandler;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.dao.ebean.Share;
@@ -16,33 +14,17 @@ import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.ShareSor
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import io.ebean.Query;
 import io.ebean.Transaction;
-import io.ebean.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ShareRepositoryEbean implements ShareRepository {
 
-  private final EbeanDatabaseManager   mDB;
-  private       Optional<Cache<Share>> mShareCache;
+  private final EbeanDatabaseManager mDB;
 
   @Inject
-  public ShareRepositoryEbean(
-    EbeanDatabaseManager ebeanDatabaseManager,
-    CacheHandler cacheHandler
-  ) {
+  public ShareRepositoryEbean(EbeanDatabaseManager ebeanDatabaseManager) {
     mDB = ebeanDatabaseManager;
-    mShareCache = cacheHandler
-      .getCache(Files.Cache.NODE)
-      .map(cache -> mShareCache = Optional.of(cache))
-      .orElse(Optional.empty());
-  }
-
-  private String getShareId(
-    String nodeId,
-    String userId
-  ) {
-    return nodeId + "/" + userId;
   }
 
   /**
@@ -58,32 +40,19 @@ public class ShareRepositoryEbean implements ShareRepository {
     String nodeId,
     String userId
   ) {
-    Optional<Share> share = mDB.getEbeanDatabase()
+    return mDB.getEbeanDatabase()
       .find(Share.class)
       .where()
       .eq(Files.Db.Share.NODE_ID, nodeId)
       .eq(Files.Db.Share.SHARE_TARGET_UUID, userId)
       .findOneOrEmpty();
-    return share;
   }
 
-  @Transactional
   public Optional<Share> getShare(
     String nodeId,
     String userId
   ) {
-    return mShareCache.map(cache -> {
-        return Optional.ofNullable(
-          cache
-            .get(getShareId(nodeId, userId))
-            .orElseGet(() -> {
-              Optional<Share> dbShare = getRealShare(nodeId, userId);
-              dbShare.ifPresent(share -> cache.add(getShareId(nodeId, userId), share));
-              return dbShare.orElse(null);
-            })
-        );
-      })
-      .orElse(getRealShare(nodeId, userId));
+    return getRealShare(nodeId, userId);
   }
 
   public Optional<Share> upsertShare(
@@ -103,9 +72,6 @@ public class ShareRepositoryEbean implements ShareRepository {
         }
         updateShare.setPermissions(permissions);
         expireTimestamp.ifPresent(updateShare::setExpiredAt);
-        mShareCache.ifPresent(cache -> {
-          cache.add(getShareId(nodeId, targetUserId), updateShare);
-        });
         return Optional.of(updateShare(updateShare));
       } else {
         // We're trying to convert a direct to an inherited share
@@ -121,9 +87,6 @@ public class ShareRepositoryEbean implements ShareRepository {
       );
       expireTimestamp.ifPresent(share::setExpiredAt);
       mDB.getEbeanDatabase().save(share);
-      mShareCache.ifPresent(cache -> {
-        cache.add(getShareId(nodeId, targetUserId), share);
-      });
       return Optional.of(share);
     }
   }
@@ -152,9 +115,6 @@ public class ShareRepositoryEbean implements ShareRepository {
 
   public Share updateShare(Share share) {
     mDB.getEbeanDatabase().update(share);
-    mShareCache.ifPresent(cache -> {
-      cache.add(getShareId(share.getNodeId(), share.getTargetUserId()), share);
-    });
     return share;
   }
 
@@ -162,15 +122,8 @@ public class ShareRepositoryEbean implements ShareRepository {
     String nodeId,
     String targetUserId
   ) {
-    return getShare(nodeId, targetUserId).map(share -> {
-        boolean deleted = mDB.getEbeanDatabase().delete(share);
-        if (deleted) {
-          mShareCache.map(cache -> {
-            return cache.delete(getShareId(nodeId, targetUserId));
-          });
-        }
-        return deleted;
-      })
+    return getShare(nodeId, targetUserId)
+      .map(share -> mDB.getEbeanDatabase().delete(share))
       .orElse(false);
   }
 
@@ -185,9 +138,8 @@ public class ShareRepositoryEbean implements ShareRepository {
       transaction.setBatchSize(50);
 
       // these go to batch buffer
-      nodeIds.forEach(nodeId -> {
-        deleteShare(nodeId, targetUserId);
-      });
+      nodeIds.forEach(nodeId -> deleteShare(nodeId, targetUserId));
+
       // flush batch and commit
       transaction.commit();
     }
@@ -203,25 +155,18 @@ public class ShareRepositoryEbean implements ShareRepository {
       .delete();
 
     // TODO Uniform the delete behaviour with other delete method when we implement unique shareId
-    mShareCache.ifPresent(Cache::flushAll);
   }
 
   public List<Share> getShares(
     List<String> nodeIds,
     String targetUserId
   ) {
-    List<Share> shares = mDB.getEbeanDatabase()
+    return mDB.getEbeanDatabase()
       .find(Share.class)
       .where()
       .in(Files.Db.Share.NODE_ID, nodeIds)
       .eq(Files.Db.Share.SHARE_TARGET_UUID, targetUserId)
       .findList();
-
-    mShareCache.ifPresent(cache -> {
-      shares.forEach(
-        share -> cache.add(getShareId(share.getNodeId(), share.getTargetUserId()), share));
-    });
-    return shares;
   }
 
   public List<Share> getShares(
@@ -238,13 +183,7 @@ public class ShareRepositoryEbean implements ShareRepository {
       query.where().in(Files.Db.Share.SHARE_TARGET_UUID, targetUserIds);
     }
 
-    List<Share> shares = query.findList();
-
-    mShareCache.ifPresent(cache -> {
-      shares.forEach(
-        share -> cache.add(getShareId(share.getNodeId(), share.getTargetUserId()), share));
-    });
-    return shares;
+    return query.findList();
   }
 
   public List<Share> getShares(List<String> nodeIds) {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/ShareRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/ShareRepositoryEbean.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files.dal.repositories.impl.ebean;
 
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.cache.Cache;
 import com.zextras.carbonio.files.cache.CacheHandler;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
@@ -244,6 +245,14 @@ public class ShareRepositoryEbean implements ShareRepository {
         share -> cache.add(getShareId(share.getNodeId(), share.getTargetUserId()), share));
     });
     return shares;
+  }
+
+  public List<Share> getShares(List<String> nodeIds) {
+    return mDB.getEbeanDatabase()
+      .find(Share.class)
+      .where()
+      .in(Db.Share.NODE_ID, nodeIds)
+      .findList();
   }
 
   public List<String> getSharesUsersIds(

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
@@ -28,8 +28,8 @@ public class SearchBuilder {
     this.userId = userId;
     this.query = this.db
       .find(Node.class)
-      .fetch("mShares")
-      .fetch("mCustomAttributes")
+      .fetchLazy("mShares")
+      .fetchLazy("mCustomAttributes")
       .where()
       .or()
       .eq("mShares.mComposedPrimaryKey.mTargetUserId", userId)

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/ShareRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/ShareRepository.java
@@ -151,6 +151,14 @@ public interface ShareRepository {
   );
 
   /**
+   * @param nodeIds is a {@link List<String>} of the node ids. For each one of them the query
+   * retrieves all the related shares.
+   *
+   * @return a {@link List} of found {@link Share}s for the specific node ids in input.
+   */
+  List<Share> getShares(List<String> nodeIds);
+
+  /**
    * Returns the list of userId for which the given node is shared.
    *
    * @param nodeId is a {@link String} of the id of the node for which retrieve the shares.

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/ShareRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/ShareRepository.java
@@ -7,7 +7,6 @@ package com.zextras.carbonio.files.dal.repositories.interfaces;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.dao.ebean.Share;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.ShareSort;
-import io.ebean.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +24,6 @@ public interface ShareRepository {
    *
    * @return an {@link Optional) containing the {@link Share} requested if exists.
    */
-  @Transactional
   Optional<Share> getShare(
     String nodeId,
     String userId

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -18,6 +18,8 @@ import com.zextras.carbonio.files.graphql.validators.InputFieldsController;
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ResultPath;
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationOptions;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
@@ -29,6 +31,7 @@ import graphql.schema.idl.SchemaParser;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import org.dataloader.BatchLoader;
 
 /**
  * <p>Setups the GraphQL instance with all the necessary properties. A GraphQL instance is
@@ -85,6 +88,7 @@ public class GraphQLProvider {
     return GraphQL.newGraphQL(buildSchema(buildWiring()))
       .queryExecutionStrategy(new AsyncExecutionStrategy())
       .instrumentation(buildValidationInstrumentation())
+      .instrumentation(buildDataLoaderDispatcherInstrumentation())
       .build();
   }
 
@@ -172,6 +176,18 @@ public class GraphQLProvider {
       );
 
     return new FieldValidationInstrumentation(fieldValidation);
+  }
+
+  /**
+   * @return a {@link DataLoaderDispatcherInstrumentation} that allows to enable the registration of
+   * {@link BatchLoader}s. By default, the statistics are disabled.
+   */
+  private DataLoaderDispatcherInstrumentation buildDataLoaderDispatcherInstrumentation() {
+    return new DataLoaderDispatcherInstrumentation(
+      DataLoaderDispatcherInstrumentationOptions
+        .newOptions()
+        .includeStatistics(false)
+    );
   }
 
   /**

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -267,7 +267,6 @@ public class GraphQLProvider {
           Files.GraphQL.FileVersion.PERMISSIONS,
           nodeDataFetcher.getPermissionsNodeFetcher()
         )
-        .dataFetcher(Files.GraphQL.FileVersion.FLAGGED, nodeDataFetcher.nodeFlagAttributeFetcher())
         .dataFetcher(Files.GraphQL.FileVersion.SHARES, shareDataFetcher.getSharesFetcher())
         .dataFetcher(Files.GraphQL.FileVersion.LINKS, linkDataFetcher.getLinks())
       )
@@ -276,9 +275,8 @@ public class GraphQLProvider {
         .dataFetcher(Files.GraphQL.Folder.OWNER, userDataFetcher.getUserFetcher())
         .dataFetcher(Files.GraphQL.Folder.LAST_EDITOR, userDataFetcher.getUserFetcher())
         .dataFetcher(Files.GraphQL.Folder.PARENT, nodeDataFetcher.getNodeFetcher())
-        .dataFetcher(Files.GraphQL.Folder.CHILDREN, nodeDataFetcher.getChildNodesFetcher())
+        .dataFetcher(Files.GraphQL.Folder.CHILDREN, nodeDataFetcher.getChildNodesFetcherFast())
         .dataFetcher(Files.GraphQL.Folder.PERMISSIONS, nodeDataFetcher.getPermissionsNodeFetcher())
-        .dataFetcher(Files.GraphQL.Folder.FLAGGED, nodeDataFetcher.nodeFlagAttributeFetcher())
         .dataFetcher(Files.GraphQL.Folder.SHARES, shareDataFetcher.getSharesFetcher())
         .dataFetcher(Files.GraphQL.Folder.LINKS, linkDataFetcher.getLinks())
       )

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Db.RootId;
 import com.zextras.carbonio.files.Files.GraphQL;
+import com.zextras.carbonio.files.Files.GraphQL.Context;
 import com.zextras.carbonio.files.Files.GraphQL.InputParameters;
 import com.zextras.carbonio.files.Files.GraphQL.InputParameters.FlagNodes;
 import com.zextras.carbonio.files.Files.GraphQL.InputParameters.GetVersions;
@@ -21,6 +22,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeCustomAttributes;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.dao.ebean.Share;
 import com.zextras.carbonio.files.dal.dao.ebean.TrashedNode;
@@ -134,116 +136,113 @@ public class NodeDataFetcher {
         : this.maxNumberOfVersions - Config.DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION;
   }
 
-  private DataFetcherResult<Map<String, Object>> fetchNodeAndConvertToDataFetcherResult(
-    String nodeId,
-    Optional<Integer> version,
+  private DataFetcherResult<Map<String, Object>> convertNodeToDataFetcherResult(
+    Node node,
+    String requesterId,
     ResultPath path
   ) {
-    return nodeRepository
-      .getNode(nodeId)
-      .map(node -> convertNodeToDataFetcherResult(node, version, path))
-      .orElse(new DataFetcherResult.Builder<Map<String, Object>>()
-        .error(GraphQLResultErrors.nodeNotFound(nodeId, path))
-        .build());
+    return convertNodeToDataFetcherResult(node, node.getCurrentVersion(), requesterId, path);
   }
 
   private DataFetcherResult<Map<String, Object>> convertNodeToDataFetcherResult(
     Node node,
-    Optional<Integer> version,
+    Integer version,
+    String requesterId,
     ResultPath path
   ) {
     Map<String, Object> result = new HashMap<>();
     Map<String, String> nodeContext = new HashMap<>();
+    Optional<GraphQLError> versionError = Optional.empty();
 
     result.put(Files.GraphQL.Node.ID, node.getId());
     result.put(Files.GraphQL.Node.CREATED_AT, node.getCreatedAt());
     result.put(Files.GraphQL.Node.UPDATED_AT, node.getUpdatedAt());
     result.put(Files.GraphQL.Node.NAME, node.getName());
-    if (node.getNodeType()
-      .equals(NodeType.ROOT)) {
-      result.put(Files.GraphQL.Node.ROOT_ID, node.getId());
-    } else {
-      result.put(Files.GraphQL.Node.ROOT_ID, node.getAncestorsList()
-        .get(0));
-    }
-    if (!node.getNodeType()
-      .equals(NodeType.FOLDER) &&
-      !node.getNodeType()
-        .equals(NodeType.ROOT)) {
-      node.getExtension()
-        .ifPresent(ext -> result.put(Files.GraphQL.Node.EXTENSION, ext));
-    }
-    node.getDescription()
-      .ifPresent(description -> result.put(Files.GraphQL.Node.DESCRIPTION, description));
-    result.put(Files.GraphQL.Node.TYPE, node.getNodeType()
-      .name());
+    result.put(Files.GraphQL.Node.TYPE, node.getNodeType().name());
 
-    Optional<GraphQLError> versionError = Optional.empty();
-    if (!node.getNodeType()
-      .equals(NodeType.FOLDER) &&
-      !node.getNodeType()
-        .equals(NodeType.ROOT)) {
-      Optional<Map<String, Object>> fileVersion = fetchFileVersionAndConvertToGraphQLMap(node,
-        version);
-      if (fileVersion.isPresent()) {
-        result.putAll(fileVersion.get());
+    result.put(
+      Files.GraphQL.Node.ROOT_ID,
+      node.getNodeType().equals(NodeType.ROOT)
+        ? node.getId()
+        : result.put(Files.GraphQL.Node.ROOT_ID, node.getAncestorsList().get(0))
+    );
+
+    result.put(
+      GraphQL.Node.FLAGGED,
+      node
+        .getCustomAttributes()
+        .stream()
+        .filter(attributes -> requesterId.equals(attributes.getUserId()))
+        .findFirst()
+        .map(NodeCustomAttributes::getFlag)
+        .orElse(false)
+    );
+
+    node
+      .getDescription()
+      .ifPresent(description -> result.put(Files.GraphQL.Node.DESCRIPTION, description));
+
+    node
+      .getParentId()
+      .ifPresent(parentId -> nodeContext.put(Files.GraphQL.Node.PARENT, parentId));
+
+    if (!node.getNodeType().equals(NodeType.FOLDER) && !node.getNodeType().equals(NodeType.ROOT)) {
+      node
+        .getExtension()
+        .ifPresent(extension -> result.put(Files.GraphQL.Node.EXTENSION, extension));
+
+      Optional<FileVersion> optFileVersion = node
+        .getFileVersions()
+        .stream()
+        .filter(fileVersion -> node.getCurrentVersion().equals(fileVersion.getVersion()))
+        .findFirst();
+
+      if (optFileVersion.isPresent()) {
+        result.putAll(convertFileVersionToGraphQLMap(optFileVersion.get()));
       } else {
         versionError = Optional.of(
-          GraphQLResultErrors.fileVersionNotFound(node.getId(), version.orElse(null), path));
+          GraphQLResultErrors.fileVersionNotFound(node.getId(), version, path));
       }
     }
+
     nodeContext.put(Files.GraphQL.Node.OWNER, node.getOwnerId());
     nodeContext.put(Files.GraphQL.Node.CREATOR, node.getCreatorId());
     nodeContext.put(Files.GraphQL.Node.ID, node.getId());
+
+    // TODO Move up when the last_editor coherent between node and file version will be coherent
     Optional
       .ofNullable((String) result.get(GraphQL.Node.LAST_EDITOR))
       .ifPresent(lastEditorId -> nodeContext.put(Files.GraphQL.Node.LAST_EDITOR, lastEditorId));
-    node.getParentId()
-      .ifPresent(parentId -> nodeContext.put(Files.GraphQL.Node.PARENT, parentId));
 
-    DataFetcherResult.Builder<Map<String, Object>> resultBuilder =
-      new DataFetcherResult.Builder<Map<String, Object>>()
-        .data(result)
-        .localContext(nodeContext);
+    DataFetcherResult.Builder<Map<String, Object>> resultBuilder = new DataFetcherResult
+      .Builder<Map<String, Object>>()
+      .data(result)
+      .localContext(nodeContext);
 
     return versionError
-      .map(error -> resultBuilder.error(error)
-        .build())
+      .map(error -> resultBuilder.error(error).build())
       .orElse(resultBuilder.build());
   }
 
-  private Optional<Map<String, Object>> fetchFileVersionAndConvertToGraphQLMap(
-    Node node,
-    Optional<Integer> version
-  ) {
+  private Map<String, Object> convertFileVersionToGraphQLMap(FileVersion fileVersion) {
 
-    Optional<FileVersion> optFileVersion = (version.isPresent())
-      ?
-      fileVersionRepository.getFileVersion(node.getId(), version.get())
-      :
-        fileVersionRepository.getFileVersion(node.getId(), node.getCurrentVersion());
-
-    return optFileVersion.map(
-        fileVersion ->
-        {
-          Map<String, Object> result = new HashMap<>();
-          result.put(Files.GraphQL.FileVersion.UPDATED_AT, fileVersion.getUpdatedAt());
-          result.put(GraphQL.FileVersion.LAST_EDITOR, fileVersion.getLastEditorId());
-          result.put(Files.GraphQL.FileVersion.VERSION, fileVersion.getVersion());
-          result.put(Files.GraphQL.FileVersion.MIME_TYPE, fileVersion.getMimeType());
-          result.put(Files.GraphQL.FileVersion.SIZE, fileVersion.getSize());
-          result.put(Files.GraphQL.FileVersion.KEEP_FOREVER, fileVersion.isKeptForever());
-          result.put(Files.GraphQL.FileVersion.DIGEST, fileVersion.getDigest());
-          fileVersion
-            .getClonedFromVersion()
-            .ifPresent(clonedFromVersion -> result.put(GraphQL.FileVersion.CLONED_FROM_VERSION,
-              clonedFromVersion));
-          return Optional.of(result);
-        }
-      )
-      .orElse(Optional.empty());
-
+    Map<String, Object> fileVersionMap = new HashMap<>();
+    fileVersionMap.put(Files.GraphQL.FileVersion.UPDATED_AT, fileVersion.getUpdatedAt());
+    fileVersionMap.put(GraphQL.FileVersion.LAST_EDITOR, fileVersion.getLastEditorId());
+    fileVersionMap.put(Files.GraphQL.FileVersion.VERSION, fileVersion.getVersion());
+    fileVersionMap.put(Files.GraphQL.FileVersion.MIME_TYPE, fileVersion.getMimeType());
+    fileVersionMap.put(Files.GraphQL.FileVersion.SIZE, fileVersion.getSize());
+    fileVersionMap.put(Files.GraphQL.FileVersion.KEEP_FOREVER, fileVersion.isKeptForever());
+    fileVersionMap.put(Files.GraphQL.FileVersion.DIGEST, fileVersion.getDigest());
+    fileVersion
+      .getClonedFromVersion()
+      .ifPresent(clonedFromVersion -> fileVersionMap.put(
+        GraphQL.FileVersion.CLONED_FROM_VERSION,
+        clonedFromVersion)
+      );
+    return fileVersionMap;
   }
+
 
   /**
    * This {@link DataFetcher} must be used for the <code>getNode</code> query. In particular:
@@ -262,42 +261,57 @@ public class NodeDataFetcher {
    * values of the node.
    */
   public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, Object>>>> getNodeFetcher() {
-    return (environment) -> CompletableFuture.supplyAsync(
-      () -> {
-        AtomicBoolean isParent = new AtomicBoolean(false);
-        String nodeId = Optional.ofNullable(
-            (String) environment.getArgument(InputParameters.NODE_ID))
-          .orElseGet(() -> Optional.ofNullable(environment.getLocalContext())
-            .map(context -> {
-              String fieldName = environment.getField()
-                .getName();
-              if (fieldName.equals(Files.GraphQL.Node.PARENT)) {
-                isParent.set(true);
-              }
-              return ((Map<String, String>) context).get(fieldName);
-            })
-            .orElse(null));
-        return Optional.ofNullable(nodeId)
-          .map(nId -> {
-            String requesterId = ((User) environment.getGraphQlContext()
-              .get(Files.GraphQL.Context.REQUESTER)).getUuid();
-            return permissionsChecker.getPermissions(nId, requesterId)
-              .has(SharePermission.READ_ONLY)
-              ? fetchNodeAndConvertToDataFetcherResult(nId,
-              Optional.ofNullable(environment.getArgument(Files.GraphQL.FileVersion.VERSION)),
-              environment.getExecutionStepInfo()
-                .getPath()
-            )
-              : (isParent.get())
-                ? new DataFetcherResult.Builder<Map<String, Object>>().build()
-                : new DataFetcherResult.Builder<Map<String, Object>>()
-                  .error(GraphQLResultErrors.nodeNotFound(nId, environment.getExecutionStepInfo()
-                    .getPath()))
-                  .build();
+    return environment -> {
+      ResultPath path = environment.getExecutionStepInfo().getPath();
+      AtomicBoolean isParent = new AtomicBoolean(false);
+      String nodeId = Optional
+        .ofNullable((String) environment.getArgument(InputParameters.NODE_ID))
+        .orElseGet(() -> Optional
+          .ofNullable(environment.getLocalContext())
+          .map(context -> {
+            String fieldName = environment.getField().getName();
+            if (fieldName.equals(Files.GraphQL.Node.PARENT)) {
+              isParent.set(true);
+            }
+            return ((Map<String, String>) context).get(fieldName);
           })
-          .orElse(new DataFetcherResult.Builder<Map<String, Object>>().build());
-      }
-    );
+          .orElse(null));
+
+      return Optional
+        .ofNullable(nodeId)
+        .map(nId ->
+          environment
+            .getDataLoader("NodeBatchLoader")
+            .load(nId)
+            .thenApply(node -> {
+              String requesterId =
+                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid();
+
+              Optional<Integer> optVersion = environment.getArgument(
+                Files.GraphQL.FileVersion.VERSION);
+
+              return permissionsChecker
+                .getPermissions(nId, requesterId)
+                .has(SharePermission.READ_ONLY)
+                ? convertNodeToDataFetcherResult((Node) node, requesterId, path)
+                : (isParent.get())
+                  ? new DataFetcherResult.Builder<Map<String, Object>>().build()
+                  : new DataFetcherResult
+                    .Builder<Map<String, Object>>()
+                    .error(GraphQLResultErrors.nodeNotFound(nId, path))
+                    .build();
+            }).exceptionally((e) ->
+              (isParent.get())
+                ? new DataFetcherResult.Builder<Map<String, Object>>().build()
+                : new DataFetcherResult
+                  .Builder<Map<String, Object>>()
+                  .error(GraphQLResultErrors.nodeNotFound(nId, path))
+                  .build()
+            ))
+        .orElse(CompletableFuture.supplyAsync(() ->
+          new DataFetcherResult.Builder<Map<String, Object>>().build()
+        ));
+    };
   }
 
   /**
@@ -310,16 +324,11 @@ public class NodeDataFetcher {
     return environment ->
     {
       Map<String, Object> result = environment.getObject();
-      return (result.get(Files.GraphQL.Node.TYPE)
-        .equals(NodeType.FOLDER.toString()) ||
-        result.get(Files.GraphQL.Node.TYPE)
-          .equals(NodeType.ROOT.toString()))
-        ?
-        (GraphQLObjectType) environment.getSchema()
-          .getType(Files.GraphQL.Types.FOLDER)
-        :
-          (GraphQLObjectType) environment.getSchema()
-            .getType(Files.GraphQL.Types.FILE);
+      return (result.get(Files.GraphQL.Node.TYPE).equals(NodeType.FOLDER.toString())
+        || result.get(Files.GraphQL.Node.TYPE).equals(NodeType.ROOT.toString())
+      )
+        ? (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FOLDER)
+        : (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FILE);
     };
   }
 
@@ -416,12 +425,11 @@ public class NodeDataFetcher {
                 .skip(numberNodesToSkip)
                 .limit(limit)
                 .collect(Collectors.toList()), optSort)
-              .map(childNode -> {
-                return this.convertNodeToDataFetcherResult(childNode,
-                  Optional.empty(),
-                  environment.getExecutionStepInfo()
-                    .getPath());
-              })
+              .map(childNode -> this.convertNodeToDataFetcherResult(
+                childNode,
+                requesterId,
+                environment.getExecutionStepInfo().getPath())
+              )
               .collect(Collectors.toList()));
 
           })
@@ -510,9 +518,9 @@ public class NodeDataFetcher {
               // Create share also for the requester if it is not the owner of the parent folder
               createIndirectShare(parentId, createdFolder);
 
-              return fetchNodeAndConvertToDataFetcherResult(
-                createdFolder.getId(),
-                Optional.empty(),
+              return convertNodeToDataFetcherResult(
+                createdFolder,
+                requesterId,
                 resultPath
               );
             })
@@ -645,9 +653,8 @@ public class NodeDataFetcher {
         nodeToUpdate.setLastEditorId(requesterId);
         return convertNodeToDataFetcherResult(
           nodeRepository.updateNode(nodeToUpdate),
-          Optional.empty(),
-          environment.getExecutionStepInfo()
-            .getPath()
+          requesterId,
+          environment.getExecutionStepInfo().getPath()
         );
       }
 
@@ -861,7 +868,7 @@ public class NodeDataFetcher {
 
       List<DataFetcherResult<Map<String, Object>>> results = restoredNodes
         .stream()
-        .map(node -> convertNodeToDataFetcherResult(node, Optional.empty(), path))
+        .map(node -> convertNodeToDataFetcherResult(node, requesterId, path))
         .collect(Collectors.toList());
 
       results.addAll(nodesInError
@@ -889,20 +896,27 @@ public class NodeDataFetcher {
    * values of a shared node.
    */
   public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, Object>>>> sharedNodeFetcher() {
-    return environment -> CompletableFuture.supplyAsync(() ->
-    {
-      return Optional.ofNullable(((Map<String, String>) environment.getLocalContext())
-          .get(environment.getField()
-            .getName()))
-        .map(nodeId -> {
-          return fetchNodeAndConvertToDataFetcherResult(nodeId,
-            Optional.empty(),
-            environment.getExecutionStepInfo()
-              .getPath());
-        })
-        .orElse(new DataFetcherResult.Builder<Map<String, Object>>().build());
+    return environment -> {
+      String nodeIdField = environment.getField().getName();
 
-    });
+      return Optional
+        .ofNullable(((Map<String, String>) environment.getLocalContext()).get(nodeIdField))
+        .map(nodeId ->
+          environment
+            .getDataLoader("NodeBatchLoader")
+            .load(nodeId)
+            .thenApply(node -> convertNodeToDataFetcherResult(
+              (Node) node,
+              ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid(),
+              environment.getExecutionStepInfo().getPath())
+            )
+            .exceptionally((e) -> new DataFetcherResult.Builder<Map<String, Object>>().build())
+        )
+        .orElse(CompletableFuture.supplyAsync(() ->
+          new DataFetcherResult.Builder<Map<String, Object>>().build())
+        );
+
+    };
   }
 
   /**
@@ -933,10 +947,11 @@ public class NodeDataFetcher {
             .equals(requesterId)) {
             return treeNodes
               .stream()
-              .map(n -> convertNodeToDataFetcherResult(n,
-                Optional.empty(),
-                environment.getExecutionStepInfo()
-                  .getPath()))
+              .map(n -> convertNodeToDataFetcherResult(
+                n,
+                requesterId,
+                environment.getExecutionStepInfo().getPath()
+              ))
               .collect(Collectors.toList());
           } else {
             List<Share> shares = shareRepository.getShares(treeNodes
@@ -954,10 +969,11 @@ public class NodeDataFetcher {
             List<DataFetcherResult<Map<String, Object>>> result = treeNodes
               .subList(treeNodes.indexOf(sharedNodes.get(0)), treeNodes.size())
               .stream()
-              .map(treeNode -> convertNodeToDataFetcherResult(treeNode,
-                Optional.empty(),
-                environment.getExecutionStepInfo()
-                  .getPath()))
+              .map(treeNode -> convertNodeToDataFetcherResult(
+                treeNode,
+                requesterId,
+                environment.getExecutionStepInfo().getPath()
+              ))
               .collect(Collectors.toList());
             return result;
           }
@@ -1121,9 +1137,13 @@ public class NodeDataFetcher {
         .map(context -> {
           return ((Map<String, List<Node>>) context).get(Files.GraphQL.NodePage.NODES)
             .stream()
-            .map(n -> convertNodeToDataFetcherResult(n, Optional.empty(),
-              environment.getExecutionStepInfo()
-                .getPath()))
+            .map(node ->
+              convertNodeToDataFetcherResult(
+                node,
+                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid(),
+                environment.getExecutionStepInfo().getPath()
+              )
+            )
             .collect(Collectors.toList());
         })
         .orElse(Collections.emptyList());
@@ -1237,7 +1257,7 @@ public class NodeDataFetcher {
 
             movedNodesResult.addAll(nodeRepository
               .getNodes(nodeIdsToMove, Optional.empty())
-              .map(node -> convertNodeToDataFetcherResult(node, Optional.empty(), resultPath))
+              .map(node -> convertNodeToDataFetcherResult(node, requesterId, resultPath))
               .collect(Collectors.toList()));
           }
 
@@ -1376,8 +1396,8 @@ public class NodeDataFetcher {
    * @param sourceNode the file that must be copied.
    * @param destinationFolder the {@link Node} representing the destination folder.
    * @param requesterId requester identifier.
-   * @param newFileName is an {@link Optional<String>} if we want to give a new name to the copied file,
-   * used for name clashes
+   * @param newFileName is an {@link Optional<String>} if we want to give a new name to the copied
+   * file, used for name clashes
    *
    * @return the number of copied nodes.
    */
@@ -1639,13 +1659,13 @@ public class NodeDataFetcher {
           List<Node> nodes = nodeRepository.getNodes(nodeIds, Optional.empty())
             .collect(Collectors.toList());
           List<String> targetFolderChildrenFilesName = nodeRepository.getNodes(
-            nodeRepository.getChildrenIds(
-              destinationFolderId,
-              Optional.empty(),
-              Optional.empty(),
-              false),
-            Optional.empty()
-          )
+              nodeRepository.getChildrenIds(
+                destinationFolderId,
+                Optional.empty(),
+                Optional.empty(),
+                false),
+              Optional.empty()
+            )
             .map(Node::getFullName)
             .collect(Collectors.toList());
 
@@ -1691,7 +1711,7 @@ public class NodeDataFetcher {
                     nodeDup, optDestinationFolder.get(), requesterId, Optional.of(newName)
                   );
                   copiedNodesResult.add(
-                    convertNodeToDataFetcherResult(copiedFolder, Optional.empty(), resultPath)
+                    convertNodeToDataFetcherResult(copiedFolder, requesterId, resultPath)
                   );
                   copyFolderCascade(nodeDup.getId(), copiedFolder, requesterId,
                     Optional.of(newName));
@@ -1701,7 +1721,7 @@ public class NodeDataFetcher {
                     nodeDup, optDestinationFolder.get(), requesterId, Optional.of(newName)
                   );
                   copiedNodesResult.add(
-                    convertNodeToDataFetcherResult(copiedFile, Optional.empty(), resultPath)
+                    convertNodeToDataFetcherResult(copiedFile, requesterId, resultPath)
                   );
                   createIndirectShare(destinationFolderId, copiedFile);
                 }
@@ -1715,14 +1735,14 @@ public class NodeDataFetcher {
                   Node copiedFolder = copyFolder(node, optDestinationFolder.get(), requesterId,
                     Optional.empty());
                   copiedNodesResult.add(
-                    convertNodeToDataFetcherResult(copiedFolder, Optional.empty(), resultPath));
+                    convertNodeToDataFetcherResult(copiedFolder, requesterId, resultPath));
                   copyFolderCascade(node.getId(), copiedFolder, requesterId, Optional.empty());
                   createIndirectShare(destinationFolderId, copiedFolder);
                 } else {
                   Node copiedFile = copyFile(node, optDestinationFolder.get(), requesterId,
                     Optional.empty());
                   copiedNodesResult.add(
-                    convertNodeToDataFetcherResult(copiedFile, Optional.empty(), resultPath));
+                    convertNodeToDataFetcherResult(copiedFile, requesterId, resultPath));
                   createIndirectShare(destinationFolderId, copiedFile);
                 }
               });
@@ -1761,7 +1781,12 @@ public class NodeDataFetcher {
             return versions;
           })
           .forEach(version -> results.add(
-            fetchNodeAndConvertToDataFetcherResult(nodeId, Optional.of(version), path)));
+            convertNodeToDataFetcherResult(
+              nodeRepository.getNode(nodeId).get(),
+              version,
+              requesterId,
+              path)
+          ));
 
         return results;
       }
@@ -1942,7 +1967,9 @@ public class NodeDataFetcher {
 
             logger.debug(MessageFormat.format(
               "Download operation concluded with result {0} with file {1} and version {2}",
-              blobResponses.isSuccess()? "success" : "failure",
+              blobResponses.isSuccess()
+                ? "success"
+                : "failure",
               nodeId,
               currVer
             ));
@@ -1986,13 +2013,13 @@ public class NodeDataFetcher {
             );
 
             node.setCurrentVersion(newVersion);
-            nodeRepository.updateNode(node);
+            Node updatedNode = nodeRepository.updateNode(node);
 
             newFileVersion.get()
               .setClonedFromVersion(versionToClone);
             fileVersionRepository.updateFileVersion(newFileVersion.get());
 
-            return fetchNodeAndConvertToDataFetcherResult(nodeId, Optional.of(newVersion), path);
+            return convertNodeToDataFetcherResult(updatedNode, newVersion, requesterId, path);
           })
           .orElse(
             new Builder<Map<String, Object>>()

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -49,7 +49,6 @@ import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.EnumValuesProvider;
-import io.ebean.annotation.Transactional;
 import io.vavr.control.Try;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -376,7 +375,6 @@ public class NodeDataFetcher {
    * @return an asynchronous {@link DataFetcher} containing a {@link List} of all child nodes of the
    * folder.
    */
-  @Transactional
   public DataFetcher<CompletableFuture<List<DataFetcherResult<Map<String, Object>>>>> getChildNodesFetcher() {
     return environment -> CompletableFuture.supplyAsync(() -> {
         Map<String, Object> partialResult = environment.getSource();

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/NodeBatchLoader.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/NodeBatchLoader.java
@@ -1,0 +1,88 @@
+package com.zextras.carbonio.files.graphql.dataloaders;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.exceptions.NodeNotFoundException;
+import graphql.schema.DataFetcher;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.dataloader.BatchLoader;
+import org.dataloader.Try;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This custom {@link BatchLoader} allows to queue a list of node ids that will be used to make a
+ * single sql query to fetch in batch the necessary {@link Node}s to populate a GraphQL response.
+ * This is useful when a GraphQL request requires to fetch single nodes on different level of the
+ * query or when nodes cannot be fetched in batch directly on a single {@link DataFetcher}.
+ */
+public class NodeBatchLoader implements BatchLoader<String, Try<Node>> {
+
+  private final static Logger logger = LoggerFactory.getLogger(NodeBatchLoader.class);
+
+  private final NodeRepository nodeRepository;
+
+  @Inject
+  public NodeBatchLoader(NodeRepository nodeRepository) {
+    this.nodeRepository = nodeRepository;
+  }
+
+  /**
+   * This method will be called by the GraphQL dataloader scheduler when all the
+   * {@link DataFetcher}s, necessary to create a GraphQL response, are called.
+   * </p>
+   * It is only responsible to fetch the {@link Node}s and it does <strong>not</strong>  check if
+   * the requester has the read permission on them.
+   *
+   * @param nodeIds the {@link List} of node ids to fetch
+   *
+   * @return a {@link CompletionStage} containing a {@link List} of {@link Try<Node>}. The list has
+   * as many elements as there are node ids in input. If a node ids does not correspond to a
+   * {@link Node} then the method return a {@link Try#failed} containing a
+   * {@link NodeNotFoundException}.
+   */
+  @Override
+  public CompletionStage<List<Try<Node>>> load(List<String> nodeIds) {
+    return CompletableFuture.supplyAsync(() -> {
+
+      logger.debug(MessageFormat.format("Start fetching nodes in batch: {0}", nodeIds));
+
+      List<Node> nodes = nodeRepository
+        .getNodes(nodeIds, Optional.empty())
+        .collect(Collectors.toList());
+
+      List<String> nodeIdsFound = nodes
+        .stream()
+        .map(Node::getId)
+        .collect(Collectors.toList());
+
+      List<String> nodeIdsNotFound = nodeIds
+        .stream()
+        .filter(nodeId -> !nodeIdsFound.contains(nodeId))
+        .collect(Collectors.toList());
+
+      List<Try<Node>> results = nodes
+        .stream()
+        .map(Try::succeeded)
+        .collect(Collectors.toList());
+
+      nodeIdsNotFound.forEach(nodeIdNotFound ->
+        results.add(Try.failed(new NodeNotFoundException()))
+      );
+
+      logger.debug(MessageFormat.format(
+        "End fetching nodes in batch.\n - Nodes found: {0}\n - Nodes not found: {1}",
+        nodeIdsFound,
+        nodeIdsNotFound
+      ));
+
+      return results;
+    });
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/NodeBatchLoader.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/NodeBatchLoader.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.files.graphql.dataloaders;
 
 import com.google.inject.Inject;

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/ShareBatchLoader.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/ShareBatchLoader.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.files.graphql.dataloaders;
 
 import com.google.inject.Inject;

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/ShareBatchLoader.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/dataloaders/ShareBatchLoader.java
@@ -1,0 +1,83 @@
+package com.zextras.carbonio.files.graphql.dataloaders;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.Share;
+import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
+import graphql.schema.DataFetcher;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.dataloader.BatchLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This custom {@link BatchLoader} allows to queue a list of node ids that will be used to make a
+ * single sql query to fetch in batch all the {@link Share}s to populate a GraphQL response. This is
+ * useful when a GraphQL request requires to fetch single shares on different level of the query or
+ * when shares cannot be fetched in batch directly on a single {@link DataFetcher}.
+ */
+public class ShareBatchLoader implements BatchLoader<String, List<Share>> {
+
+  private final static Logger logger = LoggerFactory.getLogger(ShareBatchLoader.class);
+
+  private final ShareRepository shareRepository;
+
+  @Inject
+  public ShareBatchLoader(ShareRepository shareRepository) {
+    this.shareRepository = shareRepository;
+  }
+
+  /**
+   * This method will be invoked by the GraphQL dataloader scheduler when all the
+   * {@link DataFetcher}s, necessary to create a GraphQL response, are called.
+   * </p>
+   * It is only responsible to fetch the {@link Share}s and it does <strong>not</strong> check if
+   * the requester has the read permission on the {@link Node}s.
+   *
+   * @param nodeIds the {@link List} of node ids. For each one of them it retrieves all the related
+   * shares.
+   *
+   * @return a {@link CompletionStage} containing a {@link List} of {@link List<Share>}. The list
+   * has as many elements as there are node ids in input. If a node does not have a share, then it
+   * will be associated to an empty list.
+   */
+  @Override
+  public CompletionStage<List<List<Share>>> load(List<String> nodeIds) {
+    return CompletableFuture.supplyAsync(() -> {
+
+      logger.debug(MessageFormat.format(
+        "Start fetching shares in batch for the following nodes: {0}",
+        nodeIds
+      ));
+
+      List<Share> shares = shareRepository.getShares(nodeIds);
+
+      List<List<Share>> results = new ArrayList<>();
+
+      // It populates the results: for each node ids it associates all the related shares.
+      // If a node does not have a share then the .collect(Collectors.toList()) generates
+      // an empty List: this is why is not necessary using a Try.
+      nodeIds.forEach(nodeId ->
+        results.add(
+          shares
+            .stream()
+            .filter(share -> nodeId.equals(share.getNodeId()))
+            .collect(Collectors.toList())
+        )
+      );
+
+      logger.debug(MessageFormat.format(
+        "End fetching shares in batch. {0} shares found for {1} nodes",
+        shares.size(),
+        nodeIds.size()
+      ));
+
+      return results;
+    });
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -30,6 +30,7 @@ import com.zextras.carbonio.usermanagement.exceptions.BadRequest;
 import com.zextras.filestore.api.UploadResponse;
 import com.zextras.filestore.model.FilesIdentifier;
 import com.zextras.storages.api.StoragesClient;
+import io.ebean.annotation.Transactional;
 import io.vavr.control.Try;
 import java.text.MessageFormat;
 import java.util.Collections;
@@ -131,6 +132,7 @@ public class BlobService {
       ).orElseGet(() -> Try.failure(new NodeNotFoundException()));
   }
 
+  @Transactional
   public Try<String> uploadFile(
     User requester,
     BufferInputStream bufferInputStream,
@@ -223,6 +225,7 @@ public class BlobService {
     return Try.failure(new NodePermissionException());
   }
 
+  @Transactional
   public Try<Integer> uploadFileVersion(
     User requester,
     BufferInputStream bufferInputStream,

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -290,13 +290,15 @@ type Folder implements Node {
         # Limit: an integer of how many elements to fetch (mandatory)
         limit: Int!,
 
-        # Cursor: a string of the last node id fetched in the previous page (optional)
-        cursor: String,
-
         # Sort: a list of NodeSort containing all the sort order desired (optional).
         # If it is not specified, a NAME_ASC sort is applied by default.
         sort: NodeSort!
-    ): [Node]!
+
+        # String representing a the page token. This token contains all the parameter values
+        # necessary to request the next page of a node list.
+        # If this parameter is initialized, then ALL OTHER parameters will be ignored.
+        page_token: String
+    ): NodePage!
 
     # Specific share of the current folder with the target user (if exists)
     share(share_target_id: ID!) : Share

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.3.7"
-pkgrel="4"
+pkgver="0.4.0"
+pkgrel="1"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -165,5 +165,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.3.7-4</version>
+  <version>0.4.0-1</version>
 </project>


### PR DESCRIPTION
# Problem
In general, the system makes a lot of small queries to the database which increases the time required to build complex GraphQL responses.These latencies sometimes cause timeouts and in general the service is very slow.

This is a summary of what has been done to achieve a significant reduction on response latencies.

## Add user cache to reduce requests over network
It is very likely that a GraphQL response involving a Node contains multiple User type attributes and it is very likely that these
representing the same user.

When a user is requested the first time, the system makes request to the UserManagement over the network and caches the result. Every time the same user is needed, the system goes directly in cache and does not make the same network request to have the same metadata.

For now the user remains in cache for 5 minutes.

## Add GraphQL NodeBatchLoader to optimize the Nodes fetching
- Added the `NodeBatchLoader` in order to minimize the sql queries. This loader is used by the getNodeDataFetcher method to queue each node request in one single sql query.

- Optimized how a node is converted to a GraphQL `Map<String, Object>`.

- Added the mutual `@OneToMany`, `@ManyToOne` annotations in the Node and FileVersion entities. This will help ebean to group same queries in a single one when is possible.

## Add GraphQL ShareBatchLoader to optimize the Shares fetching
- Added the `ShareBatchLoader` in order to minimize the sql queries. This loader is used by the getSharesDataFetcher method to queue a list of shares to retrieve in one single sql query.

- Added a getShares(List<String> nodeIds) method in ShareRepository. It is necessary to fetch all the shares for each node ids.

## Replace custom cache with Ebean cache
- Replaced the Node and Share custom caches with the Ebean cache using the `@Cache` annotation. Every logic about these two caches has been removed from their respective Repository.

- Fixed the FileVersion cache (now it is much more used and cleaned).
  It remains until we figure out how to replace it with Ebean.

- Removed the `@Transactional` annotations where not necessary.

For now, the Ebean cache has the following limits:
- MaxSize: 100_000 items
- MaxTimeToLive: 300 seconds
- MaxIdleTime: 300 seconds

These are very conservative settings but it should be neccesary to speed up close requests that require the same items.

## Speed up fetching of children nodes
In order to speed up the fetching of the children the system now uses the findNode functionality and returns a NodePage containing the list of children and the PageToken necessary to request the next page (if there mare any).

The `nodeCustomAttributeFetcher` has been removed because the flag of each node is retrieved during the conversion from Node to GraphQL Map. This change allows to group the fetching of custom attributes of multiple
nodes in one single sql query.

# Conclusion
We have not done stress test but the improve is significant and visible: requests that previously exceeded 15 seconds (timeout) are now processed in approximately 1.5 seconds.