### PR TITLE
refactor: add NodeCategory enum to avoid having hardcoded shorts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,6 @@ pipeline {
             }
         }
         stage("Tests") {
-            when {
-              changeRequest()
-            }
             parallel {
                 stage("UTs") {
                     steps {

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191725</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191617</version>
+    <version>0.9.1-2306191725</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191725</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191617</version>
+    <version>0.9.1-2306191725</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
@@ -123,13 +123,13 @@ class Node {
     mAncestorIds = ancestorIds;
     switch (mNodeType) {
       case ROOT:
-        mNodeCategory = 0;
+        mNodeCategory = NodeCategory.ROOT.getValue();
         break;
       case FOLDER:
-        mNodeCategory = 1;
+        mNodeCategory = NodeCategory.FOLDER.getValue();
         break;
       default:
-        mNodeCategory = 2;
+        mNodeCategory = NodeCategory.FILE.getValue();
         mCurrentVersion = 1;
     }
     mSize = size;
@@ -202,8 +202,8 @@ class Node {
     return this;
   }
 
-  public Short getNodeCategory() {
-    return mNodeCategory;
+  public NodeCategory getNodeCategory() {
+    return NodeCategory.decode(mNodeCategory);
   }
 
   public String getFullName() {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/NodeCategory.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/NodeCategory.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.dao.ebean;
+
+import java.util.Arrays;
+
+/**
+ * Allows to map a category of a {@link Node} to a short value. In the database each node belongs to
+ * a category and to save bits each one of them is represented as a short value.
+ */
+public enum NodeCategory {
+  ROOT((short) 0),
+  FOLDER((short) 1),
+  FILE((short) 2);
+
+  private final short value;
+
+  NodeCategory(short value) {
+    this.value = value;
+  }
+
+  /**
+   * @return the short related to the {@link NodeCategory}.
+   */
+  public short getValue() {
+    return value;
+  }
+
+  /**
+   * Decodes a short into a {@link NodeCategory}
+   *
+   * @param value is a <code>short</code> representing the value to convert. If the value is not 0,
+   *              1 or 2 then the method throws an {@link IllegalArgumentException}.
+   * @return a {@link NodeCategory} representing the short value passed.
+   */
+  public static NodeCategory decode(short value) {
+    return Arrays.stream(values())
+      .filter(entry -> entry.value == value)
+      .findFirst()
+      .orElseThrow(() ->
+        new IllegalArgumentException(String.format(
+          "Invalid value for the NodeCategory enum: %d",
+          value
+        ))
+      );
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -14,6 +14,7 @@ import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.Files.Db.RootId;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeCategory;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeCustomAttributes;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.dao.ebean.TrashedNode;
@@ -57,7 +58,7 @@ public class NodeRepositoryEbean implements NodeRepository {
    * @return a {@link String} representing the evaluated key set
    */
   private String buildKeyset(
-    Short nodeCategory,
+    NodeCategory nodeCategory,
     String nodeId,
     Optional<ImmutableTriple<String, String, String>> sortField
   ) {
@@ -70,17 +71,17 @@ public class NodeRepositoryEbean implements NodeRepository {
           "OR (" + sField.getLeft() + " = " +
           "'" + sField.getRight()
           .replace("'", "''") + "' AND t0.node_id > '" + nodeId + "')"
-          : "(node_category > " + nodeCategory + ") " +
-            "OR (node_category = " + nodeCategory + " AND " + sField.getLeft() +
+          : "(node_category > " + nodeCategory.getValue() + ") " +
+            "OR (node_category = " + nodeCategory.getValue() + " AND " + sField.getLeft() +
             sField.getMiddle() +
             "'" + sField.getRight()
             .replace("'", "''") + "'" + ") " +
-            "OR (node_category = " + nodeCategory + " AND " + sField.getLeft() + " = " +
+            "OR (node_category = " + nodeCategory.getValue() + " AND " + sField.getLeft() + " = " +
             "'" + sField.getRight()
             .replace("'", "''") + "' AND t0.node_id > '" + nodeId + "')";
       })
-      .orElse("(node_category > " + nodeCategory + ") OR " +
-        "(node_category = " + nodeCategory + " AND t0.node_id > '" + nodeId + "')");
+      .orElse("(node_category > " + nodeCategory.getValue() + ") OR " +
+        "(node_category = " + nodeCategory.getValue() + " AND t0.node_id > '" + nodeId + "')");
 
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/dal/dao/ebean/NodeCategoryTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/dao/ebean/NodeCategoryTest.java
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.dao.ebean;
+
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class NodeCategoryTest {
+
+  private static Stream<Arguments> nodeCategoriesProvider() {
+    return Stream.of(
+      Arguments.arguments(NodeCategory.ROOT, (short) 0),
+      Arguments.arguments(NodeCategory.FOLDER, (short) 1),
+      Arguments.arguments(NodeCategory.FILE, (short) 2)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("nodeCategoriesProvider")
+  void givenANodeCategoryTheGetValueShouldReturnTheRelatedShortValue(
+    NodeCategory category,
+    short value
+  ) {
+    // Given & When
+    short nodeCategoryValue = category.getValue();
+
+    // Then
+    Assertions.assertThat(nodeCategoryValue).isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @MethodSource("nodeCategoriesProvider")
+  void givenAValidShortTheDecodeShouldReturnTheRelatedNodeCategory(
+    NodeCategory category,
+    short value
+  ) {
+    // Given & When
+    NodeCategory nodeCategory = NodeCategory.decode(value);
+
+    // Then
+    Assertions.assertThat(nodeCategory).isEqualTo(category);
+  }
+
+  @Test
+  void givenAnInvalidShortTheDecodeShouldThrowAnIllegalArgumentException() {
+    // Given
+    short value = 3;
+
+    // When
+    ThrowableAssert.ThrowingCallable throwable = () -> NodeCategory.decode(value);
+
+    //Then
+    Assertions
+      .assertThatIllegalArgumentException()
+      .isThrownBy(throwable)
+      .withMessage("Invalid value for the NodeCategory enum: 3");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/dal/dao/ebean/NodeTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/dao/ebean/NodeTest.java
@@ -45,7 +45,7 @@ class NodeTest {
       .isPresent()
       .isEqualTo(Optional.of("Fake description"));
     Assertions.assertThat(node.getNodeType()).isEqualTo(NodeType.IMAGE);
-    Assertions.assertThat(node.getNodeCategory().intValue()).isEqualTo(2);
+    Assertions.assertThat(node.getNodeCategory()).isEqualTo(NodeCategory.FILE);
     Assertions.assertThat(node.getLastEditorId()).isEmpty();
     Assertions
       .assertThat(node.getParentId())
@@ -111,7 +111,7 @@ class NodeTest {
       .isPresent()
       .isEqualTo(Optional.of("Fake description"));
     Assertions.assertThat(node.getNodeType()).isEqualTo(NodeType.IMAGE);
-    Assertions.assertThat(node.getNodeCategory().intValue()).isEqualTo(2);
+    Assertions.assertThat(node.getNodeCategory()).isEqualTo(NodeCategory.FILE);
     Assertions
       .assertThat(node.getLastEditorId())
       .isPresent()
@@ -153,7 +153,7 @@ class NodeTest {
 
     // Then
     Assertions.assertThat(node.getNodeType()).isEqualTo(NodeType.FOLDER);
-    Assertions.assertThat(node.getNodeCategory().intValue()).isOne();
+    Assertions.assertThat(node.getNodeCategory()).isEqualTo(NodeCategory.FOLDER);
     Assertions.assertThat(node.getCurrentVersion()).isOne();
   }
 
@@ -176,7 +176,7 @@ class NodeTest {
 
     // Then
     Assertions.assertThat(node.getNodeType()).isEqualTo(NodeType.ROOT);
-    Assertions.assertThat(node.getNodeCategory().intValue()).isZero();
+    Assertions.assertThat(node.getNodeCategory()).isEqualTo(NodeCategory.ROOT);
     Assertions.assertThat(node.getCurrentVersion()).isOne();
   }
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -7,8 +7,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-files-ce"
-pkgver="0.9.1"
-pkgrel="2306191725"
+pkgver="0.9.2"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.1"
-pkgrel="2306191617"
+pkgrel="2306191725"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.1-2306191725</version>
+  <version>0.9.2-SNAPSHOT</version>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.1-2306191617</version>
+  <version>0.9.1-2306191725</version>
 
 </project>


### PR DESCRIPTION
- Added NodeCategory enum containing ROOT, FOLDER and FILE entries
- Replaced hardcoded short with the NodeCategory enum
- Added unit tests