### PR TITLE
feat: expose public GraphQL schema

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -334,6 +334,7 @@ public final class Files {
       public static final String GET_ACCOUNT_BY_EMAIL    = "getAccountByEmail";
       public static final String GET_ACCOUNTS_BY_EMAIL   = "getAccountsByEmail";
       public static final String GET_CONFIGS             = "getConfigs";
+      public static final String GET_PUBLIC_NODE         = "getPublicNode";
     }
 
     /**
@@ -738,6 +739,7 @@ public final class Files {
       public static final Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
         SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
+      public static final Pattern PUBLIC_GRAPHQL             = Pattern.compile(SERVICE + "public/graphql/?$");
     }
 
     public static final class Headers {

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.zextras.carbonio.files.Files.GraphQL.NodePage;
+import com.zextras.carbonio.files.Files.GraphQL.Queries;
+import com.zextras.carbonio.files.Files.GraphQL.Types;
+import com.zextras.carbonio.files.graphql.datafetchers.DateTimeScalar;
+import com.zextras.carbonio.files.graphql.datafetchers.PublicNodeDataFetchers;
+import graphql.GraphQL;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/**
+ * Setups the GraphQL instance with all the necessary properties. A GraphQL instance is necessary to
+ * handle and execute every single request. It knows:
+ *
+ * <ul>
+ *   <li>which is the right schema of reference
+ *   <li>how to validate the input
+ *   <li>which {@link DataFetcher} need to be called
+ * </ul>
+ */
+@Singleton
+public class PublicGraphQLProvider {
+
+  private static final String SCHEMA_URL = "/api/public-schema.graphql";
+
+  private final GraphQL graphQL;
+  private final PublicNodeDataFetchers publicNodeDataFetchers;
+
+  @Inject
+  public PublicGraphQLProvider(PublicNodeDataFetchers publicNodeDataFetchers) {
+    this.publicNodeDataFetchers = publicNodeDataFetchers;
+    graphQL = this.setup();
+  }
+
+  /**
+   * Creates the GraphQL instance building the following properties:
+   *
+   * <ul>
+   *   <li>{@link RuntimeWiring}: it links each interface, query and mutation with the related
+   *       {@link DataFetcher}
+   *   <li>{@link GraphQLSchema}: the schema definition file is imported from the resources
+   *   <li>Execution strategy: how the execution of a request is performed (async or not)
+   * </ul>
+   *
+   * @return {@link GraphQL}
+   */
+  private GraphQL setup() {
+    return GraphQL.newGraphQL(buildSchema(buildWiring()))
+        .queryExecutionStrategy(new AsyncExecutionStrategy())
+        .build();
+  }
+
+  /**
+   * Creates a {@link RuntimeWiring} object associating a specific {@link DataFetcher} to one of
+   * these GraphQL components:
+   *
+   * <ul>
+   *   <li>Interface
+   *   <li>Query
+   * </ul>
+   *
+   * @return a {@link RuntimeWiring} instance.
+   */
+  private RuntimeWiring buildWiring() {
+    return RuntimeWiring.newRuntimeWiring()
+        .scalar(new DateTimeScalar().graphQLScalarType())
+        .type(
+            newTypeWiring(Types.NODE_TYPE).enumValues(publicNodeDataFetchers.getNodeTypeResolver()))
+        .type(
+            newTypeWiring(Types.NODE_INTERFACE)
+                .typeResolver(publicNodeDataFetchers.getNodeInterfaceResolver()))
+        .type(
+            newTypeWiring(Types.NODE_PAGE)
+                .dataFetcher(NodePage.NODES, publicNodeDataFetchers.findNodesByNodePage()))
+        .type(
+            newTypeWiring("Query")
+                .dataFetcher(Queries.GET_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
+                .dataFetcher(Queries.FIND_NODES, publicNodeDataFetchers.findNodes()))
+        .build();
+  }
+
+  /**
+   * Imports the GraphQL schema file (from res folder) and creates the {@link GraphQLSchema} object
+   * associating the schema file with the RuntimeWiring object.
+   *
+   * @param wiring is a {@link RuntimeWiring} that contains the association between the GraphQL
+   *     components and their specific {@link DataFetcher}s.
+   * @return the {@link GraphQLSchema}.
+   */
+  private GraphQLSchema buildSchema(RuntimeWiring wiring) {
+    // Fetch the content of the GraphQL schema file into an InputStreamReader
+    InputStream inputStream = getClass().getResourceAsStream(SCHEMA_URL);
+
+    if (inputStream == null) {
+      throw new RuntimeException(String.format("The resource %s does not exist", SCHEMA_URL));
+    }
+
+    Reader schema = new InputStreamReader(inputStream);
+
+    // Create the GraphQLSchema object
+    return new SchemaGenerator().makeExecutableSchema(new SchemaParser().parse(schema), wiring);
+  }
+
+  public GraphQL getGraphQL() {
+    return this.graphQL;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.graphql.GraphQLRequest;
+import com.zextras.carbonio.files.graphql.PublicGraphQLProvider;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the entry-point of the Files Public GraphQL API that is accessible without
+ * authentication token. The main purpose is to:
+ *
+ * <ul>
+ *   <li>Receive a json request
+ *   <li>Parse the request creating a {@link GraphQLRequest}
+ *   <li>Execute the request via {@link GraphQL}
+ *   <li>Return the response with the JSON data requested or an error
+ * </ul>
+ */
+@ChannelHandler.Sharable
+@Singleton
+public class PublicGraphQLController extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PublicGraphQLController.class);
+
+  private final GraphQL publicGraphQL;
+
+  @Inject
+  public PublicGraphQLController(PublicGraphQLProvider publicGraphQLProvider) {
+    super(true);
+    this.publicGraphQL = publicGraphQLProvider.getGraphQL();
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext context, FullHttpRequest httpRequest) {
+    try {
+      GraphQLRequest request = parseRequest(httpRequest.content());
+      /*
+       * The ExecutionInput object represents the input of the request, it has the following fields:
+       *   - Query: the actual request to execute
+       *   - Variables: the input values of the request (optional)
+       *   - OperationName: the name of the request to execute (optional)
+       */
+      ExecutionInput input =
+          ExecutionInput.newExecutionInput()
+              .query(request.getRequest())
+              .variables(request.getVariables())
+              .operationName(request.getOperationName().orElse(""))
+              .build();
+
+      ExecutionResult executionResult = publicGraphQL.executeAsync(input).join();
+      String bodyResponse =
+          new ObjectMapper().writeValueAsString(executionResult.toSpecification());
+
+      FullHttpResponse response =
+          new DefaultFullHttpResponse(
+              httpRequest.protocolVersion(),
+              HttpResponseStatus.OK,
+              Unpooled.wrappedBuffer(bodyResponse.getBytes(StandardCharsets.UTF_8)));
+
+      response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+      response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+      httpRequest.retain();
+      context.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+
+    } catch (GraphQLRequest.InvalidPayloadRequestError | GraphQLException exception) {
+      logger.error("PublicGraphQLController catches an exception handling the request", exception);
+      context.fireExceptionCaught(new BadRequestException());
+    }
+    // Catching the RuntimeException and the JsonProcessingException
+    catch (Exception exception) {
+      logger.error("PublicGraphQLController catches an exception", exception);
+      context.fireExceptionCaught(exception);
+    }
+  }
+
+  private GraphQLRequest parseRequest(ByteBuf contentRequest)
+      throws GraphQLRequest.InvalidPayloadRequestError {
+    if (contentRequest == null || contentRequest.writerIndex() == 0) {
+      throw new GraphQLRequest.InvalidPayloadRequestError(
+          "The payload of a GraphQL request cannot be empty");
+    }
+    try {
+      String payloadString = contentRequest.toString(StandardCharsets.UTF_8);
+      return GraphQLRequest.buildFromPayload(payloadString);
+    } catch (Exception exception) {
+      throw new GraphQLRequest.InvalidPayloadRequestError(
+          "The payload of a GraphQL request cannot be parsed");
+    }
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.datafetchers;
+
+import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.EnumValuesProvider;
+import java.util.Collections;
+import java.util.Map;
+
+public class PublicNodeDataFetchers {
+
+  /**
+   * This {@link TypeResolver} checks which type of Node was requested. The type can be a File or a
+   * Folder.
+   *
+   * @return a {@link TypeResolver} that resolve the type of Node requested.
+   */
+  public TypeResolver getNodeInterfaceResolver() {
+    return environment -> {
+      Map<String, Object> result = environment.getObject();
+      return (result.get(Files.GraphQL.Node.TYPE).equals(NodeType.FOLDER)
+              || result.get(Files.GraphQL.Node.TYPE).equals(NodeType.ROOT))
+          ? (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FOLDER)
+          : (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FILE);
+    };
+  }
+
+  public EnumValuesProvider getNodeTypeResolver() {
+    return NodeType::valueOf;
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> getNodeByPublicLinkId() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> findNodes() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> findNodesByNodePage() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+}

--- a/core/src/main/resources/api/public-schema.graphql
+++ b/core/src/main/resources/api/public-schema.graphql
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Public Files API - GraphQL Schema v. 0.0.1
+
+# The Scalar type represents the date on the timestamp EPOCH format
+scalar DateTime
+
+#Definition of NodeType enumerator. This is used for discriminating the specific type of a node
+enum NodeType {
+    IMAGE
+    VIDEO
+    AUDIO
+    TEXT
+    SPREADSHEET
+    PRESENTATION
+    FOLDER
+    APPLICATION
+    MESSAGE
+    OTHER
+}
+
+# Definition of the Node interface
+interface Node {
+    # Unique identifier of the node
+    id: ID!
+
+    # Node creation timestamp
+    created_at: DateTime!
+
+    # Node update timestamp
+    updated_at: DateTime!
+
+    # Name of the node
+    name: String!
+
+    # Type of the node
+    type: NodeType!
+}
+
+# Definition of the Folder type which implements the Node interface
+type Folder implements Node {
+    # Unique identifier of the folder
+    id: ID!
+
+    # Folder creation timestamp
+    created_at: DateTime!
+
+    # Folder update timestamp
+    updated_at: DateTime!
+
+    # Name of the folder
+    name: String!
+
+    # Type of the folder
+    type: NodeType!
+}
+
+# Definition of the File type which implements the Node interface
+type File implements Node {
+    # Unique identifier of the file
+    id: ID!
+
+    # File creation timestamp
+    created_at: DateTime!
+
+    # File update timestamp
+    updated_at: DateTime!
+
+    # Name of the file
+    name: String!
+
+    # Extension of the file
+    extension: String
+
+    # Type of the file
+    type: NodeType!
+
+    # Mime type of the file
+    mime_type: String!
+
+    # Size of the file
+    size: Float!
+}
+
+# Represents a page of node list. It contains a list of nodes of the current page
+# and a token necessary to request the next page of nodes
+type NodePage {
+    # The list of nodes of the requested page
+    nodes: [Node]!
+
+    # The token to use as a cursor for requesting the next page of nodes
+    page_token: String
+}
+
+type Query {
+    # <strong>Returns a Node associated to a given public link identifier</strong>
+    getPublicNode(
+        node_link_id: String!
+    ) : Node
+
+    # <strong>Returns a NodePage based on the given criteria</strong>
+    findNodes(
+        # It searches nodes starting from the given folder
+        folder_id: ID!
+        # If valued it limits the number of nodes to return per page
+        limit: Int
+        # If valued it will return the next page of nodes based on the given page_token,
+        # if this param is passed all other params will be ignored
+        page_token: String
+    ) : NodePage
+}
+
+schema {
+    query: Query
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class GetPublicNodeApiIT {
+
+  static Simulator simulator;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  @Test
+  void givenAPublicLinkIdAndAnExistingNodeTheGetPublicNodeShouldReturnTheNode() {
+    // Given
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
+            + "id "
+            + "created_at "
+            + "updated_at "
+            + "name "
+            + "type "
+            + "} "
+            + "}";
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(
+            TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode"))
+        .isEmpty();
+  }
+}


### PR DESCRIPTION
- Defined the public GraphqQL schema
- Impletemented the PublicGraphQLController to expose the /public/graphql/ endpoint
- Implemented the PublicGraphQLProvider to set up the GraphQL instance and to define the association between each API to the related datafetcher
- Added a draft of PublicNodeDataFetchers class to test the /public/graphql/ endpoint
- Attached the PublicGraphQLController to the HttpRoutingHandler to route requests to the right handler

Refs: FILES-748