### PR TITLE
refactor: move download blob via public link on a separate controller

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -13,6 +13,7 @@ import com.zextras.carbonio.files.rest.controllers.HealthController;
 import com.zextras.carbonio.files.rest.controllers.MetricsController;
 import com.zextras.carbonio.files.rest.controllers.PreviewController;
 import com.zextras.carbonio.files.rest.controllers.ProcedureController;
+import com.zextras.carbonio.files.rest.controllers.PublicBlobController;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -33,6 +34,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
   private final HealthController            healthController;
   private final GraphQLController           graphQLController;
   private final BlobController              blobController;
+  private final PublicBlobController        publicBlobController;
   private final AuthenticationHandler       authenticationHandler;
   private final ExceptionsHandler           exceptionsHandler;
   private final PreviewController           previewController;
@@ -45,6 +47,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     HealthController healthController,
     GraphQLController graphQLController,
     BlobController blobController,
+    PublicBlobController publicBlobController,
     AuthenticationHandler authenticationHandler,
     ExceptionsHandler exceptionsHandler,
     PreviewController previewController,
@@ -58,6 +61,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     this.exceptionsHandler = exceptionsHandler;
     this.graphQLController = graphQLController;
     this.blobController = blobController;
+    this.publicBlobController = publicBlobController;
     this.previewController = previewController;
     this.procedureController = procedureController;
     this.collaborationLinkController = collaborationLinkController;
@@ -113,7 +117,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
       || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
       context.pipeline()
-        .addLast("rest-handler", blobController)
+        .addLast("rest-handler", publicBlobController)
         .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;

