### PR TITLE
feat: FILES-89 - Add onwer_id and type parameters in findNodes

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.7.0-2212231130</version>
+    <version>0.7.0-2302021651</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -296,7 +296,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.7.0-2212231130</version>
+    <version>0.7.0-2302021651</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -351,6 +351,7 @@ public interface Files {
         String PAGE_TOKEN     = "page_token";
         String KEYWORDS       = "keywords";
         String NODE_TYPE      = "type";
+        String OWNER_ID       = "owner_id";
       }
 
       interface GetVersions {

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -350,6 +350,7 @@ public interface Files {
         String SORT           = "sort";
         String PAGE_TOKEN     = "page_token";
         String KEYWORDS       = "keywords";
+        String NODE_TYPE      = "type";
       }
 
       interface GetVersions {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -108,7 +108,8 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> sharedWithMe,
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
-    Optional<NodeType> optNodeTYpe,
+    Optional<NodeType> optNodeType,
+    Optional<String> optOwnerId,
     List<String> keywords
   ) {
     PageQuery nextPage = new PageQuery();
@@ -121,7 +122,8 @@ public class NodeRepositoryEbean implements NodeRepository {
     sharedWithMe.ifPresent(nextPage::setSharedWithMe);
     sharedByMe.ifPresent(nextPage::setSharedByMe);
     directShare.ifPresent(nextPage::setDirectShare);
-    optNodeTYpe.ifPresent(nextPage::setNodeType);
+    optNodeType.ifPresent(nextPage::setNodeType);
+    optOwnerId.ifPresent(nextPage::setOwnerId);
 
     sort.ifPresent(s -> {
       switch (s) {
@@ -299,7 +301,8 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> directShare,
     List<String> keywords,
     Optional<String> keyset,
-    Optional<NodeType> optNodeType
+    Optional<NodeType> optNodeType,
+    Optional<String> optOwnerId
   ) {
 
     SearchBuilder search = new SearchBuilder(mDB.getEbeanDatabase(), userId);
@@ -315,6 +318,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     sharedByMe.ifPresent(search::setSharedByMe);
     directShare.ifPresent(search::setDirectShare);
     optNodeType.ifPresent(search::setNodeType);
+    optOwnerId.ifPresent(search::setOwner);
 
     search.setLimit(limit);
     keyset.ifPresent(search::setKeyset);
@@ -354,6 +358,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> directShare,
     Optional<Integer> limit,
     Optional<NodeType> optNodeType,
+    Optional<String> optOwnerId,
     List<String> keywords,
     Optional<String> pageToken
   ) {
@@ -371,7 +376,8 @@ public class NodeRepositoryEbean implements NodeRepository {
           params.getDirectShare(),
           params.getKeywords(),
           params.getKeySet(),
-          params.getNodeType()
+          params.getNodeType(),
+          params.getOwnerId()
         );
 
         if (nodes.size() == params.getLimit()) {
@@ -386,6 +392,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               params.getSharedByMe(),
               params.getDirectShare(),
               params.getNodeType(),
+              params.getOwnerId(),
               params.getKeywords()
             )
           );
@@ -411,7 +418,8 @@ public class NodeRepositoryEbean implements NodeRepository {
           directShare,
           keywords,
           Optional.empty(),
-          optNodeType
+          optNodeType,
+          optOwnerId
         );
 
         if (nodes.size() == realLimit) {
@@ -426,6 +434,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               sharedByMe,
               directShare,
               optNodeType,
+              optOwnerId,
               keywords)
           );
         } else {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -108,6 +108,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> sharedWithMe,
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
+    Optional<NodeType> optNodeTYpe,
     List<String> keywords
   ) {
     PageQuery nextPage = new PageQuery();
@@ -120,6 +121,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     sharedWithMe.ifPresent(nextPage::setSharedWithMe);
     sharedByMe.ifPresent(nextPage::setSharedByMe);
     directShare.ifPresent(nextPage::setDirectShare);
+    optNodeTYpe.ifPresent(nextPage::setNodeType);
 
     sort.ifPresent(s -> {
       switch (s) {
@@ -296,7 +298,8 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
     List<String> keywords,
-    Optional<String> keyset
+    Optional<String> keyset,
+    Optional<NodeType> optNodeType
   ) {
 
     SearchBuilder search = new SearchBuilder(mDB.getEbeanDatabase(), userId);
@@ -311,6 +314,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     sharedWithMe.ifPresent(swm -> search.setSharedWithMe(userId, swm));
     sharedByMe.ifPresent(search::setSharedByMe);
     directShare.ifPresent(search::setDirectShare);
+    optNodeType.ifPresent(search::setNodeType);
 
     search.setLimit(limit);
     keyset.ifPresent(search::setKeyset);
@@ -349,6 +353,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
     Optional<Integer> limit,
+    Optional<NodeType> optNodeType,
     List<String> keywords,
     Optional<String> pageToken
   ) {
@@ -365,7 +370,8 @@ public class NodeRepositoryEbean implements NodeRepository {
           params.getSharedByMe(),
           params.getDirectShare(),
           params.getKeywords(),
-          params.getKeySet()
+          params.getKeySet(),
+          params.getNodeType()
         );
 
         if (nodes.size() == params.getLimit()) {
@@ -379,6 +385,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               params.getSharedWithMe(),
               params.getSharedByMe(),
               params.getDirectShare(),
+              params.getNodeType(),
               params.getKeywords()
             )
           );
@@ -403,7 +410,8 @@ public class NodeRepositoryEbean implements NodeRepository {
           sharedByMe,
           directShare,
           keywords,
-          Optional.empty()
+          Optional.empty(),
+          optNodeType
         );
 
         if (nodes.size() == realLimit) {
@@ -417,6 +425,7 @@ public class NodeRepositoryEbean implements NodeRepository {
               sharedWithMe,
               sharedByMe,
               directShare,
+              optNodeType,
               keywords)
           );
         } else {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
@@ -28,6 +28,7 @@ public class PageQuery {
   private Optional<Boolean>  sharedByMe;
   private Optional<Boolean>  directShare;
   private Optional<NodeType> nodeType;
+  private Optional<String>   ownerId;
 
   public PageQuery() {
     limit = Files.Config.Pagination.LIMIT;
@@ -41,6 +42,7 @@ public class PageQuery {
     sharedByMe = Optional.empty();
     directShare = Optional.empty();
     nodeType = Optional.empty();
+    ownerId = Optional.empty();
   }
 
   public PageQuery(
@@ -155,5 +157,13 @@ public class PageQuery {
 
   public void setNodeType(NodeType nodeType) {
     this.nodeType = Optional.ofNullable(nodeType);
+  }
+
+  public Optional<String> getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(String ownerId) {
+    this.ownerId = Optional.ofNullable(ownerId);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
@@ -5,6 +5,8 @@
 package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
 
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +27,7 @@ public class PageQuery {
   private Optional<Boolean>  sharedWithMe;
   private Optional<Boolean>  sharedByMe;
   private Optional<Boolean>  directShare;
+  private Optional<NodeType> nodeType;
 
   public PageQuery() {
     limit = Files.Config.Pagination.LIMIT;
@@ -37,6 +40,7 @@ public class PageQuery {
     sharedWithMe = Optional.empty();
     sharedByMe = Optional.empty();
     directShare = Optional.empty();
+    nodeType = Optional.empty();
   }
 
   public PageQuery(
@@ -145,4 +149,11 @@ public class PageQuery {
     this.keywords = keywords;
   }
 
+  public Optional<NodeType> getNodeType() {
+    return nodeType;
+  }
+
+  public void setNodeType(NodeType nodeType) {
+    this.nodeType = Optional.ofNullable(nodeType);
+  }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
@@ -4,8 +4,10 @@
 
 package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
 
+import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import io.ebean.Database;
 import io.ebean.Query;
 import java.util.List;
@@ -240,6 +242,16 @@ public class SearchBuilder {
       .and()
       .raw(keyset)
       .endAnd();
+    return this;
+  }
+
+  /**
+   * Allows to set the {@link Files.Db.Node#TYPE} attribute in the <code>where</code>clause of the query.
+   * @param nodeType is a {@link NodeType} representing the node type that needs to be searched.
+   * @return the {@link SearchBuilder} for adding other options if necessary.
+   */
+  public SearchBuilder setNodeType(NodeType nodeType) {
+    this.query.where().eq(Db.Node.TYPE, nodeType);
     return this;
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
@@ -65,6 +65,7 @@ public interface NodeRepository {
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
     Optional<Integer> limit,
+    Optional<NodeType> optNodeType,
     List<String> keywords,
     Optional<String> pageToken
   );
@@ -79,6 +80,7 @@ public interface NodeRepository {
     Optional<Boolean> sharedWithMe,
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
+    Optional<NodeType> optNodeType,
     List<String> keywords
   ) throws JsonProcessingException;
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
@@ -48,6 +48,8 @@ public interface NodeRepository {
    * with me
    * @param sharedByMe is an {@link Optional<Boolean>} to search only nodes I own that are shared
    * @param limit is an {@link Optional<Integer>} used to limit the number of nodes returned
+   * @param optNodeType is an {@link Optional<NodeType>} to search only nodes having that type
+   * @param optOwnerId is an {@link Optional<String>} to search only nodes owned by that user
    * @param pageToken is an {@link Optional<Boolean>} to search for the next page of a previous find
    * via a given pageToken
    * @param keywords is a {@link List<String>} to search for specific keywords in the name or
@@ -66,6 +68,7 @@ public interface NodeRepository {
     Optional<Boolean> directShare,
     Optional<Integer> limit,
     Optional<NodeType> optNodeType,
+    Optional<String> optOwnerId,
     List<String> keywords,
     Optional<String> pageToken
   );
@@ -81,6 +84,7 @@ public interface NodeRepository {
     Optional<Boolean> sharedByMe,
     Optional<Boolean> directShare,
     Optional<NodeType> optNodeType,
+    Optional<String> optOwnerId,
     List<String> keywords
   ) throws JsonProcessingException;
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -486,6 +486,7 @@ public class NodeDataFetcher {
           Optional.empty(),
           Optional.of(limit),
          Optional.empty(),
+          Optional.empty(),
           Collections.emptyList(),
           optPageToken
         );
@@ -1128,6 +1129,10 @@ public class NodeDataFetcher {
         environment.getArgument(Files.GraphQL.InputParameters.FindNodes.NODE_TYPE)
       );
 
+      Optional<String> optOwnerId = Optional.ofNullable(
+        environment.getArgument(Files.GraphQL.InputParameters.FindNodes.OWNER_ID)
+      );
+
       Map<String, List<Node>> nodeContext = new HashMap<>();
       Map<String, String> result = new HashMap<>();
       ImmutablePair<List<Node>, String> findResult = null;
@@ -1141,6 +1146,7 @@ public class NodeDataFetcher {
         optDirectShare,
         optLimit,
         optNodeType,
+        optOwnerId,
         optKeywords.orElse(Collections.emptyList()),
         optPageToken);
       result.put(Files.GraphQL.NodePage.PAGE_TOKEN, findResult.getRight());

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -485,6 +485,7 @@ public class NodeDataFetcher {
           Optional.empty(),
           Optional.empty(),
           Optional.of(limit),
+         Optional.empty(),
           Collections.emptyList(),
           optPageToken
         );
@@ -1123,6 +1124,10 @@ public class NodeDataFetcher {
         environment.getArgument(Files.GraphQL.InputParameters.FindNodes.KEYWORDS)
       );
 
+      Optional<NodeType> optNodeType = Optional.ofNullable(
+        environment.getArgument(Files.GraphQL.InputParameters.FindNodes.NODE_TYPE)
+      );
+
       Map<String, List<Node>> nodeContext = new HashMap<>();
       Map<String, String> result = new HashMap<>();
       ImmutablePair<List<Node>, String> findResult = null;
@@ -1135,6 +1140,7 @@ public class NodeDataFetcher {
         optSharedByMe,
         optDirectShare,
         optLimit,
+        optNodeType,
         optKeywords.orElse(Collections.emptyList()),
         optPageToken);
       result.put(Files.GraphQL.NodePage.PAGE_TOKEN, findResult.getRight());

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -486,6 +486,7 @@ type Query {
         # only on the given folder or also on all the subtree, if not valued by default it will search on the whole subtree
         cascade: Boolean
         type: NodeType
+        owner_id: String
         # If valued it limits the number of nodes to return per page
         limit: Int
         # If valued it will return the next page of nodes based on the given page_token, if this param is passed

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -485,6 +485,7 @@ type Query {
         # This flag is only used in conjunction with the folderId field, if valued it will specify if i will search
         # only on the given folder or also on all the subtree, if not valued by default it will search on the whole subtree
         cascade: Boolean
+        type: NodeType
         # If valued it limits the number of nodes to return per page
         limit: Int
         # If valued it will return the next page of nodes based on the given page_token, if this param is passed

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.7.0"
-pkgrel="2212231130"
+pkgrel="2302021651"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.7.0-2212231130</version>
+  <version>0.7.0-2302021651</version>
 
 </project>


### PR DESCRIPTION
A client now can use the findNodes query to filter the results for:
 - `type`: it is a `NodeType` and only one type at a time is permitted
 - `owner_id`: if it wants items created by someone else