### PR TITLE
ci: FILES-670 - Add SonarQube and dependencyCheck tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,14 @@ repos:
 
   - repo: local
     hooks:
-      - id: check-if-version-is-bumped
-        name: check-if-version-is-bumped
+      - id: check-if-version-is-snapshot
+        name: check-if-version-is-snapshot
         entry: bash -c '
-          if [[ -z $(git diff develop --staged -G"pkgver|pkgrel" package/PKGBUILD) ]] &&
-             [[ -z $(git diff develop..HEAD -G"pkgver|pkgrel" package/PKGBUILD) ]];
+          currentBranch=$(git branch --show-current)
+          isSnapshot=$(grep -re "pkgrel=\"SNAPSHOT\"" package/PKGBUILD)
+
+          if [[ "$currentBranch" != *"release"* && -z "$isSnapshot" ]] ||
+             [[ "$currentBranch" == *"release"* && -n "$isSnapshot" ]];
           then
             exit 1;
           fi'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,16 +175,7 @@ pipeline {
                                 "pattern": "artifacts/*.deb",
                                 "target": "ubuntu-devel/pool/",
                                 "props": "deb.distribution=focal;deb.component=main;deb.architecture=amd64"
-                            }
-                        ]
-                    }'''
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-
-                    //rocky 8
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += '-centos8'
-                    uploadSpec= '''{
-                        "files": [
+                            },
                             {
                                 "pattern": "artifacts/(carbonio-files-ce)-(*).rpm",
                                 "target": "centos8-devel/zextras/{1}/{1}-{2}.rpm",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
     }
     parameters {
         booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
+        booleanParam defaultValue: false, description: 'Skip dependencyCheck', name: 'RUN_DEPENDENCY_CHECK'
     }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
@@ -64,8 +65,44 @@ pipeline {
                 publishCoverage adapters: [jacocoAdapter('core/target/jacoco-full-report/jacoco.xml')]
             }
         }
+        stage('Dependency check'){
+            when {
+                expression { params.RUN_DEPENDENCY_CHECK == true }
+            }
+            steps {
+                dependencyCheck additionalArguments: '''-f "HTML" --prettyPrint''', odcInstallation: 'dependency-check'
+            }
+        }
+        stage('SonarQube analysis') {
+            when {
+                anyOf {
+                    branch 'develop'
+                    expression { env.BRANCH_NAME.contains("PR") }
+                }
+            }
+            steps {
+                withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
+                    sh 'mvn -B --settings settings-jenkins.xml sonar:sonar'
+                }
+            }
+        }
         stage('Build deb/rpm') {
             stages {
+                // Replace the pkgrel value from SNAPSHOT with the git commit hash to ensure that
+                // each merged PR has unique artifacts and to prevent conflicts between them.
+                // Note that the pkgrel value will remain as SNAPSHOT in the codebase to avoid
+                // conflicts between multiple open PRs
+                stage('Snapshot to commit hash') {
+                    when {
+                        branch 'develop'
+                    }
+                    steps {
+                        sh'''
+                            export GIT_COMMIT_SHORT=$(git rev-parse HEAD | head -c 8)
+                            sed -i "s/pkgrel=\\"SNAPSHOT\\"/pkgrel=\\"$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
+                        '''
+                    }
+                }
                 stage('Stash') {
                     steps {
                         stash includes: 'pacur.json,package/**', name: 'binaries'
@@ -124,7 +161,9 @@ pipeline {
             }
             steps {
                 unstash 'artifacts-deb'
+                unstash 'artifacts-rpm'
                 script {
+                    // ubuntu
                     def server = Artifactory.server 'zextras-artifactory'
                     def buildInfo
                     def uploadSpec
@@ -136,6 +175,20 @@ pipeline {
                                 "pattern": "artifacts/*.deb",
                                 "target": "ubuntu-devel/pool/",
                                 "props": "deb.distribution=focal;deb.component=main;deb.architecture=amd64"
+                            }
+                        ]
+                    }'''
+                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
+
+                    //rocky 8
+                    buildInfo = Artifactory.newBuildInfo()
+                    buildInfo.name += '-centos8'
+                    uploadSpec= '''{
+                        "files": [
+                            {
+                                "pattern": "artifacts/(carbonio-files-ce)-(*).rpm",
+                                "target": "centos8-devel/zextras/{1}/{1}-{2}.rpm",
+                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras"
                             }
                         ]
                     }'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
     parameters {
         booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
-        booleanParam defaultValue: false, description: 'Skip dependencyCheck', name: 'RUN_DEPENDENCY_CHECK'
+        booleanParam defaultValue: false, description: 'Run dependencyCheck', name: 'RUN_DEPENDENCY_CHECK'
     }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -327,7 +327,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.9.2-2306231258</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-files-ce"
 pkgver="0.9.2"
-pkgrel="2306231258"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 pkgdesclong=(
   "Carbonio Files"

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,12 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven.compiler.target>11</maven.compiler.target>
     <java-compiler.version>11</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <sonar.coverage.jacoco.xmlReportPaths>
+      ../core/target/jacoco-full-report/jacoco.xml
+    </sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.dependencyCheck.htmlReportPath>
+      ./dependency-check-report.html
+    </sonar.dependencyCheck.htmlReportPath>
 
     <!-- Flags to skip/run tests and the report generation -->
     <skip.integration.tests>true</skip.integration.tests>
@@ -268,6 +274,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.9.2-2306231258</version>
+  <version>0.9.2-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
 - Updated Jenkinsfile to add SonarQube and DependencyCheck integrations
 - Updated pre-commit to check if pkgrel is `SNAPSHOT` when the branch is not `release`
 - Updated Jenkinsfile adding a step to replace the SNAPSHOT keyword with the hash of the commit when the artifacts are uploaded on develop repositories: it ensure that each merged PR has unique artifacts and prevents conflicts between them. Note that the pkgrel value will remain as SNAPSHOT in the codebase to avoid conflicts between multiple open PRs.