### PR TITLE
perf: FILES-656 - Replace PGSimpleDataSource with HikariDataSource

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.2-2305121658</version>
+    <version>0.8.2-2305191542</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -188,6 +188,11 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+
+    <dependency>
       <artifactId>ebean-postgres</artifactId>
       <groupId>io.ebean</groupId>
     </dependency>
@@ -312,7 +317,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.2-2305121658</version>
+    <version>0.8.2-2305191542</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files.dal;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.zaxxer.hikari.HikariDataSource;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
@@ -84,12 +85,12 @@ public class EbeanDatabaseManager {
       .getConfig(ServiceDiscover.Config.Db.PASSWORD)
       .getOrElse("");
 
-    jdbcPostgresUrl = "jdbc:postgresql://"
-      + config.getProperty(Files.Config.Database.URL, "127.78.0.2")
-      + ":"
-      + config.getProperty(Files.Config.Database.PORT, "20000")
-      + "/"
-      + postgresDatabase;
+    jdbcPostgresUrl = String.format(
+      "jdbc:postgresql://%s:%s/%s",
+      config.getProperty(Files.Config.Database.URL, "127.78.0.2"),
+      config.getProperty(Files.Config.Database.PORT, "20000"),
+      postgresDatabase
+      );
 
     entityList = new ArrayList<>();
     entityList.add(DbInfo.class);
@@ -226,11 +227,14 @@ public class EbeanDatabaseManager {
       return;
     }
 
-    PGSimpleDataSource dataSource = new PGSimpleDataSource();
-    dataSource.setURL(jdbcPostgresUrl);
-    dataSource.setDatabaseName(postgresDatabase);
-    dataSource.setUser(postgresUser);
+    Properties dataSourceProperties = new Properties();
+    dataSourceProperties.setProperty("sslmode", "disable");
+
+    HikariDataSource dataSource = new HikariDataSource();
+    dataSource.setJdbcUrl(jdbcPostgresUrl);
+    dataSource.setUsername(postgresUser);
     dataSource.setPassword(postgresPassword);
+    dataSource.setDataSourceProperties(dataSourceProperties);
 
     DatabaseConfig serverConfig = new DatabaseConfig();
     serverConfig.setName("carbonio-files-postgres");

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.8.2"
-pkgrel="2305121658"
+pkgrel="2305191542"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>${hikaricp.version}</version>
+      </dependency>
+
+      <dependency>
         <artifactId>ebean-postgres</artifactId>
         <groupId>io.ebean</groupId>
         <version>${ebean.version}</version>
@@ -210,6 +216,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <ebean.version>13.16.0</ebean.version>
     <graphql-java.version>20.1</graphql-java.version>
     <guice.version>5.1.0</guice.version>
+    <hikaricp.version>5.0.1</hikaricp.version>
     <jackson.version>2.14.2</jackson.version>
     <junit5.version>5.9.2</junit5.version>
     <logback-classic.version>1.3.6</logback-classic.version>
@@ -247,6 +254,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.8.2-2305121658</version>
+  <version>0.8.2-2305191542</version>
 
 </project>


### PR DESCRIPTION
This change reduces the number of connection to pgpool and avoid the creation of a new connection each time a query is sent to the database.

Having a pool of connections and using Hikari to handle it:
 - avoids the latency necessary to create a new connection for each request
 - allows the service to reuse the sleeping connections from the pool
 - reduces the latency of the sql query executions and of each API.