### PR TITLE
fix: FILES-354 - Fix GetChildren API called on LOCAL_ROOT folder

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -466,13 +466,22 @@ public class NodeDataFetcher {
           environment.getArgument(Files.GraphQL.InputParameters.PAGE_TOKEN)
         );
 
+        // The LOCAL_ROOT is shared to all the users so in the root potentially can be nodes owned
+        // by someone else and shared with the requester. The system must not return these type of
+        // nodes when the folder id is LOCAL_ROOT.
+        // Optional.empty() option considers all nodes which the requester has permission
+        // Optional.of(false) option considers only nodes owned by the requester
+        Optional<Boolean> optSharedWithMe = RootId.LOCAL_ROOT.equals(folderNodeId)
+          ? Optional.of(false)
+          : Optional.empty();
+
         ImmutablePair<List<Node>, String> findResult = nodeRepository.findNodes(
           requesterId,
           optSort,
           Optional.empty(),
           Optional.of(folderNodeId),
           Optional.of(false),
-          Optional.empty(),
+          optSharedWithMe,
           Optional.empty(),
           Optional.empty(),
           Optional.of(limit),


### PR DESCRIPTION
Now the GetChildren API called on the LOCAL_ROOT folder returns only the nodes owned by the requester.
For all other folders it continues to return all nodes which the requester has the permission:
the owned nodes and the sharedWith him/her nodes.