### PR TITLE
feat: FILES-657 - Reduce Hikari max pool size to 2

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.3-1</version>
+    <version>0.8.3-2305290940</version>
   </parent>
 
 </project>

--- a/boot/src/main/java/com/zextras/carbonio/files/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/Boot.java
@@ -57,7 +57,7 @@ public class Boot {
       nettyServer = injector.getInstance(NettyServer.class);
       nettyServer.start();
     } catch (RuntimeException exception) {
-      logger.error("Service stopped unexpectedly: " + exception.getMessage());
+      logger.error("Service stopped unexpectedly: ", exception);
     } finally {
       ebeanDatabaseManager.stop();
       purgeService.stop();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -317,7 +317,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.8.3-1</version>
+    <version>0.8.3-2305290940</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -76,6 +76,14 @@ public final class Files {
       public static final int LIMIT = 50;
     }
 
+    public static final class Hikari {
+
+      public static final int MAX_POOL_SIZE        = 2;
+      public static final int MIN_IDLE_CONNECTIONS = 1;
+
+      private Hikari() {}
+    }
+
   }
 
   public static final class Db {
@@ -771,11 +779,13 @@ public final class Files {
 
         private Db() {}
 
-        public static final String NAME             = "db-name";
-        public static final String DEFAULT_NAME     = "carbonio-files-db";
-        public static final String USERNAME         = "db-username";
-        public static final String DEFAULT_USERNAME = "carbonio-files-db";
-        public static final String PASSWORD         = "db-password";
+        public static final String NAME                        = "db-name";
+        public static final String DEFAULT_NAME                = "carbonio-files-db";
+        public static final String USERNAME                    = "db-username";
+        public static final String DEFAULT_USERNAME            = "carbonio-files-db";
+        public static final String PASSWORD                    = "db-password";
+        public static final String HIKARI_MAX_POOL_SIZE        = "hikari-max-pool-size";
+        public static final String HIKARI_MIN_IDLE_CONNECTIONS = "hikari-min-idle-connections";
       }
     }
   }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -104,8 +104,8 @@ public class EbeanDatabaseManager {
     hikariMinimumIdleConnections = ServiceDiscoverHttpClient
       .defaultURL(ServiceDiscover.SERVICE_NAME)
       .getConfig(Config.Db.HIKARI_MIN_IDLE_CONNECTIONS)
-      .map(Integer::parseInt)
-      .map(minIdleConnections -> Math.min(minIdleConnections, hikariMaximumPoolSize))
+      .map(minIdleConnections ->
+        Math.min(Integer.parseInt(minIdleConnections), hikariMaximumPoolSize))
       .getOrElse(Hikari.MIN_IDLE_CONNECTIONS);
 
     entityList = new ArrayList<>();

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -8,14 +8,16 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.Config.Hikari;
 import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
+import com.zextras.carbonio.files.Files.ServiceDiscover.Config;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.dal.dao.ebean.CollaborationLink;
 import com.zextras.carbonio.files.dal.dao.ebean.DbInfo;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersionPK;
-import com.zextras.carbonio.files.dal.dao.ebean.CollaborationLink;
 import com.zextras.carbonio.files.dal.dao.ebean.Link;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeCustomAttributes;
@@ -42,7 +44,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
-import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,8 @@ public class EbeanDatabaseManager {
   private final        String         postgresDatabase;
   private final        String         postgresUser;
   private final        String         postgresPassword;
+  private final        int            hikariMaximumPoolSize;
+  private final        int            hikariMinimumIdleConnections;
   private              Database       ebeanDatabase;
 
   @Inject
@@ -90,7 +93,19 @@ public class EbeanDatabaseManager {
       config.getProperty(Files.Config.Database.URL, "127.78.0.2"),
       config.getProperty(Files.Config.Database.PORT, "20000"),
       postgresDatabase
-      );
+    );
+
+    hikariMaximumPoolSize = ServiceDiscoverHttpClient
+      .defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(Config.Db.HIKARI_MAX_POOL_SIZE)
+      .map(Integer::parseInt)
+      .getOrElse(Hikari.MAX_POOL_SIZE);
+
+    hikariMinimumIdleConnections = ServiceDiscoverHttpClient
+      .defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(Config.Db.HIKARI_MIN_IDLE_CONNECTIONS)
+      .map(Integer::parseInt)
+      .getOrElse(Hikari.MIN_IDLE_CONNECTIONS);
 
     entityList = new ArrayList<>();
     entityList.add(DbInfo.class);
@@ -234,6 +249,8 @@ public class EbeanDatabaseManager {
     dataSource.setJdbcUrl(jdbcPostgresUrl);
     dataSource.setUsername(postgresUser);
     dataSource.setPassword(postgresPassword);
+    dataSource.setMaximumPoolSize(hikariMaximumPoolSize);
+    dataSource.setMinimumIdle(Math.min(hikariMinimumIdleConnections, hikariMaximumPoolSize));
     dataSource.setDataSourceProperties(dataSourceProperties);
 
     DatabaseConfig serverConfig = new DatabaseConfig();

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -105,6 +105,7 @@ public class EbeanDatabaseManager {
       .defaultURL(ServiceDiscover.SERVICE_NAME)
       .getConfig(Config.Db.HIKARI_MIN_IDLE_CONNECTIONS)
       .map(Integer::parseInt)
+      .map(minIdleConnections -> Math.min(minIdleConnections, hikariMaximumPoolSize))
       .getOrElse(Hikari.MIN_IDLE_CONNECTIONS);
 
     entityList = new ArrayList<>();
@@ -250,8 +251,11 @@ public class EbeanDatabaseManager {
     dataSource.setUsername(postgresUser);
     dataSource.setPassword(postgresPassword);
     dataSource.setMaximumPoolSize(hikariMaximumPoolSize);
-    dataSource.setMinimumIdle(Math.min(hikariMinimumIdleConnections, hikariMaximumPoolSize));
+    dataSource.setMinimumIdle(hikariMinimumIdleConnections);
     dataSource.setDataSourceProperties(dataSourceProperties);
+
+    logger.info("Hikari: maximum pool size: {}", hikariMaximumPoolSize);
+    logger.info("Hikari: minimum idle connections: {}", hikariMinimumIdleConnections);
 
     DatabaseConfig serverConfig = new DatabaseConfig();
     serverConfig.setName("carbonio-files-postgres");

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.8.3"
-pkgrel="1"
+pkgrel="2305290940"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.8.3-1</version>
+  <version>0.8.3-2305290940</version>
 
 </project>


### PR DESCRIPTION
On Hikari initialization the service set:
- the maximumPoolSize configuration to "2"
- the minimumIdle configuration to "1"

These configurations can be dinamically set also via service-discover creating these two keys:
- hikari-max-pool-size
- hikari-min-idle-connections

If the hikari-min-idle-connections value is greater than hikari-max-pool-size one, the system set the min-idle-connection equals to hikari-max-pool-size