### PR TITLE
build(deps): FILES-629 update dependencies

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 Apache License 2.0 (Apache-2.0) applies to:
 
+assertj, 2012-2023, Copyright 2012-2023 the original author or authors;
 netty-all, 2012, Copyright 2012 The Netty Project;
 guice, 2006, Copyright (C) 2006 Google Inc.;
 guice-assistedinject, 2006, Copyright (C) 2006 Google Inc.;
@@ -12,6 +13,7 @@ ebean;
 caffeine, 2015, Copyright 2015 Ben Manes. All Rights Reserved.;
 jackson-annotations;
 jackson-databind;
+jackson datatype JSR310, Copyright (C) 2013 FasterXML.com;
 common-lang3, 2001-2022, Copyright 2001-2022 The Apache Software Foundation;
 common-validator, 2001-2022, Copyright 2001-2022 The Apache Software Foundation;
 micrometer, Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
@@ -328,12 +330,100 @@ All Recipient's rights under this Agreement shall terminate if it fails to compl
 Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
 
 This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+
+----------------------------------------------------------------------------------
+
+Eclipse Public License 2.0 (EPL-2.0) applies to:
+
+jUnit, Copyright (C) 2002-2021 JUnit.
+
+Eclipse Public License - v 2.0
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+“Contribution” means:
+
+a) in the case of the initial Contributor, the initial content Distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
+“Contributor” means any person or entity that Distributes the Program.
+
+“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+“Program” means the Contributions Distributed in accordance with this Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+
+“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+
+“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+
+“Distribute” means the acts of a) distributing or b) making available in any manner that enables the transfer of a copy.
+
+“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+
+2. GRANT OF RIGHTS
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+e) Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
+3. REQUIREMENTS
+3.1 If a Contributor Distributes the Program in any form, then:
+
+a) the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
+b) the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
+i) effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
+iv) requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
+3.2 When the Program is Distributed as Source Code:
+
+a) it must be made available under this Agreement, or if the Program (i) is combined with other material in a separate file or files made available under a Secondary License, and (ii) the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
+b) a copy of this Agreement must be included with each copy of the Program.
+3.3 Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (‘notices’) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A – Form of Secondary Licenses Notice
+“This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
+
+Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
 ----------------------------------------------------------------------------------
 
 GNU Affero General Public License v3.0 only (AGPL-3.0-only) applies to:
 
-filestore-sdk-common, 2022, Copyright (C) 2022 Zextras <https://www.zextras.com>;
 storages-ce-sdk, 2022, Copyright (C) 2022 Zextras <https://www.zextras.com>;
+carbonio-preview-sdk, 2022, Copyright (C) 2022 Zextras <https://www.zextras.com>;
 carbonio-user-management-sdk, 2022, Copyright (C) 2022 Zextras <https://www.zextras.com>.
 
 
@@ -1514,8 +1604,10 @@ That's all there is to it!
 MIT License (MIT) applies to:
 
 graphql-java, 2015, Copyright (c) 2015 Andreas Marek and Contributors;
+mockito, Copyright (c) 2007 Mockito contributors,
+PostgreSQL JDBC Driver, Copyright (C) 2005 PostgreSQL Global Development Group;
 slf4j-api, 2004-2022, Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland);
