### PR TITLE
feat: increase the length of the hash of a public link to 32 characters

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -90,7 +90,7 @@ public final class Files {
 
     private Db() {}
 
-    public static final short DB_VERSION = 2;
+    public static final short DB_VERSION = 3;
 
     /**
      * Names of Files tables
@@ -710,8 +710,8 @@ public final class Files {
       public static final Pattern UPLOAD_FILE_TO      = Pattern.compile(SERVICE + "upload-to/?$");
       public static final Pattern DOWNLOAD_FILE       = Pattern.compile(
         SERVICE + "download/([a-f\\d\\-]*)/?([\\d]+)?/?$");
-      public static final Pattern PUBLIC_LINK         = Pattern.compile(
-        SERVICE + "link/([\\w]{8})/?$");
+      public static final Pattern PUBLIC_LINK =
+          Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Link.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Link.java
@@ -30,7 +30,7 @@ public class Link {
   @Column(name = Db.Link.NODE_ID, nullable = false, length = 36)
   private String mNodeId;
 
-  @Column(name = Db.Link.PUBLIC_ID, nullable = false, length = 8)
+  @Column(name = Db.Link.PUBLIC_ID, nullable = false)
   private String mPublicId;
 
   @Column(name = Files.Db.Link.CREATED_AT, nullable = false)

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
@@ -130,7 +130,7 @@ public class LinkDataFetcher {
         .has(SharePermission.READ_AND_SHARE)
         && nodeRepository.getNode(nodeId).get().getNodeType() != NodeType.FOLDER
       ) {
-        String publicId = RandomStringUtils.randomAlphanumeric(8);
+        String publicId = RandomStringUtils.randomAlphanumeric(32);
 
         Link createdLink = linkRepository.createLink(
           UUID.randomUUID().toString(),

--- a/core/src/main/resources/sql/postgresql_3.sql
+++ b/core/src/main/resources/sql/postgresql_3.sql
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+BEGIN;
+
+ALTER TABLE link ALTER COLUMN public_id TYPE VARCHAR(32);
+
+UPDATE db_info SET version = 3;
+
+COMMIT;

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -109,7 +109,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .hasSize("example.com/services/files/link/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", 5)
@@ -153,7 +153,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .hasSize("example.com/services/files/link/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", null)

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -86,7 +86,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -117,8 +117,7 @@ class UpdatePublicLinkApiIT {
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat((String) updatedLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -137,7 +136,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -169,8 +168,7 @@ class UpdatePublicLinkApiIT {
 
     Assertions.assertThat((String) updatedLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) updatedLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -215,7 +213,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -252,7 +250,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -284,7 +282,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -206,7 +206,9 @@ class HttpRoutingHandlerTest {
   @ParameterizedTest
   @ValueSource(strings = {
     "/link/abcd1234",
-    "/link/abcd1234/"
+    "/link/abcd1234/",
+    "/link/abcd1234abcd1234abcd1234abcd1234",
+    "/link/abcd1234abcd1234abcd1234abcd1234/"
   })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
     // Given
@@ -351,6 +353,12 @@ class HttpRoutingHandlerTest {
     "/upload/invalid",
     "/upload-version/invalid",
     "/link/abcd1234/invalid",
+    "/link/seven00",
+    "/link/seven00/",
+    "/link/nine00000",
+    "/link/nine00000/",
+    "/link/thirtythreethirtythreethirtythree",
+    "/link/thirtythreethirtythreethirtythree/",
     "/invite/abcd1234/invalid",
     "/upload-to/invalid"
   })


### PR DESCRIPTION
- Created a new sql schema (version 3) to change the type of the public_id of a public link from CHARACTERS(8) to VARCHAR(32)
- Updated Link entity, and the HttpRoutingHandler to accept a longer public_id. For legacy reasons, the system will continue to support older links generated with a public hash of 8 characters
- Updated/Created UTs and ITs where necessary

Refs: FILES-730