### PR TITLE
chore: Add tag on service definition so prometheus only scan handled …

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.7.0-2211260011</version>
+    <version>0.7.0-2212061412</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -290,7 +290,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.7.0-2211260011</version>
+    <version>0.7.0-2212061412</version>
   </parent>
 
   <profiles>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.7.0"
-pkgrel="2211260011"
+pkgrel="2212061412"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/carbonio-files.hcl
+++ b/package/carbonio-files.hcl
@@ -12,6 +12,7 @@ services {
   meta = {
     prom_port = "21500"
   }
+  tags: ["prometheus-exporter"]
   connect {
     sidecar_service {
       proxy {

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.7.0-2211260011</version>
+  <version>0.7.0-2212061412</version>
 
 </project>


### PR DESCRIPTION
Added a tag on the service definition hcl, this way with the proper prometheus configuration only services with the specific tag will be scanned. 