### PR TITLE
feat: FILES-355 - Define collaboration link in GraphQL schema and yaml

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.4.1-1</version>
+    <version>0.4.1-2208221108</version>
   </parent>
 
   <properties>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.4.0-1</version>
+    <version>0.4.1-1</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.4.1-1</version>
+    <version>0.4.1-2208221108</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.4.0-1</version>
+    <version>0.4.1-1</version>
   </parent>
 
   <properties>

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -314,14 +314,14 @@ paths:
           $ref: '#/components/responses/422ValidationError'
         502:
           $ref: '#/components/responses/502BadGateway'
-  /invitation/{invitationLinkId}:
+  /collaboration/{collaborationLinkId}:
     get:
-      description: Allows to auto-share a specific node with a specific permission to the logged 
+      description: Allows to auto-share a specific node with a specific permission to the logged
                    user that click on this link.
-      operationId: invitationLink
+      operationId: collaborationLink
       parameters:
         - $ref: '#/components/parameters/headerCookies'
-        - $ref: '#/components/parameters/pathInvitationLinkId'
+        - $ref: '#/components/parameters/pathCollaborationLinkId'
       responses:
         307:
           $ref: '#/components/responses/307TemporaryRedirect'
@@ -339,10 +339,10 @@ components:
       required: true
       schema:
         type: string
-    pathInvitationLinkId:
+    pathCollaborationLinkId:
       in: path
-      name: invitationLinkId
-      description: The id of the invitation link
+      name: collaborationLinkId
+      description: The id of the collaboration link
       required: true
       allowEmptyValue: false
       schema:

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -314,8 +314,41 @@ paths:
           $ref: '#/components/responses/422ValidationError'
         502:
           $ref: '#/components/responses/502BadGateway'
+  /invitation/{invitationLinkId}:
+    get:
+      description: Allows to auto-share a specific node with a specific permission to the logged 
+                   user that click on this link.
+      operationId: invitationLink
+      parameters:
+        - $ref: '#/components/parameters/headerCookies'
+        - $ref: '#/components/parameters/pathInvitationLinkId'
+      responses:
+        307:
+          $ref: '#/components/responses/307TemporaryRedirect'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
 components:
   parameters:
+    headerCookies:
+      in: header
+      name: Cookies
+      required: true
+      schema:
+        type: string
+    pathInvitationLinkId:
+      in: path
+      name: invitationLinkId
+      description: The id of the invitation link
+      required: true
+      allowEmptyValue: false
+      schema:
+        type: string
+        minLength: 8
+        maxLength: 8
     pathNodeId:
       in: path
       name: nodeId
@@ -416,6 +449,8 @@ components:
         application/octet-stream:
           schema:
             $ref: '#/components/schemas/NodeBinary'
+    307TemporaryRedirect:
+      description: The request is redirect to another url
     400BadRequest:
       description: The request was malformed
     403Forbidden:

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -184,6 +184,32 @@ type Link {
     description: String
 }
 
+# Definition of an invitation link. It represents an internal link that allows a logged user to
+# auto-share a specific node with a specific permission.
+# Each node can have at maximum 2 InvitationLink:
+#  - one that allows to auto-share the node with the READ+SHARE permission;
+#  - one that allows to auto-share the node with the WRITE+SHARE permission.
+# An invitation link can be generated only if the requester has the <strong>can_share</strong>
+# permission on the node.
+type InvitationLink {
+    # Unique identifier of the InvitationLink.
+    id: ID!
+
+    # Full URL allowing a logged user to auto-share the related node with the related permission.
+    # After the creation/update of the share, the system returns a redirect to the internal url of
+    # the shared node.
+    url: String!
+
+    # Node on which the share is created when a logged user clicks on the invitation link.
+    node: Node!
+
+    # Link creation timestamp.
+    created_at: DateTime!
+
+    # The permission type created/updated when a logged user clicks on the invitation link.
+    permission: SharePermission!
+}
+
 # Definition of the Node interface
 interface Node {
     # Unique identifier of the node
@@ -242,6 +268,12 @@ interface Node {
     ): [Share]!
 
     links: [Link]!
+
+    # Returns all the InvitationLinks of current node.
+    # It can be maximum of 2 invitation links:
+    #  - one that allows to auto-share the node with the READ+SHARE permission;
+    #  - one that allows to auto-share the node with the WRITE+SHARE permission.
+    invitationLinks: [InvitationLink]!
 }
 
 # Definition of the Folder type which implements the Node interface
@@ -317,6 +349,12 @@ type Folder implements Node {
     ): [Share]!
 
     links: [Link]!
