### PR TITLE
feat: FILES-675 - Integrate preview and thumbnail of GIF images

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -27,6 +27,7 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.UserRepository;
 import com.zextras.carbonio.files.graphql.validators.GenericControllerEvaluatorFactory;
 import com.zextras.filestore.api.Filestore;
 import com.zextras.storages.api.StoragesClient;
+import java.time.Clock;
 
 public class FilesModule extends AbstractModule {
 
@@ -39,6 +40,7 @@ public class FilesModule extends AbstractModule {
 
   @Override
   public void configure() {
+    bind(Clock.class).toInstance(Clock.systemUTC());
     bind(NodeRepository.class).to(NodeRepositoryEbean.class);
     bind(ShareRepository.class).to(ShareRepositoryEbean.class);
     bind(TombstoneRepository.class).to(TombstoneRepositoryEbean.class);

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/PreviewQueryParameters.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/PreviewQueryParameters.java
@@ -81,6 +81,9 @@ public class PreviewQueryParameters {
   }
 
   private enum Format {
+    @JsonProperty("gif")
+    GIF,
+
     @JsonProperty("jpeg")
     JPEG,
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
     <carbonio-user-management-sdk.version>0.2.1</carbonio-user-management-sdk.version>
-    <carbonio-preview-sdk.version>1.0.1</carbonio-preview-sdk.version>
+    <carbonio-preview-sdk.version>1.0.2</carbonio-preview-sdk.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-validator.version>1.7</commons-validator.version>
     <ebean.version>13.16.0</ebean.version>


### PR DESCRIPTION
- Updated the carbonio-preview-sdk to 1.0.2 (supporting the GIFs)
- Updated the Format enumerator adding the GIF entry to support the `output_format=gif` query parameter
- Updated the FilesModule binding the Clock interface with the concrete one.