### PR TITLE
refactor: FILES-674 - Remove non-nullity from owner attribute in Node type

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-2306231437</version>
   </parent>
 
 </project>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231437</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231437</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-2306231437</version>
   </parent>
 
   <profiles>

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -219,7 +219,7 @@ interface Node {
     creator: User!
 
     # Owner of the node (it will be a User type when it will be implemented)
-    owner: User!
+    owner: User
 
     # Last user who has edited the node (it will be a User type when it will be implemented)
     last_editor: User
@@ -285,7 +285,7 @@ type Folder implements Node {
     creator: User!
 
     # Owner of the folder
-    owner: User!
+    owner: User
 
     # Last user who has edited the folder
     last_editor: User
@@ -366,7 +366,7 @@ type File implements Node {
     creator: User!
 
     # Owner of the file
-    owner: User!
+    owner: User
 
     # Last user who has edited the file
     last_editor: User

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.2"
-pkgrel="2306231437"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.2"
-pkgrel="2306231258"
+pkgrel="2306231437"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.2-2306231258</version>
+  <version>0.9.2-2306231437</version>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.2-2306231437</version>
+  <version>0.9.2-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
In the graphql schema, the owner of a `Node` can be null when the Node is the `LOCAL_ROOT` or the `TRASH_ROOT`.
The roots are created without an owner because, at the moment, they are shared with all users.

This fix is applied also for the `File` and `Folder` types.