### PR TITLE
feat: enable the creation of public link to folders

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -693,9 +693,10 @@ public final class Files {
 
       private Endpoints() {}
 
-      public static final String SERVICE                = "/";
-      public static final String PUBLIC_LINK_URL        = "/services/files/link/";
-      public static final String COLLABORATION_LINK_URL = "/services/files/invite/";
+      public static final String SERVICE                  = "/";
+      public static final String PUBLIC_LINK_ACCESS_URL   = "/files/public/link/access/";
+      public static final String PUBLIC_LINK_DOWNLOAD_URL = "/services/files/public/link/download/";
+      public static final String COLLABORATION_LINK_URL   = "/services/files/invite/";
 
       public static final Pattern METRICS             = Pattern.compile(SERVICE + "metrics/?$");
       public static final Pattern HEALTH              = Pattern.compile(
@@ -712,6 +713,8 @@ public final class Files {
         SERVICE + "download/([a-f\\d\\-]*)/?([\\d]+)?/?$");
       public static final Pattern PUBLIC_LINK =
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
+      public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
+        Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -110,7 +110,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
       return;
     }
 
-    if (Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+    if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
+      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("rest-handler", blobController)
         .addLast("exceptions-handler", exceptionsHandler);

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -82,6 +82,8 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         Matcher uploadMatcher = Endpoints.UPLOAD_FILE.matcher(uriRequest);
         Matcher uploadVersionMatcher = Endpoints.UPLOAD_FILE_VERSION.matcher(uriRequest);
         Matcher publicLinkMatcher = Endpoints.PUBLIC_LINK.matcher(uriRequest);
+        Matcher downloadViaPublicLinkMatcher =
+          Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(uriRequest);
 
         if (downloadMatcher.find()) {
           download(context, httpRequest, downloadMatcher);
@@ -89,6 +91,10 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
 
         if (publicLinkMatcher.find()) {
           downloadByLink(context, httpRequest, publicLinkMatcher);
+        }
+
+        if (downloadViaPublicLinkMatcher.find()) {
+          downloadByLink(context, httpRequest, downloadViaPublicLinkMatcher);
         }
 
         if (uploadMatcher.find()) {

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -72,7 +72,7 @@ class CreatePublicLinkApiIT {
 
   void createFolder(String nodeId, String ownerId) {
     nodeRepository.createNewNode(
-      nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
@@ -174,42 +174,42 @@ class CreatePublicLinkApiIT {
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     final String bodyPayload =
-      "mutation { "
-        + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {"
-        + "id "
-        + "url "
-        + "expires_at "
-        + "created_at "
-        + "description "
-        + "node { "
-        + "  id "
-        + "} "
-        + "} "
-        + "}";
+        "mutation { "
+            + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
 
     final HttpRequest httpRequest =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
     final Map<String, Object> createdLink =
-      TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
 
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
-      .startsWith("example.com/files/public/link/access/")
-      .hasSize("example.com/files/public/link/access/".length() + 32);
+        .startsWith("example.com/files/public/link/access/")
+        .hasSize("example.com/files/public/link/access/".length() + 32);
 
     Assertions.assertThat(createdLink)
-      .containsEntry("expires_at", null)
-      .containsEntry("description", null);
+        .containsEntry("expires_at", null)
+        .containsEntry("description", null);
 
     Assertions.assertThat((Map<String, Object>) createdLink.get("node"))
-      .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
@@ -76,7 +76,7 @@ class GetPublicLinksApiIT {
 
   void createFolder(String nodeId, String ownerId) {
     nodeRepository.createNewNode(
-      nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
@@ -154,53 +154,52 @@ class GetPublicLinksApiIT {
 
   @Test
   void
-  givenAnExistingFolderWithOneExistingLinkTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
+      givenAnExistingFolderWithOneExistingLinkTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     linkRepository.createLink(
-      "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
-      "00000000-0000-0000-0000-000000000000",
-      "abcd1234abcd1234abcd1234abcd1234",
-      Optional.of(5L),
-      Optional.of("super-description"));
+        "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(5L),
+        Optional.of("super-description"));
 
     final String bodyPayload =
-      "query { "
-        + "getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
-        + "id "
-        + "url "
-        + "expires_at "
-        + "created_at "
-        + "description "
-        + "node { id } "
-        + "} "
-        + "} ";
+        "query { "
+            + "getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { id } "
+            + "} "
+            + "} ";
 
     final HttpRequest httpRequest =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
     final List<Map<String, Object>> publicLinks =
-      TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
 
     Assertions.assertThat(publicLinks).hasSize(1);
 
     Assertions.assertThat(publicLinks.get(0))
-      .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
-      .containsEntry(
-        "url",
-        "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
-      .containsEntry("expires_at", 5)
-      .containsEntry("description", "super-description");
+        .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
+        .containsEntry(
+            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
+        .containsEntry("expires_at", 5)
+        .containsEntry("description", "super-description");
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
-      .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
@@ -74,6 +74,11 @@ class GetPublicLinksApiIT {
     fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
   }
 
+  void createFolder(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+      nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+  }
+
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
     shareRepository.upsertShare(
         nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
@@ -81,7 +86,7 @@ class GetPublicLinksApiIT {
 
   @Test
   void
-      givenAnExistingNodeWithTwoExistingLinksTheGetLinksShouldReturnAListOfAssociatedLinksOrderedByCreationDescending() {
+      givenAnExistingFileWithTwoExistingLinksTheGetLinksShouldReturnAListOfAssociatedLinksOrderedByCreationDescending() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
@@ -128,7 +133,9 @@ class GetPublicLinksApiIT {
 
     Assertions.assertThat(publicLinks.get(0))
         .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
-        .containsEntry("url", "example.com/services/files/link/00001234abcd1234abcd1234abcd1234")
+        .containsEntry(
+            "url",
+            "example.com/services/files/public/link/download/00001234abcd1234abcd1234abcd1234")
         .containsEntry("expires_at", null)
         .containsEntry("description", null);
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
@@ -136,11 +143,64 @@ class GetPublicLinksApiIT {
 
     Assertions.assertThat(publicLinks.get(1))
         .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
-        .containsEntry("url", "example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234")
+        .containsEntry(
+            "url",
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description");
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
         .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void
+  givenAnExistingFolderWithOneExistingLinkTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
+    // Given
+    createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+      "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
+      "00000000-0000-0000-0000-000000000000",
+      "abcd1234abcd1234abcd1234abcd1234",
+      Optional.of(5L),
+      Optional.of("super-description"));
+
+    final String bodyPayload =
+      "query { "
+        + "getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+        + "id "
+        + "url "
+        + "expires_at "
+        + "created_at "
+        + "description "
+        + "node { id } "
+        + "} "
+        + "} ";
+
+    final HttpRequest httpRequest =
+      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<Map<String, Object>> publicLinks =
+      TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+
+    Assertions.assertThat(publicLinks).hasSize(1);
+
+    Assertions.assertThat(publicLinks.get(0))
+      .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
+      .containsEntry(
+        "url",
+        "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
+      .containsEntry("expires_at", 5)
+      .containsEntry("description", "super-description");
+    Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
+      .containsEntry("id", "00000000-0000-0000-0000-000000000000");
   }
 
   @Test
@@ -292,41 +352,41 @@ class GetPublicLinksApiIT {
   }
 
   @Test
-  void givenAnExistingNodeAndAnAssociatedLegacyPublicLinkWithAn8CharsPublicIdentifierTheGetLinksShouldReturnItCorrectly() {
+  void
+      givenAnExistingFileAndAnAssociatedLegacyPublicLinkWithAn8CharsPublicIdentifierTheGetLinksShouldReturnItCorrectly() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
-      "00000000-0000-0000-0000-000000000000",
-      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-      SharePermission.READ_ONLY);
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_ONLY);
 
     linkRepository.createLink(
-      "0c04783b-bdfb-446f-870c-625f5ae02a0a",
-      "00000000-0000-0000-0000-000000000000",
-      "abcd1234",
-      Optional.empty(),
-      Optional.empty());
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234",
+        Optional.empty(),
+        Optional.empty());
 
     final String bodyPayload =
-      "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id url }}";
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id url }}";
 
     final HttpRequest httpRequest =
-      HttpRequest.of(
-        "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
     final List<Map<String, Object>> publicLinks =
-      TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
 
     Assertions.assertThat(publicLinks).hasSize(1);
     Assertions.assertThat(publicLinks.get(0))
-      .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
-      .containsEntry("url", "example.com/services/files/link/abcd1234");
+        .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
+        .containsEntry("url", "example.com/services/files/public/link/download/abcd1234");
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -75,7 +75,7 @@ class UpdatePublicLinkApiIT {
 
   void createFolder(String nodeId, String ownerId) {
     nodeRepository.createNewNode(
-      nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
@@ -190,54 +190,53 @@ class UpdatePublicLinkApiIT {
 
   @Test
   void
-  givenAnExistingFolderAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
+      givenAnExistingFolderAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     linkRepository.createLink(
-      "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
-      "00000000-0000-0000-0000-000000000000",
-      "abcd1234abcd1234abcd1234abcd1234",
-      Optional.empty(),
-      Optional.empty());
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
 
     final String bodyPayload =
-      "mutation { "
-        + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 10, description: \\\"another-description\\\") {"
-        + "id "
-        + "url "
-        + "expires_at "
-        + "created_at "
-        + "description "
-        + "node { "
-        + "  id "
-        + "} "
-        + "} "
-        + "}";
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 10, description: \\\"another-description\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
 
     final HttpRequest httpRequest =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
     final Map<String, Object> updatedLink =
-      TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat((String) updatedLink.get("url"))
-      .isEqualTo(
-        "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234");
+        .isEqualTo("example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
-      .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
-      .containsEntry("expires_at", 10)
-      .containsEntry("description", "another-description");
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", 10)
+        .containsEntry("description", "another-description");
 
     Assertions.assertThat((Map<String, Object>) updatedLink.get("node"))
-      .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
   }
 
   @Test
@@ -300,40 +299,39 @@ class UpdatePublicLinkApiIT {
 
   @Test
   void
-  givenAnExistingNodeAnExistingLinkWithExpirationAndAnExpiresAtToZeroTheUpdateLinkShouldReturnAnUpdatedLinkWithoutExpiration() {
+      givenAnExistingNodeAnExistingLinkWithExpirationAndAnExpiresAtToZeroTheUpdateLinkShouldReturnAnUpdatedLinkWithoutExpiration() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
     linkRepository.createLink(
-      "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
-      "00000000-0000-0000-0000-000000000000",
-      "abcd1234abcd1234abcd1234abcd1234",
-      Optional.of(5L),
-      Optional.empty());
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(5L),
+        Optional.empty());
 
     final String bodyPayload =
-      "mutation { "
-        + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 0) {"
-        + "id "
-        + "expires_at"
-        + "}"
-        + "}";
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 0) {"
+            + "id "
+            + "expires_at"
+            + "}"
+            + "}";
     final HttpRequest httpRequest =
-      HttpRequest.of(
-        "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
     final Map<String, Object> updatedLink =
-      TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat(updatedLink)
-      .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
-      .containsEntry("expires_at", null);
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", null);
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -30,19 +29,19 @@ import org.mockito.Mockito;
 
 class HttpRoutingHandlerTest {
 
-  private HealthController            healthControllerMock;
-  private GraphQLController           graphQLControllerMock;
-  private BlobController              blobControllerMock;
-  private AuthenticationHandler       authenticationHandlerMock;
-  private ExceptionsHandler           exceptionsHandlerMock;
-  private PreviewController           previewControllerMock;
-  private ProcedureController         procedureControllerMock;
+  private HealthController healthControllerMock;
+  private GraphQLController graphQLControllerMock;
+  private BlobController blobControllerMock;
+  private AuthenticationHandler authenticationHandlerMock;
+  private ExceptionsHandler exceptionsHandlerMock;
+  private PreviewController previewControllerMock;
+  private ProcedureController procedureControllerMock;
   private CollaborationLinkController collaborationLinkControllerMock;
-  private MetricsController           metricsControllerMock;
-  private ChannelHandlerContext       channelHandlerContextMock;
-  private ChannelPipeline             channelPipelineMock;
-  private HttpRequest                 httpRequestMock;
-  private HttpRoutingHandler          httpRoutingHandler;
+  private MetricsController metricsControllerMock;
+  private ChannelHandlerContext channelHandlerContextMock;
+  private ChannelPipeline channelPipelineMock;
+  private HttpRequest httpRequestMock;
+  private HttpRoutingHandler httpRoutingHandler;
 
   @BeforeEach
   void initTest() {
@@ -60,346 +59,288 @@ class HttpRoutingHandlerTest {
     httpRequestMock = Mockito.mock(HttpRequest.class);
 
     Mockito.when(channelHandlerContextMock.pipeline()).thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.anyString(), Mockito.any(ChannelHandler.class)))
-      .thenReturn(channelPipelineMock);
+    Mockito.when(
+            channelPipelineMock.addLast(Mockito.anyString(), Mockito.any(ChannelHandler.class)))
+        .thenReturn(channelPipelineMock);
 
-    httpRoutingHandler = new HttpRoutingHandler(
-      healthControllerMock,
-      graphQLControllerMock,
-      blobControllerMock,
-      authenticationHandlerMock,
-      exceptionsHandlerMock,
-      previewControllerMock,
-      procedureControllerMock,
-      collaborationLinkControllerMock,
-      metricsControllerMock
-    );
+    httpRoutingHandler =
+        new HttpRoutingHandler(
+            healthControllerMock,
+            graphQLControllerMock,
+            blobControllerMock,
+            authenticationHandlerMock,
+            exceptionsHandlerMock,
+            previewControllerMock,
+            procedureControllerMock,
+            collaborationLinkControllerMock,
+            metricsControllerMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/metrics/", "/metrics"})
-  void givenAMetricsRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAMetricsRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("metrics-handler", metricsControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("metrics-handler", metricsControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/health/",
-    "/health",
-    "/health/live",
-    "/health/live/",
-    "/health/ready",
-    "/health/ready/"
-  })
-  void givenAnHealthRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/health/",
+        "/health",
+        "/health/live",
+        "/health/live/",
+        "/health/ready",
+        "/health/ready/"
+      })
+  void givenAnHealthRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("health-handler", healthControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("health-handler", healthControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/graphql/", "/graphql"})
-  void givenAGraphqlRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAGraphqlRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(HttpObjectAggregator.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(ChunkedWriteHandler.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("graphql-handler", graphQLControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(HttpObjectAggregator.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(ChunkedWriteHandler.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("graphql-handler", graphQLControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/upload",
-    "/upload/",
-    "/upload-version",
-    "/upload-version/"
-  })
-  void givenAnUploadOrDownloadRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/upload",
+        "/upload/",
+        "/upload-version",
+        "/upload-version/"
+      })
+  void
+      givenAnUploadOrDownloadRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+          String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("rest-handler", blobControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("rest-handler", blobControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/link/abcd1234",
-    "/link/abcd1234/",
-    "/link/abcd1234abcd1234abcd1234abcd1234",
-    "/link/abcd1234abcd1234abcd1234abcd1234/",
-    "/public/link/download/abcd1234",
-    "/public/link/download/abcd1234/",
-    "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
-    "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
-  })
-  void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/link/abcd1234",
+        "/link/abcd1234/",
+        "/link/abcd1234abcd1234abcd1234abcd1234",
+        "/link/abcd1234abcd1234abcd1234abcd1234/",
+        "/public/link/download/abcd1234",
+        "/public/link/download/abcd1234/",
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
+      })
+  void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("rest-handler", blobControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("rest-handler", blobControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/invite/abcd1234",
-    "/invite/abcd1234/"
-  })
-  void givenAnInvitationLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(strings = {"/invite/abcd1234", "/invite/abcd1234/"})
+  void givenAnInvitationLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("collaboration-link-handler", collaborationLinkControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("collaboration-link-handler", collaborationLinkControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   // The main regex for the Preview endpoint is "/preview/(.*)"
   // However I listed all the acceptable url even if the pattern accepts everything
-  @ValueSource(strings = {
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/"
-  })
-  void givenAPreviewRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/"
+      })
+  void givenAPreviewRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("preview-handler", previewControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("preview-handler", previewControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/upload-to/", "/upload-to"})
-  void givenAnUploadToModuleRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAnUploadToModuleRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(HttpObjectAggregator.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(ChunkedWriteHandler.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("procedure-handler", procedureControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(HttpObjectAggregator.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(ChunkedWriteHandler.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("procedure-handler", procedureControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/invalid/endpoint",
-    "/metrics/invalid",
-    "/health/invalid",
-    "/health/live/invalid",
-    "/health/ready/invalid",
-    "/graphql/invalid",
-    "/download/invalid",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/invalid",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/invalid",
-    "/upload/invalid",
-    "/upload-version/invalid",
-    "/link/abcd1234/invalid",
-    "/link/seven00",
-    "/link/seven00/",
-    "/link/nine00000",
-    "/link/nine00000/",
-    "/link/thirtythreethirtythreethirtythree",
-    "/link/thirtythreethirtythreethirtythree/",
-    "/public/link/download/abcd1234/invalid",
-    "/public/link/download/seven00",
-    "/public/link/download/seven00/",
-    "/public/link/download/nine00000",
-    "/public/link/download/nine00000/",
-    "/public/link/download/thirtythreethirtythreethirtythree",
-    "/public/link/download/thirtythreethirtythreethirtythree/",
-    "/invite/abcd1234/invalid",
-    "/upload-to/invalid"
-  })
+  @ValueSource(
+      strings = {
+        "/invalid/endpoint",
+        "/metrics/invalid",
+        "/health/invalid",
+        "/health/live/invalid",
+        "/health/ready/invalid",
+        "/graphql/invalid",
+        "/download/invalid",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/invalid",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/invalid",
+        "/upload/invalid",
+        "/upload-version/invalid",
+        "/link/abcd1234/invalid",
+        "/link/seven00",
+        "/link/seven00/",
+        "/link/nine00000",
+        "/link/nine00000/",
+        "/link/thirtythreethirtythreethirtythree",
+        "/link/thirtythreethirtythreethirtythree/",
+        "/public/link/download/abcd1234/invalid",
+        "/public/link/download/seven00",
+        "/public/link/download/seven00/",
+        "/public/link/download/nine00000",
+        "/public/link/download/nine00000/",
+        "/public/link/download/thirtythreethirtythreethirtythree",
+        "/public/link/download/thirtythreethirtythreethirtythree/",
+        "/invite/abcd1234/invalid",
+        "/upload-to/invalid"
+      })
   void givenAnInvalidEndpointRequestHttpRoutingHandlerShouldRespondWith404(String invalidUri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(invalidUri);
-    Mockito
-      .when(httpRequestMock.protocolVersion())
-      .thenReturn(HttpVersion.HTTP_1_1);
+    Mockito.when(httpRequestMock.uri()).thenReturn(invalidUri);
+    Mockito.when(httpRequestMock.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
 
-    ArgumentCaptor<FullHttpResponse> captorHttpResponse = ArgumentCaptor.forClass(FullHttpResponse.class);
+    ArgumentCaptor<FullHttpResponse> captorHttpResponse =
+        ArgumentCaptor.forClass(FullHttpResponse.class);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .writeAndFlush(captorHttpResponse.capture());
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .close();
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1))
+        .writeAndFlush(captorHttpResponse.capture());
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).close();
 
-    Assertions
-      .assertThat(captorHttpResponse.getValue().protocolVersion())
-      .isEqualTo(HttpVersion.HTTP_1_1);
-    Assertions
-      .assertThat(captorHttpResponse.getValue().status())
-      .isEqualTo(HttpResponseStatus.NOT_FOUND);
+    Assertions.assertThat(captorHttpResponse.getValue().protocolVersion())
+        .isEqualTo(HttpVersion.HTTP_1_1);
+    Assertions.assertThat(captorHttpResponse.getValue().status())
+        .isEqualTo(HttpResponseStatus.NOT_FOUND);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -208,7 +208,11 @@ class HttpRoutingHandlerTest {
     "/link/abcd1234",
     "/link/abcd1234/",
     "/link/abcd1234abcd1234abcd1234abcd1234",
-    "/link/abcd1234abcd1234abcd1234abcd1234/"
+    "/link/abcd1234abcd1234abcd1234abcd1234/",
+    "/public/link/download/abcd1234",
+    "/public/link/download/abcd1234/",
+    "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
+    "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
   })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
     // Given
@@ -359,6 +363,13 @@ class HttpRoutingHandlerTest {
     "/link/nine00000/",
     "/link/thirtythreethirtythreethirtythree",
     "/link/thirtythreethirtythreethirtythree/",
+    "/public/link/download/abcd1234/invalid",
+    "/public/link/download/seven00",
+    "/public/link/download/seven00/",
+    "/public/link/download/nine00000",
+    "/public/link/download/nine00000/",
+    "/public/link/download/thirtythreethirtythreethirtythree",
+    "/public/link/download/thirtythreethirtythreethirtythree/",
     "/invite/abcd1234/invalid",
     "/upload-to/invalid"
   })


### PR DESCRIPTION
- Enabled the creation of a public link to folder (in the LinkDataFetchers)
- Updated how the public url is returned based on the type of the node:
  - if the node is a file then the public url should be /services/files/public/link/download/<hash>
  - if the node is a folder then the public url should be /files/public/link/access/<hash>
- Updated the routing to accept the new public link url: for now it remains attached to the same BlobController.

Refs: FILES-731