### PR TITLE
fix: FILES-673 - Upload API should not return the version

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191617</version>
+    <version>0.9.1-2306201155</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.1-2306191617</version>
+    <version>0.9.1-2306201155</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadVersionResponse.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadVersionResponse.java
@@ -5,20 +5,30 @@
 package com.zextras.carbonio.files.rest.types;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Objects;
+
 
 public class UploadVersionResponse {
 
   public static final String SERIALIZED_NAME_VERSION_ID = "version";
-  private             String nodeId;
-  private             int    version;
+  private String nodeId;
 
-  public int getVersion() {
+  @JsonInclude(Include.NON_NULL)
+  private Integer version;
+
+  public Integer getVersion() {
     return version;
   }
 
   public void setVersion(int version) {
-    this.version = version;
+    // TODO: this is a temporary fix since we need to make a breaking change if we want to return
+    //  always the version
+    if (version > 1) {
+      this.version = version;
+    }
   }
 
   public String getNodeId() {

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.1"
-pkgrel="2306191617"
+pkgrel="2306201155"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.1-2306191617</version>
+  <version>0.9.1-2306201155</version>
 
 </project>


### PR DESCRIPTION
For now, the Upload API response does not return the version of the node to avoid breaking change.
This fix touches only the returned UploadVersionResponse POJO to avoid changing the right logic in the BlobController and making the revert more difficult.