### PR TITLE
feat: implement public download API

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -64,3 +64,37 @@ spec:
   owner: shuffled-waffles
   definition:
     $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/schema.graphql
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: carbonio-files-ce-public-rest-api
+  title: Carbonio Files CE Public REST APIs
+  description: Carbonio Files Community Edition Public REST APIs.
+  tags:
+    - public-rest
+spec:
+  type: openapi
+  lifecycle: production
+  owner: shuffled-waffles
+  definition:
+    $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/public-rest.yaml
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: carbonio-files-ce-public graphql-api
+  title: Carbonio Files CE Public GraphQL APIs
+  description: Carbonio Files Community Edition Public GraphQL APIs.
+  tags:
+    - public graphql
+spec:
+  type: graphql
+  lifecycle: production
+  owner: shuffled-waffles
+  definition:
+    $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/public-schema.graphql

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -740,6 +740,8 @@ public final class Files {
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
         Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
+      public static final Pattern DOWNLOAD_PUBLIC_FILE  = Pattern.compile(
+        SERVICE + "public/download/([a-f\\d\\-]*)/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -60,12 +60,16 @@ public class LinkRepositoryEbean implements LinkRepository {
       .findOneOrEmpty();
   }
 
-  public Optional<Link> getLinkByPublicId(String publicId) {
+  public Optional<Link> getLinkByNotExpiredPublicId(String publicId) {
     return ebeanDatabaseManager
       .getEbeanDatabase()
       .find(Link.class)
       .where()
       .eq(Db.Link.PUBLIC_ID, publicId)
+      .or()
+      .isNull(Db.Link.EXPIRES_AT)
+      .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())
+      .endOr()
       .findOneOrEmpty();
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -28,7 +28,7 @@ public interface LinkRepository {
 
   Optional<Link> getLinkById(String linkId);
 
-  Optional<Link> getLinkByPublicId(String publicId);
+  Optional<Link> getLinkByNotExpiredPublicId(String publicId);
 
   Stream<Link> getLinksByNodeId(
     String nodeId,

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -69,7 +69,7 @@ public class PublicNodeDataFetchers {
               ResultPath path = environment.getExecutionStepInfo().getPath();
               String publicLinkId = environment.getArgument(GetPublicNode.NODE_LINK_ID);
               return linkRepository
-                  .getLinkByPublicId(publicLinkId)
+                  .getLinkByNotExpiredPublicId(publicLinkId)
                   .map(
                       publicLink ->
                           nodeRepository

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -119,7 +119,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     }
 
     if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
-      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()
+      || Endpoints.DOWNLOAD_PUBLIC_FILE.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("rest-handler", publicBlobController)
         .addLast("exceptions-handler", exceptionsHandler);

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -31,7 +31,6 @@ import com.zextras.filestore.api.Filestore;
 import com.zextras.filestore.api.UploadResponse;
 import com.zextras.filestore.model.FilesIdentifier;
 import io.ebean.Transaction;
-import io.ebean.annotation.Transactional;
 import io.vavr.control.Try;
 import java.util.Collections;
 import java.util.List;
@@ -120,6 +119,23 @@ public class BlobService {
   }
 
   /**
+   * Downloads from the {@link Filestore} a blob related to an identifier of a public node.
+   *
+   * @param nodeId    is a {@link String} representing the node identifier
+   * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
+   * itself) and all its metadata if the {@link Node} exists, and it is contained on a public folder.
+   * Otherwise, it returns an {@link Optional#empty()}.
+   *
+   * @throws DependencyException if the {@link Filestore} failed to download the blob
+   */
+  public Optional<BlobResponse> downloadPublicFileById(String nodeId) {
+    return nodeRepository
+      .getNode(nodeId)
+      .filter(linkRepository::hasNodeANotExpiredPublicLink)
+      .flatMap(node -> downloadFile(nodeId, null));
+  }
+
+  /**
    * Downloads from the {@link Filestore} a specific blob linked to a public link.
    *
    * @param linkId is a {@link String} representing the identifier of a {@link Link} that is linked
@@ -131,7 +147,7 @@ public class BlobService {
    */
   public Optional<BlobResponse> downloadFileByLink(String linkId) {
     return linkRepository
-      .getLinkByPublicId(linkId)
+      .getLinkByNotExpiredPublicId(linkId)
       .flatMap(link -> downloadFile(link.getNodeId(), null));
   }
 

--- a/core/src/main/resources/api/public-rest.yaml
+++ b/core/src/main/resources/api/public-rest.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+openapi: 3.0.3
+info:
+  title: Files API
+  description: Files API to download blobs and to retrieve a link of a specific node.
+  version: 0.3.0
+servers:
+  - url: 'https://example.com/services/files/public/'
+paths:
+
+  /download/{nodeId}:
+    get:
+      description: Downloads the last version of a node if it has a valid public link associated.
+      operationId: downloadNodeLastVersion
+      parameters:
+        - in: path
+          name: nodeId
+          description: The id of the node to download
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          $ref: '#/components/responses/200DownloadNode'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        503:
+          $ref: '#/components/responses/503BadGateway'
+
+  /link/download/{linkId}:
+    get:
+      description: Download the node associated to the specific link
+      operationId: downloadNodeLastVersionByPublicLink
+      parameters:
+        - in: path
+          name: linkId
+          description: The id of the existing link
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+            minLength: 8
+            maxLength: 8
+      responses:
+        200:
+          $ref: '#/components/responses/200DownloadNode'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        503:
+          $ref: '#/components/responses/503BadGateway'
+
+components:
+  parameters:
+    pathNodeId:
+      in: path
+      name: nodeId
+      schema:
+        title: Id
+        type: string
+      required: true
+  responses:
+    200DownloadNode:
+      description: The node to download
+      content:
+        application/octet-stream:
+          schema:
+            $ref: '#/components/schemas/NodeBinary'
+    400BadRequest:
+      description: The request was malformed
+    404NotFound:
+      description: The resource was not found
+    502BadGateway:
+      description: The service was unavailable
+  schemas:
+    NodeBinary:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -69,29 +69,6 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
-  /link/{linkId}:
-    get:
-      description: Download the node associated to the specific link
-      operationId: linkDownload
-      parameters:
-        - in: path
-          name: linkId
-          description: The id of the existing link
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
-            minLength: 8
-            maxLength: 8
-      responses:
-        200:
-          $ref: '#/components/responses/200DownloadNode'
-        400:
-          $ref: '#/components/responses/400BadRequest'
-        403:
-          $ref: '#/components/responses/403Forbidden'
-        404:
-          $ref: '#/components/responses/404NotFound'
   /upload:
     post:
       description: Uploads a new node
@@ -253,7 +230,7 @@ paths:
         - Preview
       summary: Get pdf preview
       description: |
-        Creates and returns a preview of the pdf fetched by id and version, 
+        Creates and returns a preview of the pdf fetched by id and version,
         the pdf file will contain the first and last page given. With default values
         it will return a pdf with all the pages.
         - **nodeId**: UUID of the pdf

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -201,4 +201,46 @@ public class GetPublicNodeApiIT {
         .hasSize(1)
         .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
   }
+
+  @Test
+  void
+      givenAnExpiredPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(1L),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { id }}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errorMessages =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errorMessages)
+        .hasSize(1)
+        .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
+  }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -223,7 +223,9 @@ class HttpRoutingHandlerTest {
         "/public/link/download/abcd1234",
         "/public/link/download/abcd1234/",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
-        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/",
+        "/public/download/00000000-0000-0000-0000-000000000000",
+        "/public/download/00000000-0000-0000-0000-000000000000/"
       })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
       String uri) {
@@ -353,6 +355,8 @@ class HttpRoutingHandlerTest {
         "/public/link/download/nine00000/",
         "/public/link/download/thirtythreethirtythreethirtythree",
         "/public/link/download/thirtythreethirtythreethirtythree/",
+        "/public/download/invalid",
+        "/public/download/00000000-0000-0000-0000-000000000000/invalid",
         "/invite/abcd1234/invalid",
         "/upload-to/invalid"
       })


### PR DESCRIPTION
- Created the public-rest.yaml describing the two public REST endpoints:
  - /public/link/download/hash
  - /public/download/node-identifier
- Implemented the public download by nodeId REST API updating the PublicBlobController and the BlobService
- Renamed the LinkRepository#getLinkByPublicLink into getLinkByNotExpiredPublicLink: now it returns only existing links that are not expired. This fix allows to block the download of blobs when associated links expire.
- Added PublicDownloadApi integration tests
- Updated catalog-info.yaml describing the public-graphql and the public-rest schemas

Refs: FILES-738