### PR TITLE
fix: FILES-436 - Fix GetPath API to return nodes ordered correctly

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.5.0-1</version>
+    <version>0.5.0-2209261009</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,7 +136,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.5.0-1</version>
+    <version>0.5.0-2209261009</version>
   </parent>
 
   <properties>

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -55,6 +55,7 @@ import io.vavr.control.Try;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -959,62 +960,62 @@ public class NodeDataFetcher {
    */
   public DataFetcher<CompletableFuture<List<DataFetcherResult<Map<String, Object>>>>> getPathFetcher() {
     return environment -> CompletableFuture.supplyAsync(() -> {
-      String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+      ResultPath path = environment.getExecutionStepInfo().getPath();
+      String requesterId = ((User) environment
+        .getGraphQlContext()
+        .get(Files.GraphQL.Context.REQUESTER))
+        .getUuid();
       String nodeId = environment.getArgument(InputParameters.NODE_ID);
 
-      return permissionsChecker.getPermissions(nodeId, requesterId)
-        .has(SharePermission.READ_ONLY)
-        ? nodeRepository.getNode(nodeId)
-        .map(node -> {
-          List<String> pathNodeIds = new ArrayList<String>(node.getAncestorsList());
-          pathNodeIds.add(nodeId);
-          List<Node> treeNodes = nodeRepository.getNodes(pathNodeIds, Optional.empty())
-            .collect(Collectors.toList());
-          if (node.getNodeType()
-            .equals(NodeType.ROOT) || node.getOwnerId()
-            .equals(requesterId)) {
-            return treeNodes
-              .stream()
-              .map(n -> convertNodeToDataFetcherResult(
-                n,
-                requesterId,
-                environment.getExecutionStepInfo().getPath()
-              ))
-              .collect(Collectors.toList());
-          } else {
-            List<Share> shares = shareRepository.getShares(treeNodes
-                .stream()
-                .map(Node::getId)
-                .collect(Collectors.toList()),
-              requesterId);
-            List<Node> sharedNodes = treeNodes
-              .stream()
-              .filter(treeNode -> shares.stream()
-                .anyMatch(share -> share.getNodeId()
-                  .equals(treeNode.getId())))
+      if (permissionsChecker.getPermissions(nodeId, requesterId).has(SharePermission.READ_ONLY)) {
+        return nodeRepository
+          .getNode(nodeId)
+          .map(node -> {
+            List<String> pathNodeIds = new ArrayList<>(node.getAncestorsList());
+            pathNodeIds.add(nodeId);
+            List<Node> treeNodes = nodeRepository
+              .getNodes(pathNodeIds, Optional.empty())
+              // The sort is necessary to reflect the order of the nodes in the path
+              .sorted(Comparator.comparing(nodeToSort -> pathNodeIds.indexOf(nodeToSort.getId())))
               .collect(Collectors.toList());
 
-            List<DataFetcherResult<Map<String, Object>>> result = treeNodes
-              .subList(treeNodes.indexOf(sharedNodes.get(0)), treeNodes.size())
-              .stream()
-              .map(treeNode -> convertNodeToDataFetcherResult(
-                treeNode,
-                requesterId,
-                environment.getExecutionStepInfo().getPath()
-              ))
-              .collect(Collectors.toList());
-            return result;
-          }
-        })
-        .orElse(Collections.singletonList(new DataFetcherResult.Builder<Map<String, Object>>()
-          .error(GraphQLResultErrors.nodeNotFound(nodeId, environment.getExecutionStepInfo()
-            .getPath()))
-          .build()))
-        : Collections.singletonList(new DataFetcherResult.Builder<Map<String, Object>>()
-          .error(GraphQLResultErrors.nodeNotFound(nodeId, environment.getExecutionStepInfo()
-            .getPath()))
-          .build());
+            if (node.getNodeType().equals(NodeType.ROOT) || node.getOwnerId().equals(requesterId)) {
+              return treeNodes
+                .stream()
+                .map(currentNode -> convertNodeToDataFetcherResult(currentNode, requesterId, path))
+                .collect(Collectors.toList());
+            } else {
+              List<Share> shares = shareRepository.getShares(
+                treeNodes.stream().map(Node::getId).collect(Collectors.toList()),
+                requesterId
+              );
+              List<Node> sharedNodes = treeNodes
+                .stream()
+                .filter(treeNode ->
+                  shares.stream().anyMatch(share -> share.getNodeId().equals(treeNode.getId()))
+                )
+                .collect(Collectors.toList());
+
+              return treeNodes
+                .subList(treeNodes.indexOf(sharedNodes.get(0)), treeNodes.size())
+                .stream()
+                .map(treeNode -> convertNodeToDataFetcherResult(treeNode, requesterId, path))
+                .collect(Collectors.toList());
+            }
+          })
+          .orElse(Collections.singletonList(
+            DataFetcherResult
+              .<Map<String, Object>>newResult()
+              .error(GraphQLResultErrors.nodeNotFound(nodeId, path))
+              .build()
+          ));
+      }
+      return Collections.singletonList(
+        DataFetcherResult
+          .<Map<String, Object>>newResult()
+          .error(GraphQLResultErrors.nodeNotFound(nodeId, path))
+          .build()
+      );
     });
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/tasks/PrometheusService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/tasks/PrometheusService.java
@@ -1,6 +1,9 @@
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.files.tasks;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.prometheus.PrometheusConfig;

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.5.0"
-pkgrel="2"
+pkgrel="2209261009"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.5.0-1</version>
+  <version>0.5.0-2209261009</version>
 
 </project>


### PR DESCRIPTION
When the getPath API is called, now it returns the nodes in a correct order.