### PR TITLE
fix: FILES-311 - Fix download timeout on large files

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-4</version>
+    <version>0.3.7-6</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.3.7-4</version>
+    <version>0.3.7-6</version>
   </parent>
 
   <properties>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.3.7"
-pkgrel="4"
+pkgrel="6"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -31,8 +31,10 @@ sources=(
   "intentions.json"
   "policies.json"
   "service-protocol.json"
+  "service-router.json"
 )
 hashsums=(
+  "skip"
   "skip"
   "skip"
   "skip"
@@ -61,6 +63,7 @@ package() {
   install -Dm 644 intentions.json "${pkgdir}/etc/carbonio/files/service-discover/intentions.json"
   install -Dm 644 policies.json "${pkgdir}/etc/carbonio/files/service-discover/policies.json"
   install -Dm 644 service-protocol.json "${pkgdir}/etc/carbonio/files/service-discover/service-protocol.json"
+  install -Dm 644 service-router.json "${pkgdir}/etc/carbonio/files/service-discover/service-router.json"
 }
 
 postinst() {

--- a/package/carbonio-files
+++ b/package/carbonio-files
@@ -43,6 +43,10 @@ consul config write /etc/carbonio/files/service-discover/service-protocol.json
 # Allow other services to contact this service
 consul config write /etc/carbonio/files/service-discover/intentions.json
 
+# Declare the service-router containing the override of the RequestTimeout
+# config for the download, upload and upload-version endpoints
+consul config write /etc/carbonio/files/service-discover/service-router.json
+
 if [[ ! -f "/etc/carbonio/files/service-discover/token" ]]; then
     # Create the token
     consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for

--- a/package/carbonio-files.hcl
+++ b/package/carbonio-files.hcl
@@ -8,6 +8,9 @@ services {
   connect {
     sidecar_service {
       proxy {
+        config {
+          local_request_timeout_ms = 3600000
+        }
         local_service_address = "127.78.0.2"
         upstreams = [
           {

--- a/package/service-router.json
+++ b/package/service-router.json
@@ -1,0 +1,36 @@
+{
+  "Kind": "service-router",
+  "Name": "carbonio-files",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/download"
+        }
+      },
+      "Destination": {
+        "RequestTimeout": "3600s"
+      }
+    },
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/upload"
+        }
+      },
+      "Destination": {
+        "RequestTimeout": "3600s"
+      }
+    },
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/upload-version"
+        }
+      },
+      "Destination": {
+        "RequestTimeout": "3600s"
+      }
+    }
+  ]
+}

--- a/package/service-router.json.license
+++ b/package/service-router.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/pom.xml
+++ b/pom.xml
@@ -165,5 +165,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.3.7-4</version>
+  <version>0.3.7-6</version>
 </project>


### PR DESCRIPTION
The service-discover has a default timeout for every requests between
services. This timeout is set to 15 seconds and it is not enough to
complete a download of files larger than around 500MB.

A new service-discover configuration has been added:
`service-router.json`. It will be written to the service-discover during
the setup phase and it will override the timeout for the following
endpoints:
 - /download
 - /upload
 - /upload-version

For now the timeout is increased to 1h but we saw that if, for some
reason, the download fails the service-discover close the connection
after around 60 seconds.