+
+    # Returns all the InvitationLinks of current node.
+    # It can be maximum of 2 invitation links:
+    #  - one that allows to auto-share the node with the READ+SHARE permission;
+    #  - one that allows to auto-share the node with the WRITE+SHARE permission.
+    invitationLinks: [InvitationLink]!
 }
 
 # Definition of the File type which implements the Node interface
@@ -394,6 +432,12 @@ type File implements Node {
     ): [Share]!
 
     links: [Link]!
+
+    # Returns all the InvitationLinks of current node.
+    # It can be maximum of 2 invitation links:
+    #  - one that allows to auto-share the node with the READ+SHARE permission;
+    #  - one that allows to auto-share the node with the WRITE+SHARE permission.
+    invitationLinks: [InvitationLink]!
 }
 
 # Definition of the type Root. Represents a root folder
@@ -490,6 +534,14 @@ type Query {
     getLinks(
         node_id: ID!
     ): [Link]!
+
+    # Returns all the InvitationLinks of the specified node.
+    # The response is not paginated because each node can have a maximum of 2 invitation links:
+    #  - one that allows to auto-share the node with the READ+SHARE permission;
+    #  - one that allows to auto-share the node with the WRITE+SHARE permission.
+    getInvitationLinks(
+        node_id: ID!
+    ): [InvitationLink]!
 
     # Returns the list of all root folders
     getRootsList: [Root]!
@@ -619,6 +671,26 @@ type Mutation {
     deleteLinks(
         # An array of link unique identifiers (mandatory).
         link_ids: [ID!]!
+    ): [ID]!
+
+    # Allows to create an invitation link for an existing node. An invitation link can be created
+    # only if the requester has the <strong>can_share<strong> permission on the specified node.
+    # If the invitation already exists the system returns the already created one.
+    createInvitationLink(
+        # The unique identifier of the node on which the share will be created (mandatory)
+        node_id: ID!
+
+        # The permission type that will be created/updated when a logged user clicks on the link.
+        # (mandatory)
+        permission: SharePermission!
+    ): InvitationLink!
+
+    # Allows to delete a list of invitation links in batch. It returns:
+    #  - an array of IDs for each invitation link removed;
+    #  - a list of errors for each invitation link that could not be removed.
+    deleteInvitationLinks(
+        # An array of invitation link identifiers (mandatory).
+        invitation_link_ids: [ID!]!
     ): [ID]!
 }
 

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -184,15 +184,15 @@ type Link {
     description: String
 }
 
-# Definition of an invitation link. It represents an internal link that allows a logged user to
+# Definition of a collaboration link. It represents an internal link that allows a logged user to
 # auto-share a specific node with a specific permission.
-# Each node can have at maximum 2 InvitationLink:
+# Each node can have at maximum 2 CollaborationLink:
 #  - one that allows to auto-share the node with the READ+SHARE permission;
 #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-# An invitation link can be generated only if the requester has the <strong>can_share</strong>
+# A collaboration link can be generated only if the requester has the <strong>can_share</strong>
 # permission on the node.
-type InvitationLink {
-    # Unique identifier of the InvitationLink.
+type CollaborationLink {
+    # Unique identifier of the CollaborationLink.
     id: ID!
 
     # Full URL allowing a logged user to auto-share the related node with the related permission.
@@ -200,13 +200,13 @@ type InvitationLink {
     # the shared node.
     url: String!
 
-    # Node on which the share is created when a logged user clicks on the invitation link.
+    # Node on which the share is created when a logged user clicks on the collaboration link.
     node: Node!
 
     # Link creation timestamp.
     created_at: DateTime!
 
-    # The permission type created/updated when a logged user clicks on the invitation link.
+    # The permission type created/updated when a logged user clicks on the collaboration link.
     permission: SharePermission!
 }
 
@@ -269,11 +269,11 @@ interface Node {
 
     links: [Link]!
 
-    # Returns all the InvitationLinks of current node.
-    # It can be maximum of 2 invitation links:
+    # Returns all the CollaborationLinks of current node.
+    # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    invitationLinks: [InvitationLink]!
+    collaborationLinks: [CollaborationLink]!
 }
 
 # Definition of the Folder type which implements the Node interface
@@ -350,11 +350,11 @@ type Folder implements Node {
 
     links: [Link]!
 
-    # Returns all the InvitationLinks of current node.
-    # It can be maximum of 2 invitation links:
+    # Returns all the CollaborationLinks of current node.
+    # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    invitationLinks: [InvitationLink]!
+    collaborationLinks: [CollaborationLink]!
 }
 
 # Definition of the File type which implements the Node interface
@@ -433,11 +433,11 @@ type File implements Node {
 
     links: [Link]!
 
-    # Returns all the InvitationLinks of current node.
-    # It can be maximum of 2 invitation links:
+    # Returns all the CollaborationLinks of current node.
+    # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    invitationLinks: [InvitationLink]!
+    collaborationLinks: [CollaborationLink]!
 }
 
 # Definition of the type Root. Represents a root folder
@@ -535,13 +535,13 @@ type Query {
         node_id: ID!
     ): [Link]!
 
-    # Returns all the InvitationLinks of the specified node.
-    # The response is not paginated because each node can have a maximum of 2 invitation links:
+    # Returns all the CollaborationLinks of the specified node.
+    # The response is not paginated because each node can have a maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    getInvitationLinks(
+    getCollaborationLinks(
         node_id: ID!
-    ): [InvitationLink]!
+    ): [CollaborationLink]!
 
     # Returns the list of all root folders
     getRootsList: [Root]!
@@ -673,24 +673,24 @@ type Mutation {
         link_ids: [ID!]!
     ): [ID]!
 
-    # Allows to create an invitation link for an existing node. An invitation link can be created
+    # Allows to create a collaboration link for an existing node. A collaboration link can be created
     # only if the requester has the <strong>can_share<strong> permission on the specified node.
-    # If the invitation already exists the system returns the already created one.
-    createInvitationLink(
+    # If the collaboration link already exists the system returns the already created one.
+    createCollaborationLink(
         # The unique identifier of the node on which the share will be created (mandatory)
         node_id: ID!
 
         # The permission type that will be created/updated when a logged user clicks on the link.
         # (mandatory)
         permission: SharePermission!
-    ): InvitationLink!
+    ): CollaborationLink!
 
-    # Allows to delete a list of invitation links in batch. It returns:
-    #  - an array of IDs for each invitation link removed;
-    #  - a list of errors for each invitation link that could not be removed.
-    deleteInvitationLinks(
-        # An array of invitation link identifiers (mandatory).
-        invitation_link_ids: [ID!]!
+    # Allows to delete a list of collaboration links in batch. It returns:
+    #  - an array of IDs for each collaboration link removed;
+    #  - a list of errors for each collaboration link that could not be removed.
+    deleteCollaborationLinks(
+        # An array of collaboration link identifiers (mandatory).
+        collaboration_link_ids: [ID!]!
     ): [ID]!
 }
 

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -273,7 +273,7 @@ interface Node {
     # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    collaborationLinks: [CollaborationLink]!
+    collaboration_links: [CollaborationLink]!
 }
 
 # Definition of the Folder type which implements the Node interface
@@ -354,7 +354,7 @@ type Folder implements Node {
     # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    collaborationLinks: [CollaborationLink]!
+    collaboration_links: [CollaborationLink]!
 }
 
 # Definition of the File type which implements the Node interface
@@ -437,7 +437,7 @@ type File implements Node {
     # It can be maximum of 2 collaboration links:
     #  - one that allows to auto-share the node with the READ+SHARE permission;
     #  - one that allows to auto-share the node with the WRITE+SHARE permission.
-    collaborationLinks: [CollaborationLink]!
+    collaboration_links: [CollaborationLink]!
 }
 
 # Definition of the type Root. Represents a root folder

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.4.1"
-pkgrel="1"
+pkgrel=""
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.4.0"
+pkgver="0.4.1"
 pkgrel="1"
 pkgdesc="Carbonio Files"
 pkgdesclong=(

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
   
-  <version>0.4.1-1</version>
+  <version>0.4.1-2208221108</version>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
   
-  <version>0.4.0-1</version>
+  <version>0.4.1-1</version>
 
 </project>


### PR DESCRIPTION
In GraphQL schema has been added:
 - CollaborationLink type.
 - collaboration_links attribute in Node, Folder and File type.
 - getCollaborationLinks query to retrieve all the collaboration links of a specific node.
 - createCollaborationLink mutation to create a collaboration link for a specific node 
   with a specific permission. (Each node can have a maximum of 2 collaboration 
   link: one for READ+SHARE and the other for WRITE+SHARE).
 - deleteCollaborationLinks mutation to delete collaboration links in batch.
   It allows to delete collaboration links of different nodes.

In YAML schema has beed added:
 - GET /collaboration/{id} API that allows to create/update a share of a specific node 
   and returns a redirect to the internal url of the node itself.