### PR TITLE
fix: FILES-638 - Fix GetNode when a specific node version is given

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.1-1</version>
+    <version>0.8.1-2304221444</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -312,7 +312,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.1-1</version>
+    <version>0.8.1-2304221444</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -287,13 +287,14 @@ public class NodeDataFetcher {
               String requesterId =
                 ((User) environment.getGraphQlContext().get(Context.REQUESTER)).getId();
 
-              Optional<Integer> optVersion = environment.getArgument(
-                Files.GraphQL.FileVersion.VERSION);
+              Integer version = Optional
+                .ofNullable((Integer) environment.getArgument(Files.GraphQL.FileVersion.VERSION))
+                .orElse(((Node) node).getCurrentVersion());
 
               return permissionsChecker
                 .getPermissions(nId, requesterId)
                 .has(SharePermission.READ_ONLY)
-                ? convertNodeToDataFetcherResult((Node) node, requesterId, path)
+                ? convertNodeToDataFetcherResult((Node) node, version, requesterId, path)
                 : (isParent.get())
                   ? new DataFetcherResult.Builder<Map<String, Object>>().build()
                   : new DataFetcherResult

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.8.1"
-pkgrel="1"
+pkgrel="2304221444"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.8.1-1</version>
+  <version>0.8.1-2304221444</version>
 
 </project>


### PR DESCRIPTION
Fixed GetNode data fetcher to return metadata of a node even when a client gives a specific version different from the last one.

With this fix the user can again open a specific version of a document via carbonio-docs-editor