-slf4j-simple, 2004-2022, Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland).
+testcontainers, Copyright (c) 2015-2019 Richard North,
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -16,13 +16,13 @@ SPDX-License-Identifier: AGPL-3.0-only
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>${maven-compiler.version}</version>
         <configuration>
           <release>${java-compiler.version}</release>
           <source>${java-compiler.version}</source>
           <target>${java-compiler.version}</target>
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>${maven-compiler.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -59,15 +59,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <version>${project.parent.version}</version>
     </dependency>
 
-    <dependency>
-      <artifactId>netty-all</artifactId>
-      <groupId>io.netty</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>logback-classic</artifactId>
-      <groupId>ch.qos.logback</groupId>
-    </dependency>
   </dependencies>
 
   <licenses>
@@ -84,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.0-1</version>
+    <version>0.8.0-2303301107</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,6 +118,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <!-- Merge and generate a full report -->
           <execution>
             <id>merge-reports</id>
+            <phase>verify</phase>
             <goals>
               <goal>merge</goal>
             </goals>
@@ -157,11 +158,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </build>
   <dependencies>
 
-    <dependency>
-      <artifactId>netty-all</artifactId>
-      <groupId>io.netty</groupId>
-    </dependency>
-
+    <!-- Injector -->
     <dependency>
       <artifactId>guice</artifactId>
       <groupId>com.google.inject</groupId>
@@ -172,6 +169,19 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>com.google.inject.extensions</groupId>
     </dependency>
 
+    <!-- Logger -->
+    <dependency>
+      <artifactId>logback-classic</artifactId>
+      <groupId>ch.qos.logback</groupId>
+    </dependency>
+
+    <!-- Netty -->
+    <dependency>
+      <artifactId>netty-all</artifactId>
+      <groupId>io.netty</groupId>
+    </dependency>
+
+    <!-- Database -->
     <dependency>
       <artifactId>postgresql</artifactId>
       <groupId>org.postgresql</groupId>
@@ -182,14 +192,22 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>io.ebean</groupId>
     </dependency>
 
+    <!-- GraphQL -->
     <dependency>
       <artifactId>graphql-java</artifactId>
       <groupId>com.graphql-java</groupId>
     </dependency>
 
+    <!-- Cache -->
     <dependency>
       <artifactId>caffeine</artifactId>
       <groupId>com.github.ben-manes.caffeine</groupId>
+    </dependency>
+
+    <!-- Services: storages, authentication, preview -->
+    <dependency>
+      <artifactId>carbonio-user-management-sdk</artifactId>
+      <groupId>com.zextras.carbonio.user-management</groupId>
     </dependency>
 
     <dependency>
@@ -198,20 +216,12 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <artifactId>carbonio-user-management-sdk</artifactId>
-      <groupId>com.zextras.carbonio.user-management</groupId>
-    </dependency>
-
-    <dependency>
       <groupId>com.zextras.carbonio.preview</groupId>
       <artifactId>carbonio-preview-sdk</artifactId>
     </dependency>
 
-    <dependency>
-      <artifactId>logback-classic</artifactId>
-      <groupId>ch.qos.logback</groupId>
-    </dependency>
 
+    <!-- Utilities -->
     <dependency>
       <artifactId>jackson-annotations</artifactId>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -237,11 +247,13 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>commons-validator</groupId>
     </dependency>
 
+    <!-- Metrics -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
+    <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
@@ -263,21 +275,25 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>
@@ -296,7 +312,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.0-1</version>
+    <version>0.8.0-2303301107</version>
   </parent>
 
   <profiles>
@@ -312,6 +328,14 @@ SPDX-License-Identifier: AGPL-3.0-only
       <properties>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>true</skip.unit.tests>
+      </properties>
+    </profile>
+    <profile>
+      <id>run-all-tests</id>
+      <properties>
+        <skip.integration.tests>false</skip.integration.tests>
+        <skip.unit.tests>false</skip.unit.tests>
+        <skip.jacoco.full.report.generation>false</skip.jacoco.full.report.generation>
       </properties>
     </profile>
     <profile>

--- a/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandlerFactory.java
+++ b/core/src/main/java/com/zextras/carbonio/files/cache/CacheHandlerFactory.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files.cache;
 
 import com.google.inject.assistedinject.Assisted;
+import com.zextras.carbonio.files.dal.dao.User;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.dao.ebean.Share;
@@ -29,7 +30,7 @@ public interface CacheHandlerFactory {
     @Assisted("defaultItemLifetimeInMillis") long defaultItemLifetimeInMillis
   );
 
-  LocalCacheAdapter<Share> createUserCache(
+  LocalCacheAdapter<User> createUserCache(
     String cacheName,
     @Assisted("defaultCacheSize") long defaultCacheSize,
     @Assisted("defaultItemLifetimeInMillis") long defaultItemLifetimeInMillis

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/User.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/User.java
@@ -12,25 +12,25 @@ package com.zextras.carbonio.files.dal.dao;
  */
 public class User {
 
-  private final String uuid;
+  private final String id;
   private final String fullName;
   private final String email;
   private final String domain;
 
   public User(
-    String uuid,
+    String id,
     String fullName,
     String email,
     String domain
   ) {
-    this.uuid = uuid;
+    this.id = id;
     this.fullName = fullName;
     this.email = email;
     this.domain = domain;
   }
 
-  public String getUuid() {
-    return uuid;
+  public String getId() {
+    return id;
   }
 
   public String getFullName() {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/UserRepositoryRest.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/UserRepositoryRest.java
@@ -16,7 +16,6 @@ import com.zextras.carbonio.usermanagement.entities.UserId;
 import io.vavr.control.Try;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,23 +42,23 @@ public class UserRepositoryRest implements UserRepository {
   @Override
   public Optional<User> getUserById(
     String cookies,
-    UUID userUUID
+    String userId
   ) {
     return userCache
-      .get(userUUID.toString())
+      .get(userId)
       .or(() ->
         UserManagementClient
           .atURL(usermanagementUrl)
-          .getUserByUUID(cookies, userUUID)
+          .getUserById(cookies, userId)
           .onFailure(failure -> logger.error(failure.getMessage()))
           .map(userInfo -> {
               User user = new User(
-                userInfo.getId(),
+                userInfo.getId().getUserId(),
                 userInfo.getFullName(),
                 userInfo.getEmail(),
                 userInfo.getDomain()
               );
-              userCache.add(user.getUuid(), user);
+              userCache.add(user.getId(), user);
               userCache.add(user.getEmail(), user);
 
               return user;
@@ -84,12 +83,12 @@ public class UserRepositoryRest implements UserRepository {
           .onFailure(failure -> logger.error(failure.getMessage()))
           .map(userInfo -> {
               User user = new User(
-                userInfo.getId(),
+                userInfo.getId().getUserId(),
                 userInfo.getFullName(),
                 userInfo.getEmail(),
                 userInfo.getDomain()
               );
-              userCache.add(user.getUuid(), user);
+              userCache.add(user.getId(), user);
               userCache.add(user.getEmail(), user);
 
               return user;

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/UserRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/UserRepository.java
@@ -8,13 +8,12 @@ import com.zextras.carbonio.files.dal.dao.User;
 import com.zextras.carbonio.usermanagement.entities.UserId;
 import io.vavr.control.Try;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface UserRepository {
 
   Optional<User> getUserById(
     String cookies,
-    UUID userUUID
+    String userId
   );
 
   Optional<User> getUserByEmail(

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/CollaborationLinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/CollaborationLinkDataFetcher.java
@@ -88,7 +88,7 @@ public class CollaborationLinkDataFetcher {
       String nodeId = environment.getArgument(CreateCollaborationLink.NODE_ID);
       SharePermission permissions = environment.getArgument(CreateCollaborationLink.PERMISSION);
 
-      if (permissionsChecker.getPermissions(nodeId, requester.getUuid()).has(permissions)) {
+      if (permissionsChecker.getPermissions(nodeId, requester.getId()).has(permissions)) {
 
         // If there is an existing collaboration link having the same permission then the system
         // returns it, otherwise it creates a new collaboration link
@@ -125,7 +125,7 @@ public class CollaborationLinkDataFetcher {
         ? optLocalContext.get().get(Node.ID)
         : environment.getArgument(GetCollaborationLink.NODE_ID);
 
-      ACL permissions = permissionsChecker.getPermissions(nodeId, requester.getUuid());
+      ACL permissions = permissionsChecker.getPermissions(nodeId, requester.getId());
 
       if (permissions.has(SharePermission.READ_AND_SHARE)
         || permissions.has(SharePermission.READ_WRITE_AND_SHARE)
@@ -163,7 +163,7 @@ public class CollaborationLinkDataFetcher {
           .getLinkById(UUID.fromString(collaborationId))
           .filter(collaborationLink -> {
             ACL requesterPermission = permissionsChecker
-              .getPermissions(collaborationLink.getNodeId(), requester.getUuid());
+              .getPermissions(collaborationLink.getNodeId(), requester.getId());
 
             return requesterPermission.has(SharePermission.READ_WRITE_AND_SHARE) ||
               requesterPermission.has(SharePermission.READ_AND_SHARE);

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
@@ -126,7 +126,7 @@ public class LinkDataFetcher {
       String nodeId = environment.getArgument(Files.GraphQL.InputParameters.Link.NODE_ID);
 
       if (permissionsChecker
-        .getPermissions(nodeId, requester.getUuid())
+        .getPermissions(nodeId, requester.getId())
         .has(SharePermission.READ_AND_SHARE)
         && nodeRepository.getNode(nodeId).get().getNodeType() != NodeType.FOLDER
       ) {
@@ -160,7 +160,7 @@ public class LinkDataFetcher {
         : environment.getArgument(InputParameters.Link.NODE_ID);
 
       return permissionsChecker
-        .getPermissions(nodeId, requester.getUuid())
+        .getPermissions(nodeId, requester.getId())
         .has(SharePermission.READ_AND_SHARE)
         ? linkRepository
         .getLinksByNodeId(nodeId, LinkSort.CREATED_AT_DESC)
@@ -182,7 +182,7 @@ public class LinkDataFetcher {
 
       return linkRepository.getLinkById(linkId)
         .filter(link -> permissionsChecker
-          .getPermissions(link.getNodeId(), requester.getUuid())
+          .getPermissions(link.getNodeId(), requester.getId())
           .has(SharePermission.READ_AND_SHARE)
         )
         .map(link -> {
@@ -213,7 +213,7 @@ public class LinkDataFetcher {
       ResultPath path = environment.getExecutionStepInfo().getPath();
       String requesterId = ((User) environment
         .getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> linkIds = environment.getArgument(InputParameters.Link.LINK_IDS);
 
       List<String> linkIdsToDelete = linkIds

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -36,7 +36,6 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepositor
 import com.zextras.carbonio.files.graphql.GraphQLProvider;
 import com.zextras.carbonio.files.graphql.errors.GraphQLResultErrors;
 import com.zextras.carbonio.files.graphql.types.Permissions;
-import com.zextras.carbonio.files.rest.services.BlobService;
 import com.zextras.carbonio.files.utilities.PermissionsChecker;
 import com.zextras.filestore.model.FilesIdentifier;
 import graphql.GraphQLError;
@@ -286,7 +285,7 @@ public class NodeDataFetcher {
             .load(nId)
             .thenApply(node -> {
               String requesterId =
-                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid();
+                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getId();
 
               Optional<Integer> optVersion = environment.getArgument(
                 Files.GraphQL.FileVersion.VERSION);
@@ -381,7 +380,7 @@ public class NodeDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() -> {
         Map<String, Object> partialResult = environment.getSource();
         String requesterId = ((User) environment.getGraphQlContext()
-          .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+          .get(Files.GraphQL.Context.REQUESTER)).getId();
         String folderNodeId = (String) partialResult.get(Files.GraphQL.Node.ID);
         /*
          * If the execution is arrived in this data fetcher then the partialResult contains the folderId
@@ -444,7 +443,7 @@ public class NodeDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() -> {
         Map<String, Object> partialResult = environment.getSource();
         String requesterId = ((User) environment.getGraphQlContext()
-          .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+          .get(Files.GraphQL.Context.REQUESTER)).getId();
         String folderNodeId = (String) partialResult.get(Files.GraphQL.Node.ID);
         /*
          * If the execution is arrived in this data fetcher then the partialResult contains the folderId
@@ -542,7 +541,7 @@ public class NodeDataFetcher {
         String requesterId = ((User) environment
           .getGraphQlContext()
           .get(Files.GraphQL.Context.REQUESTER)
-        ).getUuid();
+        ).getId();
 
         if (permissionsChecker
           .getPermissions(parentId, requesterId)
@@ -627,7 +626,7 @@ public class NodeDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() -> {
       Map<String, Object> partialResult = environment.getSource();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String nodeId = (String) partialResult.get(Files.GraphQL.Node.ID);
 
       /*
@@ -679,7 +678,7 @@ public class NodeDataFetcher {
       ResultPath path = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String nodeId = environment.getArgument(Files.GraphQL.InputParameters.UpdateNode.NODE_ID);
 
       if (permissionsChecker.getPermissions(nodeId, requesterId)
@@ -734,7 +733,7 @@ public class NodeDataFetcher {
   public DataFetcher<CompletableFuture<List<String>>> flagNodes() {
     return environment -> CompletableFuture.supplyAsync(() -> {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodesIds = environment.getArgument(FlagNodes.NODE_IDS);
       boolean starNodes = environment.getArgument(FlagNodes.FLAG);
 
@@ -759,7 +758,7 @@ public class NodeDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodesIds = environment.getArgument(
         Files.GraphQL.InputParameters.TrashNodes.NODE_IDS);
 
@@ -814,7 +813,7 @@ public class NodeDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodesIds = environment.getArgument(RestoreNodes.NODE_IDS);
 
       List<String> restorableNodeIds = nodesIds.stream()
@@ -938,7 +937,7 @@ public class NodeDataFetcher {
             .load(nodeId)
             .thenApply(node -> convertNodeToDataFetcherResult(
               (Node) node,
-              ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid(),
+              ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getId(),
               environment.getExecutionStepInfo().getPath())
             )
             .exceptionally((e) -> new DataFetcherResult.Builder<Map<String, Object>>().build())
@@ -965,7 +964,7 @@ public class NodeDataFetcher {
       String requesterId = ((User) environment
         .getGraphQlContext()
         .get(Files.GraphQL.Context.REQUESTER))
-        .getUuid();
+        .getId();
       String nodeId = environment.getArgument(InputParameters.NODE_ID);
 
       if (permissionsChecker.getPermissions(nodeId, requesterId).has(SharePermission.READ_ONLY)) {
@@ -1093,7 +1092,7 @@ public class NodeDataFetcher {
   public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, String>>>> findNodesFetcher() {
     return environment -> CompletableFuture.supplyAsync(() -> {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       Optional<Boolean> optFlagged = Optional.ofNullable(
         environment.getArgument(Files.GraphQL.InputParameters.FindNodes.FLAGGED)
       );
@@ -1181,7 +1180,7 @@ public class NodeDataFetcher {
             .map(node ->
               convertNodeToDataFetcherResult(
                 node,
-                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getUuid(),
+                ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getId(),
                 environment.getExecutionStepInfo().getPath()
               )
             )
@@ -1210,7 +1209,7 @@ public class NodeDataFetcher {
       ResultPath resultPath = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodeIds = environment.getArgument(
         Files.GraphQL.InputParameters.MoveNodes.NODE_IDS);
       String destinationFolderId = environment.getArgument(
@@ -1356,7 +1355,7 @@ public class NodeDataFetcher {
       ResultPath resultPath = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodeIds = environment.getArgument(
         Files.GraphQL.InputParameters.DeleteNodes.NODE_IDS);
 
@@ -1671,7 +1670,7 @@ public class NodeDataFetcher {
       ResultPath resultPath = environment.getExecutionStepInfo().getPath();
       String requesterId = ((User) environment
         .getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       List<String> nodeIds = environment.getArgument(InputParameters.MoveNodes.NODE_IDS);
       String destinationFolderId = environment.getArgument(
         InputParameters.MoveNodes.DESTINATION_ID);
@@ -1847,7 +1846,7 @@ public class NodeDataFetcher {
       ResultPath path = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String nodeId = environment.getArgument(GetVersions.NODE_ID);
       Optional<List<Integer>> optVersions = Optional.ofNullable(
         environment.getArgument(GetVersions.VERSIONS));
@@ -1886,7 +1885,7 @@ public class NodeDataFetcher {
       ResultPath path = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String nodeId = environment.getArgument(GetVersions.NODE_ID);
       Optional<List<Integer>> optVersionsToDelete = Optional.ofNullable(
         environment.getArgument(GetVersions.VERSIONS));
@@ -1939,7 +1938,7 @@ public class NodeDataFetcher {
       ResultPath path = environment.getExecutionStepInfo()
         .getPath();
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String nodeId = environment.getArgument(GetVersions.NODE_ID);
       List<Integer> versionsToKeepForever = environment.getArgument(GetVersions.VERSIONS);
       Boolean keepForever = environment.getArgument(KeepVersions.KEEP_FOREVER);
@@ -2016,7 +2015,7 @@ public class NodeDataFetcher {
       String requesterId = ((User) environment
         .getGraphQlContext()
         .get(Files.GraphQL.Context.REQUESTER))
-        .getUuid();
+        .getId();
       String nodeId = environment.getArgument(Files.GraphQL.InputParameters.CloneVersion.NODE_ID);
       Integer versionToClone = environment.getArgument(
         Files.GraphQL.InputParameters.CloneVersion.VERSION

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ShareDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ShareDataFetcher.java
@@ -115,7 +115,7 @@ public class ShareDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String sharedNodeId = environment.getArgument(Files.GraphQL.InputParameters.Share.NODE_ID);
       String targetUserId = environment.getArgument(
         Files.GraphQL.InputParameters.Share.SHARE_TARGET_ID
@@ -220,7 +220,7 @@ public class ShareDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String sharedNodeId = environment.getArgument(Files.GraphQL.InputParameters.Share.NODE_ID);
       String targetUserId = environment.getArgument(
         Files.GraphQL.InputParameters.Share.SHARE_TARGET_ID);
@@ -317,7 +317,7 @@ public class ShareDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       String sharedNodeId = environment.getArgument(Files.GraphQL.InputParameters.Share.NODE_ID);
       String targetUserId = environment.getArgument(
         Files.GraphQL.InputParameters.Share.SHARE_TARGET_ID);
@@ -382,7 +382,7 @@ public class ShareDataFetcher {
     return environment -> CompletableFuture.supplyAsync(() ->
     {
       String requesterId = ((User) environment.getGraphQlContext()
-        .get(Files.GraphQL.Context.REQUESTER)).getUuid();
+        .get(Files.GraphQL.Context.REQUESTER)).getId();
       final String sharedNodeId = environment.getArgument(
         Files.GraphQL.InputParameters.Share.NODE_ID);
       final String targetUserId = environment.getArgument(

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/UserDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/UserDataFetcher.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -67,7 +66,7 @@ public class UserDataFetcher {
     ResultPath path
   ) {
     return userRepository
-      .getUserById(cookies, UUID.fromString(userId))
+      .getUserById(cookies, userId)
       .map(this::convertUserToDataFetcherResult)
       .orElse(
         new DataFetcherResult.Builder<Map<String, Object>>()
@@ -92,7 +91,7 @@ public class UserDataFetcher {
 
   private DataFetcherResult<Map<String, Object>> convertUserToDataFetcherResult(User user) {
     Map<String, Object> result = new HashMap<>();
-    result.put(Files.GraphQL.User.ID, user.getUuid());
+    result.put(Files.GraphQL.User.ID, user.getId());
     result.put(Files.GraphQL.User.EMAIL, user.getEmail());
     result.put(Files.GraphQL.User.FULL_NAME, user.getFullName());
     result.put(Files.GraphQL.ENTITY_TYPE, Files.GraphQL.Types.USER);

--- a/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
@@ -6,7 +6,6 @@ package com.zextras.carbonio.files.netty;
 
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.repositories.interfaces.UserRepository;
 import com.zextras.carbonio.files.exceptions.AuthenticationException;
 import io.netty.channel.ChannelHandler;
@@ -20,7 +19,6 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.util.AttributeKey;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +119,7 @@ public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpReque
       .validateToken(zmAuthToken)
       .onSuccess(userId -> {
           userRepository
-            .getUserById(cookies, UUID.fromString(userId.getUserId()))
+            .getUserById(cookies, userId.getUserId())
             .ifPresentOrElse(
               user -> {
                 context.channel()

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -240,7 +240,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
       .map(Integer::parseInt);
 
     if (permissionsChecker
-      .getPermissions(nodeId, requester.getUuid())
+      .getPermissions(nodeId, requester.getId())
       .has(SharePermission.READ_ONLY)
     ) {
 
@@ -250,7 +250,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         optVersion.map(integer -> MessageFormat.format("optional version: {0}", integer))
           .orElse("no optional version"),
         requester.getDomain(),
-        requester.getUuid()
+        requester.getId()
       ));
 
       blobService
@@ -295,7 +295,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
       logger.error(MessageFormat.format(
         "Request {0}: The user {1} does not have the READ permission to download the node {2}",
         request.uri(),
-        requester.getUuid(),
+        requester.getId(),
         nodeId
       ));
 

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/CollaborationLinkController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/CollaborationLinkController.java
@@ -49,7 +49,7 @@ public class CollaborationLinkController extends SimpleChannelInboundHandler<Htt
         User requester = (User) context.channel().attr(AttributeKey.valueOf("requester")).get();
 
         collaborationLinkService
-          .createShareByInvitationId(invitationId, requester.getUuid())
+          .createShareByInvitationId(invitationId, requester.getId())
           .onSuccess(sharedNode -> {
             FullHttpResponse response = new DefaultFullHttpResponse(
               httpRequest.protocolVersion(),

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
@@ -191,7 +191,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(5));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       Collections.singleton("image/")
@@ -240,7 +240,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       Collections.singleton("image/")
@@ -289,7 +289,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       Collections.singleton("application/pdf")
@@ -338,7 +338,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       Collections.singleton("application/pdf")
@@ -388,7 +388,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       documentAllowedTypes
@@ -438,7 +438,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
     PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode = checkNodePermissionAndExistence(
-      requester.getUuid(),
+      requester.getId(),
       nodeId,
       Integer.parseInt(nodeVersion),
       documentAllowedTypes

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/ProcedureController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/ProcedureController.java
@@ -115,7 +115,7 @@ public class ProcedureController extends SimpleChannelInboundHandler<FullHttpReq
     }
 
     if (permissionsChecker
-      .getPermissions(bodyRequest.getNodeId().toString(), requester.getUuid())
+      .getPermissions(bodyRequest.getNodeId().toString(), requester.getId())
       .has(SharePermission.READ_ONLY)
     ) {
       procedureService

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -143,16 +143,16 @@ public class BlobService {
   ) {
 
     if (permissionsChecker
-      .getPermissions(folderId, requester.getUuid())
+      .getPermissions(folderId, requester.getId())
       .has(SharePermission.READ_AND_WRITE)
     ) {
 
       String nodeId = UUID.randomUUID().toString();
       String nodeOwner = folderId.equals(RootId.LOCAL_ROOT)
-        ? requester.getUuid()
+        ? requester.getId()
         : nodeRepository.getNode(folderId)
           .map(Node::getOwnerId)
-          .orElse(requester.getUuid());
+          .orElse(requester.getId());
 
       MediaType mediaType = mimeTypeUtils.detectMimeTypeFromFilename(
         filename,
@@ -167,7 +167,7 @@ public class BlobService {
         uploadResponse = StoragesClient
           .atUrl(storageUrl)
           .uploadPost(
-            FilesIdentifier.of(nodeId, 1, requester.getUuid()),
+            FilesIdentifier.of(nodeId, 1, requester.getId()),
             bufferInputStream,
             blobLength
           );
@@ -184,7 +184,7 @@ public class BlobService {
       Node folder = nodeRepository.getNode(folderId).get();
       nodeRepository.createNewNode(
         nodeId,
-        requester.getUuid(),
+        requester.getId(),
         nodeOwner,
         folderId,
         searchAlternativeName(filename.trim(), folderId, nodeOwner),
@@ -198,7 +198,7 @@ public class BlobService {
 
       fileVersionRepository.createNewFileVersion(
         nodeId,
-        requester.getUuid(),
+        requester.getId(),
         1,
         mediaType.toString(),
         uploadResponse.getSize(),
@@ -238,7 +238,7 @@ public class BlobService {
   ) {
 
     if (permissionsChecker
-      .getPermissions(nodeId, requester.getUuid())
+      .getPermissions(nodeId, requester.getId())
       .has(SharePermission.READ_AND_WRITE)
     ) {
 
@@ -318,7 +318,7 @@ public class BlobService {
     } else {
       logger.debug(MessageFormat.format(
         "User {0} does not have the necessary permission for node {1}",
-        requester.getUuid(),
+        requester.getId(),
         nodeId
       ));
       return Try.failure(new NodePermissionException());
@@ -346,7 +346,7 @@ public class BlobService {
         uploadResponse = StoragesClient
           .atUrl(storageUrl)
           .uploadPut(
-            FilesIdentifier.of(nodeId, newVersion, requester.getUuid()),
+            FilesIdentifier.of(nodeId, newVersion, requester.getId()),
             bufferInputStream,
             blobLength
           );
@@ -355,7 +355,7 @@ public class BlobService {
         uploadResponse = StoragesClient
           .atUrl(storageUrl)
           .uploadPost(
-            FilesIdentifier.of(nodeId, newVersion, requester.getUuid()),
+            FilesIdentifier.of(nodeId, newVersion, requester.getId()),
             bufferInputStream,
             blobLength
           );
@@ -373,7 +373,7 @@ public class BlobService {
 
     Optional<FileVersion> result = fileVersionRepository.createNewFileVersion(
       nodeId,
-      requester.getUuid(),
+      requester.getId(),
       newVersion,
       mediaType.toString(),
       uploadResponse.getSize(),
@@ -381,7 +381,7 @@ public class BlobService {
       false
     );
     node.setSize(uploadResponse.getSize());
-    node.setLastEditorId(requester.getUuid());
+    node.setLastEditorId(requester.getId());
     nodeRepository.updateNode(node);
 
     return result.map(fileVersion -> Try.success(fileVersion.getVersion()))

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/PreviewService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/PreviewService.java
@@ -293,7 +293,7 @@ public class PreviewService {
   ) {
     QueryBuilder parameterBuilder = new QueryBuilder()
       .setServiceType(ServiceType.FILES)
-      .setNodeId(nodeId)
+      .setFileId(nodeId)
       .setVersion(version)
       .setFileOwnerId(ownerId);
 

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
@@ -104,7 +104,7 @@ public class ProcedureService {
             .download(FilesIdentifier.of(
               nodeId.toString(),
               nodeToUpload.getCurrentVersion(),
-              requester.getUuid())
+              requester.getId())
             );
         } catch (Exception exception) {
           logger.error(MessageFormat.format("Failed to download the node: {0}", nodeId));

--- a/core/src/test/java/com/zextras/carbonio/files/dal/dao/UserTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/dao/UserTest.java
@@ -21,7 +21,7 @@ public class UserTest {
 
     // Then
     Assertions
-      .assertThat(user.getUuid())
+      .assertThat(user.getId())
       .isEqualTo("fake-user-id");
 
     Assertions

--- a/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
@@ -122,7 +122,7 @@ public class AuthenticationHandlerTest {
       .thenReturn(Try.success(new UserId("6c594bb9-f8c7-424f-9320-7bf72daae3e7")));
     Mockito
       .when(userRepositoryMock.getUserById("IRIS=ui; ZM_AUTH_TOKEN=valid-token",
-        UUID.fromString("6c594bb9-f8c7-424f-9320-7bf72daae3e7")))
+        "6c594bb9-f8c7-424f-9320-7bf72daae3e7"))
       .thenReturn(Optional.of(userMock));
     Mockito
       .when(channelMock.attr(AttributeKey.valueOf("requester")))
@@ -202,7 +202,7 @@ public class AuthenticationHandlerTest {
       .thenReturn(Try.success(new UserId("6c594bb9-f8c7-424f-9320-7bf72daae3e7")));
     Mockito
       .when(userRepositoryMock.getUserById("IRIS=ui; ZM_AUTH_TOKEN=valid-token",
-        UUID.fromString("6c594bb9-f8c7-424f-9320-7bf72daae3e7")))
+        "6c594bb9-f8c7-424f-9320-7bf72daae3e7"))
       .thenReturn(Optional.empty());
 
     ArgumentCaptor<AuthenticationException> captorException = ArgumentCaptor.forClass(

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.8.0"
-pkgrel="1"
+pkgrel="2303301107"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <caffeine.version>3.1.5</caffeine.version>
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-sdk.version>0.2.0</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.2.1</carbonio-user-management-sdk.version>
     <carbonio-preview-sdk.version>1.0.1</carbonio-preview-sdk.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-validator.version>1.7</commons-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <dependencyManagement>
     <dependencies>
 
-      <dependency>
-        <artifactId>netty-all</artifactId>
-        <groupId>io.netty</groupId>
-        <version>${netty.version}</version>
-      </dependency>
-
+      <!-- Injector -->
       <dependency>
         <artifactId>guice</artifactId>
         <groupId>com.google.inject</groupId>
@@ -32,6 +27,21 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${guice.version}</version>
       </dependency>
 
+      <!-- Logger -->
+      <dependency>
+        <artifactId>logback-classic</artifactId>
+        <groupId>ch.qos.logback</groupId>
+        <version>${logback-classic.version}</version>
+      </dependency>
+
+      <!-- Netty -->
+      <dependency>
+        <artifactId>netty-all</artifactId>
+        <groupId>io.netty</groupId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <!-- Database -->
       <dependency>
         <artifactId>postgresql</artifactId>
         <groupId>org.postgresql</groupId>
@@ -44,22 +54,26 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${ebean.version}</version>
       </dependency>
 
+      <!-- GraphQL -->
       <dependency>
         <artifactId>graphql-java</artifactId>
         <groupId>com.graphql-java</groupId>
         <version>${graphql-java.version}</version>
       </dependency>
 
+      <!-- Cache -->
       <dependency>
         <artifactId>caffeine</artifactId>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <version>${caffeine.version}</version>
       </dependency>
 
+
+      <!-- Services: storages, authentication, preview -->
       <dependency>
-        <artifactId>filestore-sdk-common</artifactId>
-        <groupId>com.zextras</groupId>
-        <version>${carbonio-storages-common.version}</version>
+        <artifactId>carbonio-user-management-sdk</artifactId>
+        <groupId>com.zextras.carbonio.user-management</groupId>
+        <version>${carbonio-user-management-sdk.version}</version>
       </dependency>
 
       <dependency>
@@ -69,23 +83,13 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <artifactId>carbonio-user-management-sdk</artifactId>
-        <groupId>com.zextras.carbonio.user-management</groupId>
-        <version>${carbonio-user-management-sdk.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.zextras.carbonio.preview</groupId>
         <artifactId>carbonio-preview-sdk</artifactId>
         <version>${carbonio-preview-sdk.version}</version>
       </dependency>
 
-      <dependency>
-        <artifactId>logback-classic</artifactId>
-        <groupId>ch.qos.logback</groupId>
-        <version>${logback-classic.version}</version>
-      </dependency>
 
+      <!-- Utilities -->
       <dependency>
         <artifactId>jackson-annotations</artifactId>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -116,19 +120,14 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${commons-validator.version}</version>
       </dependency>
 
+      <!-- Metrics -->
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
         <version>${micrometer.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit5.version}</version>
-        <scope>test</scope>
-      </dependency>
-
+      <!-- Testing -->
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
@@ -154,6 +153,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${asserj.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -199,38 +199,38 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <!-- Dependencies -->
-    <asserj.version>3.23.1</asserj.version>
-    <caffeine.version>3.1.2</caffeine.version>
+    <asserj.version>3.24.2</asserj.version>
+    <caffeine.version>3.1.5</caffeine.version>
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-sdk.version>0.1.3</carbonio-user-management-sdk.version>
-    <carbonio-preview-sdk.version>0.2.4</carbonio-preview-sdk.version>
+    <carbonio-user-management-sdk.version>0.2.0</carbonio-user-management-sdk.version>
+    <carbonio-preview-sdk.version>1.0.1</carbonio-preview-sdk.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-validator.version>1.7</commons-validator.version>
-    <ebean.version>13.10.2</ebean.version>
-    <graphql-java.version>19.2</graphql-java.version>
+    <ebean.version>13.16.0</ebean.version>
+    <graphql-java.version>20.1</graphql-java.version>
     <guice.version>5.1.0</guice.version>
-    <jackson.version>2.14.0</jackson.version>
-    <java-compiler.version>11</java-compiler.version>
-    <junit5.version>5.9.1</junit5.version>
-    <logback-classic.version>1.3.5</logback-classic.version>
-    <micrometer.version>1.10.2</micrometer.version>
-    <mockito.version>4.9.0</mockito.version>
-    <netty.version>4.1.85.Final</netty.version>
-    <postgresql.version>42.4.3</postgresql.version>
+    <jackson.version>2.14.2</jackson.version>
+    <junit5.version>5.9.2</junit5.version>
+    <logback-classic.version>1.3.6</logback-classic.version>
+    <micrometer.version>1.10.5</micrometer.version>
+    <mockito.version>5.2.0</mockito.version>
+    <netty.version>4.1.90.Final</netty.version>
+    <postgresql.version>42.6.0</postgresql.version>
     <testcontainers.version>1.17.6</testcontainers.version>
 
     <!-- Plugins -->
-    <maven-assembly.version>3.4.2</maven-assembly.version>
-    <maven-compiler.version>3.10.1</maven-compiler.version>
-    <maven-failsafe.version>3.0.0-M7</maven-failsafe.version>
+    <maven-assembly.version>3.5.0</maven-assembly.version>
+    <maven-compiler.version>3.11.0</maven-compiler.version>
+    <maven-failsafe.version>3.0.0</maven-failsafe.version>
     <maven-jacoco.version>0.8.8</maven-jacoco.version>
-    <maven-surfire.version>3.0.0-M7</maven-surfire.version>
-    <tiles-maven.version>2.19</tiles-maven.version>
+    <maven-surfire.version>3.0.0</maven-surfire.version>
+    <tiles-maven.version>2.34</tiles-maven.version>
 
     <!-- Other properties -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <java-compiler.version>11</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Flags to skip/run tests and the report generation -->
@@ -247,6 +247,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.8.0-1</version>
+  <version>0.8.0-2303301107</version>
 
 </project>


### PR DESCRIPTION
Dependencies updated:
- assertj: 3.24.2
- caffeine: 3.1.5
- carbonio-user-management-sdk: 0.2.0
- carbonio-preview-sdk: 1.0.1
- ebean: 13.16.0
- graphql-java: 20.1
- jackson: 2.14.2
- junit5: 5.9.2
- logback-classic: 1.3.6
- micrometer: 1.10.5
- mockito: 5.2.0
- netty: 4.1.90
- postgresql: 42.6.0
- maven-assembly-plugin: 3.5.0
- maven-compiler-plugin: 3.11.0
- maven-failsafe-plugin: 3.0.0
- maven-surfire-plugin: 3.0.0
- tiles-maven-plugin: 2.34

- Updated `PreviewService` to replace `setNodeId` with `setFileId` method
- Aligned codebase to the new carbonio-user-management-sdk version: the main 
  change is the replacement from UUID to String of the user id