--- a/core/src/main/java/com/zextras/carbonio/files/netty/utilities/HttpResponseBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/utilities/HttpResponseBuilder.java
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.netty.utilities;
+
+import com.zextras.carbonio.files.rest.types.BlobResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.vavr.control.Try;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class HttpResponseBuilder {
+
+  /**
+   * Allows to create a {@link DefaultHttpResponse} containing all the following headers:
+   *
+   * <ul>
+   *   <li>{@link HttpHeaderNames#CONNECTION} to close
+   *   <li>{@link HttpHeaderNames#CONTENT_LENGTH} of the blob to download
+   *   <li>{@link HttpHeaderNames#CONTENT_TYPE} of the blob to download
+   *   <li>{@link HttpHeaderNames#CONTENT_DISPOSITION} with the filename of the blob to download
+   * </ul>
+   *
+   * @param blobResponse is a {@link BlobResponse} containing all the related attributes of the blob
+   *     to download.
+   * @return a {@link HttpResponse} containing all the necessary headers of the blob to download.
+   */
+  public static HttpResponse createSuccessDownloadHttpResponse(BlobResponse blobResponse) {
+    final String encodedFilename =
+        Try.of(() -> URLEncoder.encode(blobResponse.getFilename(), StandardCharsets.UTF_8))
+            .getOrElseThrow(
+                failure -> {
+                  String errorMessage =
+                      String.format(
+                          "Unable to encode node filename %s to download",
+                          blobResponse.getFilename());
+                  return new IllegalArgumentException(errorMessage, failure);
+                });
+
+    DefaultHttpHeaders headers = new DefaultHttpHeaders(true);
+    headers.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+    headers.add(HttpHeaderNames.CONTENT_LENGTH, blobResponse.getSize());
+    headers.add(HttpHeaderNames.CONTENT_TYPE, blobResponse.getMimeType());
+    headers.add(
+        HttpHeaderNames.CONTENT_DISPOSITION,
+        String.format("attachment; filename*=UTF-8''%s", encodedFilename));
+
+    return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, headers);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.controllers;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files.API.Endpoints;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.netty.utilities.HttpResponseBuilder;
+import com.zextras.carbonio.files.netty.utilities.NettyBufferWriter;
+import com.zextras.carbonio.files.rest.services.BlobService;
+import com.zextras.carbonio.files.rest.types.BlobResponse;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpRequest;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ChannelHandler.Sharable
+public class PublicBlobController extends SimpleChannelInboundHandler<HttpRequest> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PublicBlobController.class);
+
+  private final BlobService blobService;
+
+  @Inject
+  public PublicBlobController(BlobService blobService) {
+    this.blobService = blobService;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext context, HttpRequest httpRequest) {
+    try {
+      final Matcher publicLinkMatcher = Endpoints.PUBLIC_LINK.matcher(httpRequest.uri());
+      final Matcher downloadViaPublicLinkMatcher =
+          Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(httpRequest.uri());
+
+      if (publicLinkMatcher.find()) {
+        downloadByPublicLink(context, httpRequest, publicLinkMatcher);
+        return;
+      }
+
+      if (downloadViaPublicLinkMatcher.find()) {
+        downloadByPublicLink(context, httpRequest, downloadViaPublicLinkMatcher);
+        return;
+      }
+
+      context.fireExceptionCaught(new BadRequestException());
+
+    } catch (Exception exception) {
+      logger.error("PublicBlobController catches an exception", exception);
+      context.fireExceptionCaught(exception);
+    }
+  }
+
+  void downloadByPublicLink(
+      ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched) {
+
+    final String publicLinkId = uriMatched.group(1);
+    final Optional<BlobResponse> blobResponse = blobService.downloadFileByLink(publicLinkId);
+
+    if (blobResponse.isPresent()) {
+      context.write(HttpResponseBuilder.createSuccessDownloadHttpResponse(blobResponse.get()));
+      new NettyBufferWriter(context)
+          .writeStream(blobResponse.get().getBlobStream(), context.newPromise());
+      return;
+    }
+
+    final String errorMessage =
+        String.format(
+            "Request %s: the link and/or the node associated to it does not exist",
+            httpRequest.uri());
+
+    context.fireExceptionCaught(new NoSuchElementException(errorMessage));
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -264,6 +264,10 @@ public class Simulator implements AutoCloseable {
     return userManagementMock;
   }
 
+  public MockServerClient getStoragesMock() {
+    return storagesMock;
+  }
+
   public EmbeddedChannel getNettyChannel() {
     return new EmbeddedChannel(injector.getInstance(HttpRoutingHandler.class));
   }

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -12,9 +12,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
@@ -131,10 +132,14 @@ public class TestUtils {
     fullHttpRequest.retain(1);
     nettyChannel.writeInbound(fullHttpRequest);
 
-    final FullHttpResponse fullHttpResponse = nettyChannel.readOutbound();
+    final DefaultHttpResponse defaultHttpResponse = nettyChannel.readOutbound();
 
-    return HttpResponse.of(
-        fullHttpResponse.status().code(),
-        fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+    if (defaultHttpResponse instanceof DefaultFullHttpResponse fullHttpResponse) {
+      return HttpResponse.of(
+          fullHttpResponse.status().code(),
+          fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+    }
+
+    return HttpResponse.of(defaultHttpResponse.status().code(), null);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockserver.model.HttpError;
+import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
+
+public class DownloadByPublicLinkApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            .withStorages()
+            .build()
+            .start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+    simulator.getStoragesMock().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "abcd1234,/public/link/download/,",
+    "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,",
+    "abcd1234,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,fake-token",
+    "abcd1234abcd1234abcd1234abcd1234,/link/,fake-token",
+  })
+  void
+      givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedTheDownloadByPublicLinkShouldReturnTheBlob(
+          String publicLinkId, String publicLinkEndpoint, String userToken) {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "test.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        10L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        10L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        publicLinkId,
+        Optional.empty(),
+        Optional.empty());
+
+    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+
+    final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
+    HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download")
+                .withQueryStringParameter(
+                    Parameter.param("node", "00000000-0000-0000-0000-000000000000"))
+                .withQueryStringParameter(Parameter.param("version", "1"))
+                .withQueryStringParameter(Parameter.param("type", "files")),
+            VerificationTimes.once());
+  }
+
+  @Test
+  void givenANotExistingLinkTheDownloadByPublicLinkShouldReturnA404StatusCode() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "file.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        1L);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        "000000",
+        Optional.empty(),
+        Optional.empty());
+
+    HttpRequest httpRequest = HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"),
+            VerificationTimes.never());
+  }
+
+  @Test
+  void givenANotExistingNodeTheDownloadByPublicLinkShouldReturnA404StatusCode() {
+    // Given
+    HttpRequest httpRequest = HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"),
+            VerificationTimes.never());
+  }
+
+  @Test
+  void t() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "test.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        10L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        10L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd1234abcd1234abcd1234abcd",
+        Optional.empty(),
+        Optional.empty());
+
+    simulator
+        .getStoragesMock()
+        .when(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"))
+        .error(HttpError.error().withDropConnection(true));
+
+    // When
+    HttpRequest httpRequest =
+        HttpRequest.of("GET", "/public/link/download/1234abcd1234abcd1234abcd1234abcd", null, null);
+
+    // Then
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -11,6 +11,7 @@ import com.zextras.carbonio.files.rest.controllers.HealthController;
 import com.zextras.carbonio.files.rest.controllers.MetricsController;
 import com.zextras.carbonio.files.rest.controllers.PreviewController;
 import com.zextras.carbonio.files.rest.controllers.ProcedureController;
+import com.zextras.carbonio.files.rest.controllers.PublicBlobController;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -32,6 +33,7 @@ class HttpRoutingHandlerTest {
   private HealthController healthControllerMock;
   private GraphQLController graphQLControllerMock;
   private BlobController blobControllerMock;
+  private PublicBlobController publicBlobController;
   private AuthenticationHandler authenticationHandlerMock;
   private ExceptionsHandler exceptionsHandlerMock;
   private PreviewController previewControllerMock;
@@ -48,6 +50,7 @@ class HttpRoutingHandlerTest {
     healthControllerMock = Mockito.mock(HealthController.class);
     graphQLControllerMock = Mockito.mock(GraphQLController.class);
     blobControllerMock = Mockito.mock(BlobController.class);
+    publicBlobController = Mockito.mock(PublicBlobController.class);
     authenticationHandlerMock = Mockito.mock(AuthenticationHandler.class);
     exceptionsHandlerMock = Mockito.mock(ExceptionsHandler.class);
     previewControllerMock = Mockito.mock(PreviewController.class);
@@ -68,6 +71,7 @@ class HttpRoutingHandlerTest {
             healthControllerMock,
             graphQLControllerMock,
             blobControllerMock,
+            publicBlobController,
             authenticationHandlerMock,
             exceptionsHandlerMock,
             previewControllerMock,
@@ -201,7 +205,7 @@ class HttpRoutingHandlerTest {
 
     // Then
     Mockito.verify(channelPipelineMock, Mockito.times(1))
-        .addLast("rest-handler", blobControllerMock);
+        .addLast("rest-handler", publicBlobController);
     Mockito.verify(channelPipelineMock, Mockito.times(1))
         .addLast("exceptions-handler", exceptionsHandlerMock);
     Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);


### PR DESCRIPTION
- Created PublicBlobController to handle the download by public link requests. This controller can be used without authentication
- Created ITs to test the download blob via public link API

Refs: FILES-737