### PR TITLE
feat: implement GetPublicNode API

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -544,6 +544,13 @@ public final class Files {
 
         public static final String COLLABORATION_LINK_IDS = "collaboration_link_ids";
       }
+
+      public static final class GetPublicNode {
+
+        private GetPublicNode() {}
+
+        public static final String NODE_LINK_ID = "node_link_id";
+      }
     }
 
     /**
@@ -683,6 +690,23 @@ public final class Files {
 
       public static final String NAME  = "name";
       public static final String VALUE = "value";
+    }
+
+    /**
+     * Attributes name for the type Node exposed by Public API
+     */
+    public static final class PublicNode {
+
+      private PublicNode() {}
+
+      public static final String ID         = "id";
+      public static final String CREATED_AT = "created_at";
+      public static final String UPDATED_AT = "updated_at";
+      public static final String NAME       = "name";
+      public static final String EXTENSION  = "extension";
+      public static final String TYPE       = "type";
+      public static final String MIME_TYPE  = "mime_type";
+      public static final String SIZE       = "size";
     }
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
@@ -90,7 +90,8 @@ public class PublicGraphQLProvider {
                 .dataFetcher(NodePage.NODES, publicNodeDataFetchers.findNodesByNodePage()))
         .type(
             newTypeWiring("Query")
-                .dataFetcher(Queries.GET_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
+                .dataFetcher(
+                    Queries.GET_PUBLIC_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
                 .dataFetcher(Queries.FIND_NODES, publicNodeDataFetchers.findNodes()))
         .build();
   }

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -4,17 +4,34 @@
 
 package com.zextras.carbonio.files.graphql.datafetchers;
 
+import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.GraphQL.InputParameters.GetPublicNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.graphql.errors.GraphQLResultErrors;
+import com.zextras.carbonio.files.graphql.types.PublicNode;
 import graphql.execution.DataFetcherResult;
+import graphql.execution.ResultPath;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.EnumValuesProvider;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class PublicNodeDataFetchers {
+
+  private final NodeRepository nodeRepository;
+  private final LinkRepository linkRepository;
+
+  @Inject
+  public PublicNodeDataFetchers(NodeRepository nodeRepository, LinkRepository linkRepository) {
+    this.nodeRepository = nodeRepository;
+    this.linkRepository = linkRepository;
+  }
 
   /**
    * This {@link TypeResolver} checks which type of Node was requested. The type can be a File or a
@@ -36,9 +53,35 @@ public class PublicNodeDataFetchers {
     return NodeType::valueOf;
   }
 
-  public DataFetcher<DataFetcherResult<Map<String, String>>> getNodeByPublicLinkId() {
+  public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, Object>>>>
+      getNodeByPublicLinkId() {
     return environment ->
-        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+        CompletableFuture.supplyAsync(
+            () -> {
+              ResultPath path = environment.getExecutionStepInfo().getPath();
+              String publicLinkId = environment.getArgument(GetPublicNode.NODE_LINK_ID);
+              return linkRepository
+                  .getLinkByPublicId(publicLinkId)
+                  .map(
+                      publicLink ->
+                          nodeRepository
+                              .getNode(publicLink.getNodeId())
+                              .map(
+                                  node ->
+                                      DataFetcherResult.<Map<String, Object>>newResult()
+                                          .data(PublicNode.createFromNode(node).convertToMap())
+                                          .build())
+                              .orElse(
+                                  DataFetcherResult.<Map<String, Object>>newResult()
+                                      .error(
+                                          GraphQLResultErrors.nodeNotFound(
+                                              publicLink.getNodeId(), path))
+                                      .build()))
+                  .orElse(
+                      DataFetcherResult.<Map<String, Object>>newResult()
+                          .error(GraphQLResultErrors.linkNotFound(publicLinkId, path))
+                          .build());
+            });
   }
 
   public DataFetcher<DataFetcherResult<Map<String, String>>> findNodes() {

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/types/PublicNode.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/types/PublicNode.java
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.types;
+
+import com.zextras.carbonio.files.Files.GraphQL;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeCategory;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PublicNode {
+
+  private final String id;
+  private final long createdAt;
+  private final long updatedAt;
+  private final String name;
+  private final String extension;
+  private final NodeType type;
+  private final String mimeType;
+  private final Long size;
+
+  private PublicNode(
+      String id,
+      long createdAt,
+      long updatedAt,
+      String name,
+      String extension,
+      NodeType nodeType,
+      String mimeType,
+      Long size) {
+    this.id = id;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.name = name;
+    this.extension = extension;
+    this.type = nodeType;
+    this.mimeType = mimeType;
+    this.size = size;
+  }
+
+  public static PublicNode createFromNode(Node node) {
+    return new PublicNode(
+        node.getId(),
+        node.getCreatedAt(),
+        node.getUpdatedAt(),
+        node.getName(),
+        node.getExtension().orElse(null),
+        node.getNodeType(),
+        node.getNodeCategory().equals(NodeCategory.FILE)
+            ? node.getFileVersions().stream().findFirst().get().getMimeType()
+            : null,
+        node.getNodeCategory().equals(NodeCategory.FILE) ? node.getSize() : null);
+  }
+
+  public Map<String, Object> convertToMap() {
+    Map<String, Object> mapBuilder = new HashMap<>();
+    mapBuilder.put(GraphQL.PublicNode.ID, id);
+    mapBuilder.put(GraphQL.PublicNode.CREATED_AT, createdAt);
+    mapBuilder.put(GraphQL.PublicNode.UPDATED_AT, updatedAt);
+    mapBuilder.put(GraphQL.PublicNode.NAME, name);
+    mapBuilder.put(GraphQL.PublicNode.TYPE, type);
+
+    if (!(NodeType.FOLDER.equals(type) || NodeType.ROOT.equals(type))) {
+      mapBuilder.put(GraphQL.PublicNode.EXTENSION, extension);
+      mapBuilder.put(GraphQL.PublicNode.MIME_TYPE, mimeType);
+      mapBuilder.put(GraphQL.PublicNode.SIZE, size);
+    }
+
+    return mapBuilder;
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -4,11 +4,20 @@
 
 package com.zextras.carbonio.files.api;
 
+import com.google.inject.Injector;
 import com.zextras.carbonio.files.Simulator;
 import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -17,11 +26,19 @@ import org.junit.jupiter.api.Test;
 public class GetPublicNodeApiIT {
 
   static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static LinkRepository linkRepository;
+  static FileVersionRepository fileVersionRepository;
 
   @BeforeAll
   static void init() {
     simulator =
         SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
   }
 
   @AfterAll
@@ -30,8 +47,27 @@ public class GetPublicNodeApiIT {
   }
 
   @Test
-  void givenAPublicLinkIdAndAnExistingNodeTheGetPublicNodeShouldReturnTheNode() {
+  void givenAPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturnThePublicFolder() {
     // Given
+    final Node folder =
+        nodeRepository.createNewNode(
+            "00000000-0000-0000-0000-000000000000",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "LOCAL_ROOT",
+            "folder",
+            "",
+            NodeType.FOLDER,
+            "LOCAL_ROOT",
+            0L);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
     final String bodyPayload =
         "query { "
             + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
@@ -42,6 +78,7 @@ public class GetPublicNodeApiIT {
             + "type "
             + "} "
             + "}";
+
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
@@ -49,8 +86,113 @@ public class GetPublicNodeApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    Assertions.assertThat(
-            TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode"))
-        .isEmpty();
+
+    final Map<String, Object> publicNode =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode");
+
+    Assertions.assertThat(publicNode.get("id")).isEqualTo("00000000-0000-0000-0000-000000000000");
+    Assertions.assertThat(publicNode.get("created_at")).isEqualTo(folder.getCreatedAt());
+    Assertions.assertThat(publicNode.get("updated_at")).isEqualTo(folder.getUpdatedAt());
+    Assertions.assertThat(publicNode.get("name")).isEqualTo("folder");
+    Assertions.assertThat(publicNode.get("type")).isEqualTo(NodeType.FOLDER.toString());
+  }
+
+  @Test
+  void givenAPublicLinkIdAndAnExistingFileTheGetPublicNodeShouldReturnThePublicFile() {
+    // Given
+    final Node file =
+        nodeRepository.createNewNode(
+            "00000000-0000-0000-0000-000000000000",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "LOCAL_ROOT",
+            "test.txt",
+            "",
+            NodeType.TEXT,
+            "LOCAL_ROOT",
+            5L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        5L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
+            + "id "
+            + "created_at "
+            + "updated_at "
+            + "name "
+            + "type "
+            + "... on File { extension mime_type size }"
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> publicNode =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode");
+
+    Assertions.assertThat(publicNode.get("id")).isEqualTo("00000000-0000-0000-0000-000000000000");
+    Assertions.assertThat(publicNode.get("created_at")).isEqualTo(file.getCreatedAt());
+    Assertions.assertThat(publicNode.get("updated_at")).isEqualTo(file.getUpdatedAt());
+    Assertions.assertThat(publicNode.get("name")).isEqualTo("test");
+    Assertions.assertThat(publicNode.get("extension")).isEqualTo("txt");
+    Assertions.assertThat(publicNode.get("type")).isEqualTo(NodeType.TEXT.toString());
+    Assertions.assertThat(publicNode.get("mime_type")).isEqualTo("text/plain");
+    Assertions.assertThat(publicNode.get("size")).isEqualTo(5.0);
+  }
+
+  @Test
+  void
+      givenANotExistingPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { id }}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errorMessages =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errorMessages)
+        .hasSize(1)
+        .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,11 @@ public class GetPublicNodeApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
   }
 
   @AfterAll


### PR DESCRIPTION
- Implemented GraphQL GetPublicNode API
- Implemented PublicNode POJO to represent a GraphQL Node exposed by public APIs. It has one static method to create the POJO from a Node entity and one method to map the PublicNode to a Map<String, Object>
- Updated and added GetPublicNodeApi integration tests

Refs: FILES-740