### PR TITLE
refactor: make endpoint url regex easier to read

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306261631</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-2306261631</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-2306261631</version>
   </parent>
 
   <profiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306261631</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -709,31 +709,31 @@ public final class Files {
         SERVICE + "upload-version/?$");
       public static final Pattern UPLOAD_FILE_TO      = Pattern.compile(SERVICE + "upload-to/?$");
       public static final Pattern DOWNLOAD_FILE       = Pattern.compile(
-        SERVICE + "download/([a-f0-9\\\\-]*)/?([0-9]+)?/?$");
+        SERVICE + "download/([a-f\\d\\-]*)(/[\\d]+)?/?$");
       public static final Pattern PUBLIC_LINK         = Pattern.compile(
-        SERVICE + "link/([a-zA-Z0-9]{8})/?$");
+        SERVICE + "link/([\\w]{8})/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
-        SERVICE + "invite/([a-zA-Z0-9]{8})/?$");
+        SERVICE + "invite/([\\w]{8})/?$");
 
       public static final Pattern PREVIEW            = Pattern.compile(SERVICE + "preview/(.*)");
       public static final Pattern PREVIEW_IMAGE      = Pattern.compile(
         SERVICE
-          + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+          + "preview/image/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_IMAGE    = Pattern.compile(
-        SERVICE + "preview/image/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/image/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
       public static final Pattern PREVIEW_PDF        = Pattern.compile(
-        SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+        SERVICE + "preview/pdf/([a-f\\d\\-]*)/([\\d]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_PDF      = Pattern.compile(
-        SERVICE + "preview/pdf/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/pdf/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
       public static final Pattern PREVIEW_DOCUMENT   = Pattern.compile(
-        SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+        SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
-        SERVICE + "preview/document/([a-f0-9\\-]*)/([0-9]+)/([0-9]*x[0-9]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
     }
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -229,7 +229,6 @@ public class NodeRepositoryEbean implements NodeRepository {
     try {
       return Base64.getEncoder().encodeToString(mapper.writeValueAsString(nextPage).getBytes());
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
       throw new RuntimeException(e);
     }
 
@@ -248,7 +247,6 @@ public class NodeRepositoryEbean implements NodeRepository {
     try {
       return mapper.readValue(new String(Base64.getDecoder().decode(token)), PageQuery.class);
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLRequest.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLRequest.java
@@ -112,8 +112,8 @@ public class GraphQLRequest {
 
     try {
       payloadMap = mapper.readValue(payloadString, Map.class);
-    } catch (IOException e) {
-      e.printStackTrace();
+    } catch (IOException exception) {
+      throw new InvalidPayloadRequestError("Unable to encode a Graphql payload into a Map object");
     }
 
     if (payloadMap.get(GRAPHQL_FIELD_REQUEST) == null) {

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadVersionResponse.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/UploadVersionResponse.java
@@ -4,8 +4,6 @@
 
 package com.zextras.carbonio.files.rest.types;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Objects;

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -337,12 +337,28 @@ class HttpRoutingHandlerTest {
       .fireChannelRead(httpRequestMock);
   }
 
-  @Test
-  void givenAnInvalidEndpointRequestHttpRoutingHandlerShouldRespondWith404() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "/invalid/endpoint",
+    "/metrics/invalid",
+    "/health/invalid",
+    "/health/live/invalid",
+    "/health/ready/invalid",
+    "/graphql/invalid",
+    "/download/invalid",
+    "/download/8caeef71-6f72-439c-847a-38e90efd0965/invalid",
+    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/invalid",
+    "/upload/invalid",
+    "/upload-version/invalid",
+    "/link/abcd1234/invalid",
+    "/invite/abcd1234/invalid",
+    "/upload-to/invalid"
+  })
+  void givenAnInvalidEndpointRequestHttpRoutingHandlerShouldRespondWith404(String invalidUri) {
     // Given
     Mockito
       .when(httpRequestMock.uri())
-      .thenReturn("/invalid/endpoint");
+      .thenReturn(invalidUri);
     Mockito
       .when(httpRequestMock.protocolVersion())
       .thenReturn(HttpVersion.HTTP_1_1);

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.2"
-pkgrel="2306231258"
+pkgrel="2306261631"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.2"
-pkgrel="2306261631"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.2-2306261631</version>
+  <version>0.9.2-SNAPSHOT</version>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.2-2306231258</version>
+  <version>0.9.2-2306261631</version>
 
 </project>


### PR DESCRIPTION
- Updated the regex necessary to validate an endpoint and to select the right ChannelInboundHandler.
- Trasform a test to a parameterized one to check if various invalid endpoints are rejected by the HttpRoutingHandler class.