### PR TITLE
refactor: FILES-651 - Refactor BlobService and BlobController

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.0-1</version>
+    <version>0.9.0-2306051303</version>
   </parent>
 
 </project>

--- a/boot/src/main/java/com/zextras/carbonio/files/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/Boot.java
@@ -44,7 +44,7 @@ public class Boot {
       )
     );
 
-    Injector injector = Guice.createInjector(new FilesModule());
+    Injector injector = Guice.createInjector(new FilesModule(new FilesConfig()));
     injector.getInstance(FilesConfig.class);
 
     try {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -317,7 +317,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.0-1</version>
+    <version>0.9.0-2306051303</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -6,6 +6,8 @@ package com.zextras.carbonio.files.config;
 
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.ServiceDiscover;
+import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.preview.PreviewClient;
 import com.zextras.carbonio.usermanagement.UserManagementClient;
 import com.zextras.filestore.api.Filestore;
@@ -90,5 +92,12 @@ public class FilesConfig {
 
   public PreviewClient getPreviewClient() {
     return PreviewClient.atURL(previewURL);
+  }
+
+  public int getMaxNumberOfFileVersion() {
+    return Integer.parseInt(ServiceDiscoverHttpClient
+      .defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
+      .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -80,6 +80,14 @@ public class FilesConfig {
     return StoragesClient.atUrl(fileStoreURL);
   }
 
+  public String getFileStoreUrl() {
+    return String.format(
+      "http://%s:%s/",
+      properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+      properties.getProperty(Files.Config.Storages.PORT, "20002")
+    );
+  }
+
   public PreviewClient getPreviewClient() {
     return PreviewClient.atURL(previewURL);
   }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -5,6 +5,9 @@
 package com.zextras.carbonio.files.config;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.zextras.carbonio.files.cache.CacheHandlerFactory;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.FileVersionRepositoryEbean;
@@ -22,8 +25,17 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.UserRepository;
 import com.zextras.carbonio.files.graphql.validators.GenericControllerEvaluatorFactory;
+import com.zextras.filestore.api.Filestore;
+import com.zextras.storages.api.StoragesClient;
 
 public class FilesModule extends AbstractModule {
+
+  private final FilesConfig filesConfig;
+
+  @Inject
+  public FilesModule(FilesConfig filesConfig) {
+    this.filesConfig = filesConfig;
+  }
 
   @Override
   public void configure() {
@@ -38,5 +50,10 @@ public class FilesModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(CacheHandlerFactory.class));
 
     install(new FactoryModuleBuilder().build(GenericControllerEvaluatorFactory.class));
+  }
+
+  @Provides
+  public Filestore getFileStore() {
+    return StoragesClient.atUrl(filesConfig.getFileStoreUrl());
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/DependencyException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/DependencyException.java
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class DependencyException extends RuntimeException {
+
+  public DependencyException(String message) {
+    super(message);
+  }
+
+  public DependencyException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public DependencyException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/FileTypeMismatchException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/FileTypeMismatchException.java
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class FileTypeMismatchException extends RuntimeException {
+
+  public FileTypeMismatchException(String message) {
+    super(message);
+  }
+
+  public FileTypeMismatchException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public FileTypeMismatchException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/MaxNumberOfFileVersionsException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/MaxNumberOfFileVersionsException.java
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class MaxNumberOfFileVersionsException extends RuntimeException {
+
+  public MaxNumberOfFileVersionsException(String message) {
+    super(message);
+  }
+
+  public MaxNumberOfFileVersionsException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public MaxNumberOfFileVersionsException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/NodeNotFoundException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/NodeNotFoundException.java
@@ -4,8 +4,6 @@
 
 package com.zextras.carbonio.files.exceptions;
 
-import java.text.MessageFormat;
-
 public class NodeNotFoundException extends Exception {
 
   public NodeNotFoundException() {
@@ -16,8 +14,8 @@ public class NodeNotFoundException extends Exception {
     String requesterId,
     String nodeId
   ) {
-    super(MessageFormat.format(
-      "Node {0} requested by {1} does not exist",
+    super(String.format(
+      "Node %s requested by %s does not exist or it does not have the permission to read it",
       nodeId,
       requesterId
     ));

--- a/core/src/main/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriter.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriter.java
@@ -10,8 +10,12 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NettyBufferWriter {
+
+  private static final Logger logger = LoggerFactory.getLogger(NettyBufferWriter.class);
 
   private final ChannelHandlerContext context;
   private final ByteBuf               byteBuffer;
@@ -42,8 +46,8 @@ public class NettyBufferWriter {
 
       try {
         contentStream.close();
-      } catch (IOException e) {
-        e.printStackTrace();
+      } catch (IOException exception) {
+       logger.error("Exception when closing the upload input stream", exception);
       }
       promise.setSuccess();
       return;

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -7,9 +7,11 @@ package com.zextras.carbonio.files.rest.services;
 import com.google.common.net.MediaType;
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files.Db.RootId;
+import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.User;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
+import com.zextras.carbonio.files.dal.dao.ebean.Link;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
@@ -17,7 +19,9 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
-import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import com.zextras.carbonio.files.exceptions.DependencyException;
+import com.zextras.carbonio.files.exceptions.FileTypeMismatchException;
+import com.zextras.carbonio.files.exceptions.MaxNumberOfFileVersionsException;
 import com.zextras.carbonio.files.netty.utilities.BufferInputStream;
 import com.zextras.carbonio.files.rest.types.BlobResponse;
 import com.zextras.carbonio.files.utilities.MimeTypeUtils;
@@ -27,15 +31,19 @@ import com.zextras.filestore.api.UploadResponse;
 import com.zextras.filestore.model.FilesIdentifier;
 import io.ebean.annotation.Transactional;
 import io.vavr.control.Try;
-import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Provides methods to handle blob operations like download (via node identifier and via public
+ * link), upload of a new node and upload of a new version of a specific node.
+ */
 public class BlobService {
 
   private static final Logger logger = LoggerFactory.getLogger(BlobService.class);
@@ -48,7 +56,7 @@ public class BlobService {
   private final MimeTypeUtils mimeTypeUtils;
   private final TombstoneRepository tombstoneRepository;
   private final Filestore fileStore;
-
+  private final FilesConfig filesConfig;
 
   @Inject
   public BlobService(
@@ -59,7 +67,8 @@ public class BlobService {
     PermissionsChecker permissionsChecker,
     TombstoneRepository tombstoneRepository,
     MimeTypeUtils mimeTypeUtils,
-    Filestore fileStore
+    Filestore fileStore,
+    FilesConfig filesConfig
   ) {
     this.nodeRepository = nodeRepository;
     this.fileVersionRepository = fileVersionRepository;
@@ -69,47 +78,25 @@ public class BlobService {
     this.mimeTypeUtils = mimeTypeUtils;
     this.tombstoneRepository = tombstoneRepository;
     this.fileStore = fileStore;
+    this.filesConfig = filesConfig;
   }
 
-  public Optional<BlobResponse> downloadFile(
-    String nodeId,
-    Integer version
-  ) {
-    return nodeRepository
-      .getNode(nodeId)
-      .map(node -> fileVersionRepository
-        .getFileVersion(node.getId(), version == null ? node.getCurrentVersion() : version)
-        .flatMap(fileVersion -> Try
-          .of(() -> fileStore
-            .download(FilesIdentifier.of(
-              fileVersion.getNodeId(),
-              fileVersion.getVersion(),
-              node.getOwnerId())
-            )
-          )
-          .map((blob) -> new BlobResponse(
-            blob,
-            node.getFullName(),
-            fileVersion.getSize(),
-            fileVersion.getMimeType())
-          )
-          .orElse(() -> {
-            logger.error(
-              "Unable to download file with id {} and version {}",
-              fileVersion.getNodeId(),
-              fileVersion.getVersion()
-            );
-            return Optional.empty();
-          }).toJavaOptional())
-      .orElseGet(() -> {
-        logger.error("Unable to download file {}: the node id does not exist", nodeId);
-        return Optional.empty();
-      });
-  }
-
+  /**
+   * Downloads from the {@link Filestore} a blob related to a node identifier and/or a specific
+   * version.
+   *
+   * @param nodeId    is a {@link String} representing the node identifier
+   * @param version   is s {@link Integer} representing the node version. If the version is null,
+   *                  the method downloads the latest version of the node
+   * @param requester is a {@link User} making the download request
+   * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
+   * itself) and all its metadata if the requester has the {@link SharePermission#READ} permission
+   * and the {@link Node} exists. Otherwise, it returns an {@link Optional#empty()}.
+   * @throws DependencyException if the {@link Filestore} failed to download the blob
+   */
   public Optional<BlobResponse> downloadFileById(
     String nodeId,
-    Integer version,
+    @Nullable Integer version,
     User requester
   ) {
     if (permissionsChecker
@@ -127,13 +114,43 @@ public class BlobService {
     return Optional.empty();
   }
 
+  /**
+   * Downloads from the {@link Filestore} a specific blob linked to a public link.
+   *
+   * @param linkId is a {@link String} representing the identifier of a {@link Link} that is linked
+   *               to a specific node identifier
+   * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
+   * itself) and all its metadata if the {@link Link} and the related {@link Node} exist. Otherwise,
+   * it returns an {@link Optional#empty()}.
+   * @throws DependencyException if the {@link Filestore} failed to download the blob
+   */
   public Optional<BlobResponse> downloadFileByLink(String linkId) {
     return linkRepository
       .getLinkByPublicId(linkId)
       .flatMap(link -> downloadFile(link.getNodeId(), null));
   }
 
-  @Transactional
+  /**
+   * Uploads a blob to the {@link Filestore} and, when the upload is completed, it:
+   * <ul>
+   *   <li>creates the related {@link Node} and {@link FileVersion} metadata</li>
+   *   <li>creates the shares for the new node if the destination folder has shares associated</li>
+   * </ul>
+   *
+   * @param requester         is a {@link User} making the upload request
+   * @param bufferInputStream is a {@link BufferInputStream} of the blob to upload
+   * @param blobLength        is a <code>long</code> representing the length of the blob
+   * @param folderId          is a {@link String} representing the folder identifier where the node
+   *                          will be uploaded
+   * @param filename          is a {@link String} representing the full filename (name and
+   *                          extension) of the node
+   * @param description       is a {@link String} representing the description of the node
+   * @return an {@link Optional} of {@link String} containing the identifier of the node associated
+   * to the blob uploaded if the requester has the {@link SharePermission#READ_AND_WRITE} permission
+   * on the destination folder and if the destination folder exists. Otherwise, it returns an
+   * {@link Optional#empty()}.
+   * @throws DependencyException if the {@link Filestore} failed to upload the blob
+   */
   public Optional<String> uploadFile(
     User requester,
     BufferInputStream bufferInputStream,
@@ -142,18 +159,16 @@ public class BlobService {
     String filename,
     String description
   ) {
-
     if (permissionsChecker
       .getPermissions(folderId, requester.getId())
       .has(SharePermission.READ_AND_WRITE)
     ) {
-
+      // Here we are sure that the node exists otherwise the permission checker would be failed
+      Node destinationFolder = nodeRepository.getNode(folderId).get();
       String nodeId = UUID.randomUUID().toString();
       String nodeOwner = folderId.equals(RootId.LOCAL_ROOT)
         ? requester.getId()
-        : nodeRepository.getNode(folderId)
-          .map(Node::getOwnerId)
-          .orElse(requester.getId());
+        : destinationFolder.getOwnerId();
 
       MediaType mediaType = mimeTypeUtils.detectMimeTypeFromFilename(
         filename,
@@ -162,32 +177,27 @@ public class BlobService {
 
       NodeType nodeType = NodeType.getNodeType(mediaType);
 
-      logger.debug("attributes read: " + filename);
-      UploadResponse uploadResponse;
-      try {
-        uploadResponse = fileStore
+      UploadResponse uploadResponse = Try.of(() ->
+        fileStore
           .uploadPost(
             FilesIdentifier.of(nodeId, 1, requester.getId()),
             bufferInputStream,
             blobLength
-          );
-        logger.debug(MessageFormat.format(
-          "Uploaded file to storage with nodeId {0}, size: {1}, digest: {2}",
-          nodeId,
-          uploadResponse.getDigest(),
-          uploadResponse.getSize()
-        ));
-      } catch (Exception exception) {
-        logger.error(String.format(
-          "Filestore failed to upload the node %s: %s",
-          nodeId,
-          exception
-        ));
+          )
+      ).getOrElseThrow(failure -> {
+        throw new DependencyException(
+          String.format("Storages failed: unable to upload node with id %s and version 1", nodeId),
+          failure
+        );
+      });
 
-        return Try.failure(new InternalServerErrorException("Upload new node failed"));
-      }
+      logger.info(
+        "Uploaded file to storages successfully: nodeId {}, version 1, size: {}, digest: {}",
+        nodeId,
+        uploadResponse.getSize(),
+        uploadResponse.getDigest()
+      );
 
-      Node folder = nodeRepository.getNode(folderId).get();
       nodeRepository.createNewNode(
         nodeId,
         requester.getId(),
@@ -196,9 +206,9 @@ public class BlobService {
         searchAlternativeName(filename.trim(), folderId, nodeOwner),
         description,
         nodeType,
-        NodeType.ROOT.equals(folder.getNodeType())
+        NodeType.ROOT.equals(destinationFolder.getNodeType())
           ? folderId
-          : folder.getAncestorIds() + "," + folderId,
+          : destinationFolder.getAncestorIds() + "," + folderId,
         uploadResponse.getSize()
       );
 
@@ -225,15 +235,51 @@ public class BlobService {
             share.getExpiredAt()
           )
         );
-
       return Optional.of(nodeId);
-      //return Try.success(nodeId);
     }
 
+    logger.warn(
+      "User {} does not have the necessary permission to upload the node {} on the folder {}",
+      requester.getId(),
+      filename,
+      folderId
+    );
     return Optional.empty();
-    //return Try.failure(new NodePermissionException());
   }
 
+  /**
+   * Uploads a blob to the {@link Filestore} representing a version of an existing {@link Node}. The
+   * uploaded version can be a new one if the {@param overwrite} is <code>false</code>, otherwise
+   * the version is overwritten to the latest one. When the upload is completed, it:
+   * <ul>
+   *   <li>checks if the number of versions a node can have has already reached the limit</li>
+   *   <li>creates the related {@link FileVersion} metadata</li>
+   *   <li>updates the {@link Node} metadata associated to it</li>
+   *   <li>checks if it is necessary to make space for future versions deleting the oldest one that
+   *   is not marked with the "keep forever" flag.</li>
+   * </ul>
+   *
+   * @param requester         is a {@link User} making the upload version request
+   * @param bufferInputStream is a {@link BufferInputStream} of the blob to upload
+   * @param blobLength        is a <code>long</code> representing the length of the blob
+   * @param nodeId            is a {@link String} representing the node identifier to which add the
+   *                          new version
+   * @param filename          is a {@link String} representing the full filename (name and
+   *                          extension) of the node. It is necessary in order to check if the
+   *                          {@link NodeType} of the new version is the same of all the other
+   *                          version types.
+   * @param overwrite         is a <code>boolean</code> that can be <code>true</code> if the
+   *                          requester wants to overwrite the latest version of a specific node;
+   *                          <code>false</code> if the requester wants to upload a new version
+   * @return an {@link Optional} of {@link Integer} containing the version of the node uploaded if
+   * the requester has the {@link SharePermission#READ_AND_WRITE} permission on the {@link Node} and
+   * if the {@link Node} itself exists. Otherwise, it returns an {@link Optional#empty()}.
+   * @throws MaxNumberOfFileVersionsException if the specific {@link Node} already reached the
+   *                                          maximum number of version that a node can have
+   * @throws FileTypeMismatchException        if the requester wants to upload a blob with a
+   *                                          different {@link NodeType} than previous versions
+   * @throws DependencyException              if the {@link Filestore} failed to upload the blob
+   */
   @Transactional
   public Optional<Integer> uploadFileVersion(
     User requester,
@@ -241,14 +287,29 @@ public class BlobService {
     long blobLength,
     String nodeId,
     String filename,
-    boolean overwrite,
-    int maxNumberOfVersions
+    boolean overwrite
   ) {
 
     if (permissionsChecker
       .getPermissions(nodeId, requester.getId())
       .has(SharePermission.READ_AND_WRITE)
     ) {
+      List<FileVersion> allFileVersion = fileVersionRepository.getFileVersions(nodeId);
+      int maxNumberOfVersions = filesConfig.getMaxNumberOfFileVersion();
+
+      // This check seems (at first) useless since there is a mechanism to remove the oldest version
+      // not flagged as keep forever. However, it remains useful when the sysadmin reduces the config
+      // regarding the maximum number of versions a node can have
+      if (!overwrite && allFileVersion.size() > maxNumberOfVersions) {
+        throw new MaxNumberOfFileVersionsException(String.format(
+          "Node %s has reached max number of versions (%d), cannot add more versions",
+          nodeId,
+          maxNumberOfVersions
+        ));
+      }
+
+      // Here we are sure that the node exists otherwise the permission checker would be failed
+      Node node = nodeRepository.getNode(nodeId).get();
 
       MediaType mediaType = mimeTypeUtils.detectMimeTypeFromFilename(
         filename,
@@ -257,134 +318,153 @@ public class BlobService {
 
       NodeType nodeType = NodeType.getNodeType(mediaType);
 
-      Optional<Node> node = nodeRepository.getNode(nodeId);
-      if (node.isEmpty()) {
-        logger.debug(MessageFormat.format(
-          "Node {0} not found",
-          nodeId
-        ));
-        //return Try.failure(new NodeNotFoundException());
-        return Optional.empty();
-      }
-      Node currNode = node.get();
-
-      if (nodeType != node.get().getNodeType()) {
-        logger.debug(MessageFormat.format(
-          "Node {0} with wrong type {1}, should be the same as old versions: {2}",
+      if (nodeType != node.getNodeType()) {
+        throw new FileTypeMismatchException(String.format(
+          "Node %s with wrong type %s, should be the same as old versions: %s",
           nodeId,
-          node.get().getNodeType(),
-          nodeType
+          nodeType,
+          node.getNodeType()
         ));
-        //return Try.failure(new BadRequest());
-        return Optional.empty();
-      }
-      FileVersion oldestVersionNotKeptForever = null;
-      if (!overwrite && getNumberOfVersionOfFile(nodeId) >= maxNumberOfVersions) {
-        List<FileVersion> allFileVersion = fileVersionRepository.getFileVersions(nodeId);
-        int keepForeverCounter = 0;
-        for (FileVersion version : allFileVersion) {
-          keepForeverCounter = version.isKeptForever()
-            ? keepForeverCounter + 1
-            : keepForeverCounter;
-        }
-        List<FileVersion> allVersionsNotKeptForever = allFileVersion.stream()
-          .filter(version -> !version.isKeptForever())
-          .collect(Collectors.toList());
-        oldestVersionNotKeptForever = allVersionsNotKeptForever.get(
-          allVersionsNotKeptForever.size() - 1);
-        /*
-        The List of not keep forever element is never <1, at this point the element that are
-        kept forever are always less than max allowed.
-        */
       }
 
-      Optional<Integer> uploadResult = uploadFileVersionOperation(
+      return uploadFileVersionOperation(
         requester,
         bufferInputStream,
         blobLength,
-        nodeId,
-        currNode,
+        node,
         mediaType,
         overwrite
-      );
-      logger.debug(MessageFormat.format(
-        "File version upload result: {0} with node: {1}",
-        uploadResult.isPresent()
-          ? "success"
-          : "failure",
-        nodeId
-      ));
+      ).map(versionUploaded -> {
+        // Detect if it is necessary to delete an old version to make space for the new one
+        // respecting the maxNumberOfVersion limit.
+        // allFileVersion.size() does not contain the just created new FileVersion so the comparison
+        // with the maxNumberOfVersion must be more strict (>=). (this saves a query to the db)
+        if (!overwrite && allFileVersion.size() >= maxNumberOfVersions) {
+          List<FileVersion> allVersionsNotKeptForever = allFileVersion
+            .stream()
+            .filter(version -> !version.isKeptForever())
+            .collect(Collectors.toList());
+          FileVersion oldestVersionToDelete =
+            allVersionsNotKeptForever.get(allVersionsNotKeptForever.size() - 1);
 
-      if (uploadResult.isPresent() && oldestVersionNotKeptForever != null) {
-        fileVersionRepository.deleteFileVersion(oldestVersionNotKeptForever);
-        tombstoneRepository.createTombstonesBulk(List.of(oldestVersionNotKeptForever), currNode.getOwnerId());
-        logger.debug(MessageFormat.format(
-          "After successful upload file version limit has been reached, deleting version {0} of {1} to make space for a new version",
-          oldestVersionNotKeptForever.getVersion(),
-          oldestVersionNotKeptForever.getNodeId()
-        ));
-      }
-      return uploadResult;
+          // The List of not keep forever elements is never <1, at this point the element that are
+          // kept forever are always less than max allowed.
+          fileVersionRepository.deleteFileVersion(oldestVersionToDelete);
+          tombstoneRepository.createTombstonesBulk(
+            List.of(oldestVersionToDelete),
+            node.getOwnerId()
+          );
+
+          logger.info(
+            "File version limit for node {} has been reached, deleting version {} to make space for the new one",
+            oldestVersionToDelete.getNodeId(),
+            oldestVersionToDelete.getVersion()
+          );
+        }
+
+        return versionUploaded;
+      });
     } else {
       logger.warn(
-        "User {} does not have the necessary permission to upload the node {}",
+        "User {} does not have the necessary permission to upload a new version of the node {}",
         requester.getId(),
         nodeId
       );
-      //return Try.failure(new NodePermissionException());
       return Optional.empty();
     }
   }
 
+  private Optional<BlobResponse> downloadFile(
+    String nodeId,
+    @Nullable Integer version
+  ) {
+    logger.info(String.format(
+      "Start to download node with id %s and version %s",
+      nodeId,
+      version == null ? "latest" : version
+    ));
+    return nodeRepository
+      .getNode(nodeId)
+      .map(node -> fileVersionRepository
+        .getFileVersion(node.getId(), version == null ? node.getCurrentVersion() : version)
+        .map(fileVersion -> Try
+          .of(() -> fileStore
+            .download(FilesIdentifier.of(
+              fileVersion.getNodeId(),
+              fileVersion.getVersion(),
+              node.getOwnerId())
+            )
+          )
+          .map(blob -> new BlobResponse(
+            blob,
+            node.getFullName(),
+            fileVersion.getSize(),
+            fileVersion.getMimeType())
+          )
+          .getOrElseThrow(failure -> {
+            throw new DependencyException(String.format(
+              "Storages failed: unable to download node with id %s and version %s",
+              fileVersion.getNodeId(),
+              fileVersion.getVersion()),
+              failure
+            );
+          })))
+      .orElseGet(() -> {
+        logger.error("Unable to download node {}: the node id does not exist", nodeId);
+        return Optional.empty();
+      });
+  }
 
   private Optional<Integer> uploadFileVersionOperation(
     User requester,
     BufferInputStream bufferInputStream,
     long blobLength,
-    String nodeId,
     Node node,
     MediaType mediaType,
     boolean overwrite
   ) {
 
-    int newVersion = overwrite
-      ? node.getCurrentVersion()
-      : node.getCurrentVersion() + 1;
+    String nodeId = node.getId();
+    int versionToUpload = node.getCurrentVersion();
 
-    UploadResponse uploadResponse = null;
+    UploadResponse uploadResponse;
     try {
       if (overwrite) {
         uploadResponse = fileStore
           .uploadPut(
-            FilesIdentifier.of(nodeId, newVersion, requester.getId()),
+            FilesIdentifier.of(nodeId, versionToUpload, requester.getId()),
             bufferInputStream,
             blobLength
           );
 
+        // Delete the metadata of the old version since they will be recreated below
+        fileVersionRepository.deleteFileVersions(nodeId,
+          Collections.singletonList(versionToUpload));
+
       } else {
+        versionToUpload = node.getCurrentVersion() + 1;
         uploadResponse = fileStore
           .uploadPost(
-            FilesIdentifier.of(nodeId, newVersion, requester.getId()),
+            FilesIdentifier.of(nodeId, versionToUpload, requester.getId()),
             bufferInputStream,
             blobLength
           );
       }
     } catch (Exception exception) {
-      logger.error("Unable to upload the file {} with version {}", nodeId, newVersion, exception);
-      return Optional.empty();
-    }
-
-    if (overwrite) {
-      FileVersion fileVersionOld = fileVersionRepository.getFileVersion(nodeId, newVersion).get();
-      fileVersionRepository.deleteFileVersion(fileVersionOld);
-    } else {
-      node.setCurrentVersion(newVersion);
+      throw new DependencyException(
+        String.format(
+          "Storages failed: unable to upload node with id %s and version %d",
+          nodeId,
+          versionToUpload
+        ),
+        exception
+      );
     }
 
     Optional<FileVersion> result = fileVersionRepository.createNewFileVersion(
       nodeId,
       requester.getId(),
-      newVersion,
+      versionToUpload,
       mediaType.toString(),
       uploadResponse.getSize(),
       uploadResponse.getDigest(),
@@ -392,15 +472,21 @@ public class BlobService {
     );
     node.setSize(uploadResponse.getSize());
     node.setLastEditorId(requester.getId());
+    // The update of the current version can be overkill when the version is overwritten but,
+    // since we are already doing the sql query to update the other node metadata, it doesn't add
+    // any extra costs, and it makes the code more readable.
+    node.setCurrentVersion(versionToUpload);
     nodeRepository.updateNode(node);
 
+    logger.info(
+      "Uploaded file to storages successfully: nodeId {}, version {}, size: {}, digest: {}",
+      nodeId,
+      versionToUpload,
+      uploadResponse.getSize(),
+      uploadResponse.getDigest()
+    );
+
     return result.map(FileVersion::getVersion);
-    /*
-    return result.map(fileVersion -> Try.success(fileVersion.getVersion()))
-      .orElseGet(() -> Try.failure(new InternalServerErrorException("Upload failed")));
-
-    */
-
   }
 
   /**
@@ -431,9 +517,5 @@ public class BlobService {
       ++level;
     }
     return finalFilename;
-  }
-
-  public int getNumberOfVersionOfFile(String nodeId) {
-    return fileVersionRepository.getFileVersions(nodeId).size();
   }
 }

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.0"
-pkgrel="1"
+pkgrel="2306051303"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.0-1</version>
+  <version>0.9.0-2306051303</version>
 
 </project>


### PR DESCRIPTION
[chore: lastVersion variable renamed in to oldestVersionNotKeptForever](https://github.com/Zextras/carbonio-files-ce/commit/a1c38835ce05f108bee5bebe54be4a65a27ed608)

---
[refactor: use Optional instead of Try in BlobService and BlobController](https://github.com/Zextras/carbonio-files-ce/pull/65/commits/d8e29c022f999e7686ff1c722613a99bd44fed52)
- Refactored BlobService and BlobController to return Optional instead
  of Try and to better organize error handling
- Added uncatched exceptions to improve centralization of exception handling

---

[fix: move upload operation outside of the transaction](https://github.com/Zextras/carbonio-files-ce/pull/65/commits/28159d0f227172c41e2a01d89f45f7cb87714bb4)