### PR TITLE
fix: FILES-618 add ExceptionHandler at the end of each endpoint pipeline

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.0-2303301107</version>
+    <version>0.8.0-2303301703</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -312,7 +312,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.0-2303301107</version>
+    <version>0.8.0-2303301703</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/GraphQLController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/GraphQLController.java
@@ -87,32 +87,6 @@ public class GraphQLController extends SimpleChannelInboundHandler<FullHttpReque
 
   /**
    * {@inheritDoc}
-   * <p>
-   * This method handles the exception thrown If something goes wrong during the execution of the
-   * request. It returns a response containing an INTERNAL_SERVER_ERROR to the client instead of
-   * forwarding the exception to the next ChannelHandler in the ChannelPipeline.
-   * </p>
-   *
-   * @param ctx
-   * @param cause
-   *
-   * @throws Exception
-   */
-  @Override
-  public void exceptionCaught(
-    ChannelHandlerContext ctx,
-    Throwable cause
-  ) {
-    logger.warn("GraphQLController exception:\n" + cause.toString());
-    ctx.writeAndFlush(new DefaultFullHttpResponse(
-        HttpVersion.HTTP_1_0,
-        HttpResponseStatus.INTERNAL_SERVER_ERROR
-      ))
-      .addListener(sNettyChannelFutureClose);
-  }
-
-  /**
-   * {@inheritDoc}
    * <p>This method:
    *  <ul>
    *   <li>
@@ -206,8 +180,8 @@ public class GraphQLController extends SimpleChannelInboundHandler<FullHttpReque
     }
     // Catching the RuntimeException and the JsonProcessingException
     catch (Exception exception) {
-      exception.printStackTrace();
-      exceptionCaught(context, exception.getCause());
+      logger.error("GraphQLController catches an exception", exception);
+      context.fireExceptionCaught(exception);
     }
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
@@ -19,6 +19,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,17 @@ public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LoggerFactory.getLogger(ExceptionsHandler.class);
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This method handles the exception thrown If something goes wrong during the execution of
+   * the request. It creates a response containing a status code based on the type of the
+   * {@link Throwable} and it returns it to the client instead of forwarding the exception to the
+   * next ChannelHandler in the ChannelPipeline.
+   *
+   * @param context is a {@link ChannelHandlerContext}.
+   * @param cause is a {@link Throwable} containing the cause of the exception.
+   */
   @Override
   public void exceptionCaught(
     ChannelHandlerContext context,
@@ -49,7 +61,9 @@ public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
       responseStatus = HttpResponseStatus.BAD_REQUEST;
       payload = HttpResponseStatus.BAD_REQUEST.toString();
     }
-    else if( cause instanceof NodeNotFoundException) {
+    else if( cause instanceof NodeNotFoundException
+      || cause instanceof NoSuchElementException
+    ) {
       responseStatus = HttpResponseStatus.NOT_FOUND;
       payload = HttpResponseStatus.NOT_FOUND.toString();
     }

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -79,7 +79,9 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     }
 
     if (Endpoints.HEALTH.matcher(request.uri()).matches()) {
-      context.pipeline().addLast("health-handler", healthController);
+      context.pipeline()
+        .addLast("health-handler", healthController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }
@@ -91,7 +93,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
         .addLast(new HttpObjectAggregator(256 * 1024))
         .addLast(new ChunkedWriteHandler())
         .addLast("auth-handler", authenticationHandler)
-        .addLast("graphql-handler", graphQLController);
+        .addLast("graphql-handler", graphQLController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }
@@ -101,14 +104,16 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
       || Endpoints.UPLOAD_FILE_VERSION.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("auth-handler", authenticationHandler)
-        .addLast("rest-handler", blobController);
+        .addLast("rest-handler", blobController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }
 
     if (Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
       context.pipeline()
-        .addLast("rest-handler", blobController);
+        .addLast("rest-handler", blobController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }
@@ -117,7 +122,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
       context
         .pipeline()
         .addLast("auth-handler", authenticationHandler)
-        .addLast("collaboration-link-handler", collaborationLinkController);
+        .addLast("collaboration-link-handler", collaborationLinkController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }
@@ -125,7 +131,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     if (Endpoints.PREVIEW.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("auth-handler", authenticationHandler)
-        .addLast("preview-handler", previewController);
+        .addLast("preview-handler", previewController)
+        .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;
     }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,15 +74,11 @@ public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
         return;
       }
 
-      context
-        .writeAndFlush(new DefaultFullHttpResponse(
-          httpRequest.protocolVersion(),
-          HttpResponseStatus.NOT_FOUND
-        ))
-        .addListener(ChannelFutureListener.CLOSE);
+      context.fireExceptionCaught(new NoSuchElementException());
 
     } catch (Exception exception) {
-      context.fireExceptionCaught(new InternalServerErrorException(exception));
+      logger.error("HealthController catches an exception", exception);
+      context.fireExceptionCaught(exception);
     }
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -123,6 +123,9 @@ public class HttpRoutingHandlerTest {
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("health-handler", healthControllerMock);
     Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);
   }
@@ -158,6 +161,9 @@ public class HttpRoutingHandlerTest {
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("graphql-handler", graphQLControllerMock);
     Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);
   }
@@ -190,6 +196,9 @@ public class HttpRoutingHandlerTest {
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("rest-handler", blobControllerMock);
     Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);
   }
@@ -212,6 +221,9 @@ public class HttpRoutingHandlerTest {
     Mockito
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("rest-handler", blobControllerMock);
+    Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
     Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);
@@ -238,6 +250,9 @@ public class HttpRoutingHandlerTest {
     Mockito
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("collaboration-link-handler", collaborationLinkControllerMock);
+    Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
     Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);
@@ -276,6 +291,9 @@ public class HttpRoutingHandlerTest {
     Mockito
       .verify(channelPipelineMock, Mockito.times(1))
       .addLast("preview-handler", previewControllerMock);
+    Mockito
+      .verify(channelPipelineMock, Mockito.times(1))
+      .addLast("exceptions-handler", exceptionsHandlerMock);
     Mockito
       .verify(channelHandlerContextMock, Mockito.times(1))
       .fireChannelRead(httpRequestMock);

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.8.0"
-pkgrel="2303301107"
+pkgrel="2303301703"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.8.0-2303301107</version>
+  <version>0.8.0-2303301703</version>
 
 </project>


### PR DESCRIPTION
The ExceptionHandler was introduced months ago but it was applied only 
to some endpoints. This fix added the handler at the end of each endpoint pipeline. 
A micro refactor was done to redirect all the exceptions to this handler but I consider 
it as a starting point for a major refactor that needs to be done in the future