### PR TITLE
feat: implement public share folder

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -6,3 +6,7 @@ Source: https://github.com/Zextras/carbonio-files-ce
 Files: .github/CODEOWNERS
 Copyright: 2023 Zextras <https://www.zextras.com>
 License: CC0-1.0
+
+Files: yap.json
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -64,3 +64,37 @@ spec:
   owner: shuffled-waffles
   definition:
     $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/schema.graphql
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: carbonio-files-ce-public-rest-api
+  title: Carbonio Files CE Public REST APIs
+  description: Carbonio Files Community Edition Public REST APIs.
+  tags:
+    - public-rest
+spec:
+  type: openapi
+  lifecycle: production
+  owner: shuffled-waffles
+  definition:
+    $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/public-rest.yaml
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: carbonio-files-ce-public graphql-api
+  title: Carbonio Files CE Public GraphQL APIs
+  description: Carbonio Files Community Edition Public GraphQL APIs.
+  tags:
+    - public graphql
+spec:
+  type: graphql
+  lifecycle: production
+  owner: shuffled-waffles
+  definition:
+    $text: https://github.com/Zextras/carbonio-files-ce/blob/develop/core/src/main/resources/api/public-schema.graphql

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -183,6 +183,18 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>ebean-platform-hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty-no-dependencies</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java-no-dependencies</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -90,7 +90,7 @@ public final class Files {
 
     private Db() {}
 
-    public static final short DB_VERSION = 2;
+    public static final short DB_VERSION = 3;
 
     /**
      * Names of Files tables
@@ -710,8 +710,8 @@ public final class Files {
       public static final Pattern UPLOAD_FILE_TO      = Pattern.compile(SERVICE + "upload-to/?$");
       public static final Pattern DOWNLOAD_FILE       = Pattern.compile(
         SERVICE + "download/([a-f\\d\\-]*)/?([\\d]+)?/?$");
-      public static final Pattern PUBLIC_LINK         = Pattern.compile(
-        SERVICE + "link/([\\w]{8})/?$");
+      public static final Pattern PUBLIC_LINK =
+          Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -740,6 +740,8 @@ public final class Files {
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
         Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
+      public static final Pattern DOWNLOAD_PUBLIC_FILE  = Pattern.compile(
+        SERVICE + "public/download/([a-f\\d\\-]*)/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -693,9 +693,10 @@ public final class Files {
 
       private Endpoints() {}
 
-      public static final String SERVICE                = "/";
-      public static final String PUBLIC_LINK_URL        = "/services/files/link/";
-      public static final String COLLABORATION_LINK_URL = "/services/files/invite/";
+      public static final String SERVICE                  = "/";
+      public static final String PUBLIC_LINK_ACCESS_URL   = "/files/public/link/access/";
+      public static final String PUBLIC_LINK_DOWNLOAD_URL = "/services/files/public/link/download/";
+      public static final String COLLABORATION_LINK_URL   = "/services/files/invite/";
 
       public static final Pattern METRICS             = Pattern.compile(SERVICE + "metrics/?$");
       public static final Pattern HEALTH              = Pattern.compile(
@@ -712,6 +713,8 @@ public final class Files {
         SERVICE + "download/([a-f\\d\\-]*)/?([\\d]+)?/?$");
       public static final Pattern PUBLIC_LINK =
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
+      public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
+        Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -544,6 +544,13 @@ public final class Files {
 
         public static final String COLLABORATION_LINK_IDS = "collaboration_link_ids";
       }
+
+      public static final class GetPublicNode {
+
+        private GetPublicNode() {}
+
+        public static final String NODE_LINK_ID = "node_link_id";
+      }
     }
 
     /**
@@ -683,6 +690,23 @@ public final class Files {
 
       public static final String NAME  = "name";
       public static final String VALUE = "value";
+    }
+
+    /**
+     * Attributes name for the type Node exposed by Public API
+     */
+    public static final class PublicNode {
+
+      private PublicNode() {}
+
+      public static final String ID         = "id";
+      public static final String CREATED_AT = "created_at";
+      public static final String UPDATED_AT = "updated_at";
+      public static final String NAME       = "name";
+      public static final String EXTENSION  = "extension";
+      public static final String TYPE       = "type";
+      public static final String MIME_TYPE  = "mime_type";
+      public static final String SIZE       = "size";
     }
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -334,6 +334,7 @@ public final class Files {
       public static final String GET_ACCOUNT_BY_EMAIL    = "getAccountByEmail";
       public static final String GET_ACCOUNTS_BY_EMAIL   = "getAccountsByEmail";
       public static final String GET_CONFIGS             = "getConfigs";
+      public static final String GET_PUBLIC_NODE         = "getPublicNode";
     }
 
     /**
@@ -738,6 +739,7 @@ public final class Files {
       public static final Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
         SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
+      public static final Pattern PUBLIC_GRAPHQL             = Pattern.compile(SERVICE + "public/graphql/?$");
     }
 
     public static final class Headers {

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files.config;
 
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.Config.Database;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.preview.PreviewClient;
@@ -17,6 +18,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.Optional;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,5 +101,17 @@ public class FilesConfig {
       .defaultURL(ServiceDiscover.SERVICE_NAME)
       .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
       .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
+  }
+
+  public String getDatabaseUrl() {
+    final String databaseHost = Optional
+      .ofNullable(System.getProperty(Database.URL))
+      .orElse(getProperties().getProperty(Database.URL, "127.78.0.2"));
+
+    final String databasePort = Optional
+      .ofNullable(System.getProperty(Database.PORT))
+      .orElse(getProperties().getProperty(Database.PORT, "20000"));
+
+    return String.format("%s:%s", databaseHost, databasePort);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/EbeanDatabaseManager.java
@@ -71,8 +71,6 @@ public class EbeanDatabaseManager {
 
   @Inject
   public EbeanDatabaseManager(FilesConfig filesConfig) {
-    Properties config = filesConfig.getProperties();
-
     postgresDatabase = ServiceDiscoverHttpClient
       .defaultURL(ServiceDiscover.SERVICE_NAME)
       .getConfig(ServiceDiscover.Config.Db.NAME)
@@ -89,9 +87,8 @@ public class EbeanDatabaseManager {
       .getOrElse("");
 
     jdbcPostgresUrl = String.format(
-      "jdbc:postgresql://%s:%s/%s",
-      config.getProperty(Files.Config.Database.URL, "127.78.0.2"),
-      config.getProperty(Files.Config.Database.PORT, "20000"),
+      "jdbc:postgresql://%s/%s",
+      filesConfig.getDatabaseUrl(),
       postgresDatabase
     );
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Link.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Link.java
@@ -30,7 +30,7 @@ public class Link {
   @Column(name = Db.Link.NODE_ID, nullable = false, length = 36)
   private String mNodeId;
 
-  @Column(name = Db.Link.PUBLIC_ID, nullable = false, length = 8)
+  @Column(name = Db.Link.PUBLIC_ID, nullable = false)
   private String mPublicId;
 
   @Column(name = Files.Db.Link.CREATED_AT, nullable = false)

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -8,11 +8,14 @@ import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.Link;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.LinkSort;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import io.ebean.Query;
 import io.ebean.Transaction;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -108,4 +111,20 @@ public class LinkRepositoryEbean implements LinkRepository {
     }
   }
 
+  public boolean hasNodeANotExpiredPublicLink(Node node) {
+    List<String> nodeIds = new ArrayList<>();
+    nodeIds.add(node.getId());
+    nodeIds.addAll(node.getAncestorsList());
+
+    return ebeanDatabaseManager
+      .getEbeanDatabase()
+      .find(Link.class)
+      .where()
+      .in(Db.Link.NODE_ID, nodeIds)
+      .or()
+      .isNull(Db.Link.EXPIRES_AT)
+      .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())
+      .endOr()
+      .exists();
+  }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -60,12 +60,16 @@ public class LinkRepositoryEbean implements LinkRepository {
       .findOneOrEmpty();
   }
 
-  public Optional<Link> getLinkByPublicId(String publicId) {
+  public Optional<Link> getLinkByNotExpiredPublicId(String publicId) {
     return ebeanDatabaseManager
       .getEbeanDatabase()
       .find(Link.class)
       .where()
       .eq(Db.Link.PUBLIC_ID, publicId)
+      .or()
+      .isNull(Db.Link.EXPIRES_AT)
+      .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())
+      .endOr()
       .findOneOrEmpty();
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -28,7 +28,7 @@ public interface LinkRepository {
 
   Optional<Link> getLinkById(String linkId);
 
-  Optional<Link> getLinkByPublicId(String publicId);
+  Optional<Link> getLinkByNotExpiredPublicId(String publicId);
 
   Stream<Link> getLinksByNodeId(
     String nodeId,

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files.dal.repositories.interfaces;
 
 import com.zextras.carbonio.files.dal.dao.ebean.Link;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.LinkSort;
 import java.util.Collection;
 import java.util.Optional;
@@ -39,4 +40,13 @@ public interface LinkRepository {
   void deleteLink(String linkId);
 
   void deleteLinksBulk(Collection<String> linkIds);
+
+  /**
+   * Checks whether a given {@link Node} has at least one unexpired public link associated with it,
+   * which allows access to the node without requiring permissions.
+  *
+   * @param node is a given {@link Node} to check.
+   * @return true if the {@link Node} has at least one public link associated, false otherwise.
+   */
+  boolean hasNodeANotExpiredPublicLink(Node node);
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
@@ -13,6 +13,7 @@ import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
@@ -87,6 +88,21 @@ public interface NodeRepository {
     Optional<String> optOwnerId,
     List<String> keywords
   ) throws JsonProcessingException;
+
+  /**
+   * Allows to retrieve a list of {@link Node}s from the database filter by chosen criteria.
+   *
+   * @param folderId is an {@link Optional<String>} to search only nodes on the subtree of that
+   *     folder
+   * @param limit is an {@link Integer} used to limit the number of nodes returned (It can be null).
+   * @param pageToken is an {@link String} representing a token necessary to search for the next
+   *     page (it can be null).
+   * @return an {@link ImmutablePair} containing a {@link List} of found {@link Node}s and a {@link
+   *     String} representing the page token to fetch the next page. The list could be empty if
+   *     there aren't nodes found and the page token could be null if there isn't a next page.
+   */
+  ImmutablePair<List<Node>, String> publicFindNodes(
+    String folderId, @Nullable Integer limit, @Nullable String pageToken);
 
   /**
    * <p>Allows to retrieve the list of {@link Node}s from the database or from the cache if already

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
@@ -90,7 +90,8 @@ public class PublicGraphQLProvider {
                 .dataFetcher(NodePage.NODES, publicNodeDataFetchers.findNodesByNodePage()))
         .type(
             newTypeWiring("Query")
-                .dataFetcher(Queries.GET_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
+                .dataFetcher(
+                    Queries.GET_PUBLIC_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
                 .dataFetcher(Queries.FIND_NODES, publicNodeDataFetchers.findNodes()))
         .build();
   }

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/PublicGraphQLProvider.java
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.zextras.carbonio.files.Files.GraphQL.NodePage;
+import com.zextras.carbonio.files.Files.GraphQL.Queries;
+import com.zextras.carbonio.files.Files.GraphQL.Types;
+import com.zextras.carbonio.files.graphql.datafetchers.DateTimeScalar;
+import com.zextras.carbonio.files.graphql.datafetchers.PublicNodeDataFetchers;
+import graphql.GraphQL;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/**
+ * Setups the GraphQL instance with all the necessary properties. A GraphQL instance is necessary to
+ * handle and execute every single request. It knows:
+ *
+ * <ul>
+ *   <li>which is the right schema of reference
+ *   <li>how to validate the input
+ *   <li>which {@link DataFetcher} need to be called
+ * </ul>
+ */
+@Singleton
+public class PublicGraphQLProvider {
+
+  private static final String SCHEMA_URL = "/api/public-schema.graphql";
+
+  private final GraphQL graphQL;
+  private final PublicNodeDataFetchers publicNodeDataFetchers;
+
+  @Inject
+  public PublicGraphQLProvider(PublicNodeDataFetchers publicNodeDataFetchers) {
+    this.publicNodeDataFetchers = publicNodeDataFetchers;
+    graphQL = this.setup();
+  }
+
+  /**
+   * Creates the GraphQL instance building the following properties:
+   *
+   * <ul>
+   *   <li>{@link RuntimeWiring}: it links each interface, query and mutation with the related
+   *       {@link DataFetcher}
+   *   <li>{@link GraphQLSchema}: the schema definition file is imported from the resources
+   *   <li>Execution strategy: how the execution of a request is performed (async or not)
+   * </ul>
+   *
+   * @return {@link GraphQL}
+   */
+  private GraphQL setup() {
+    return GraphQL.newGraphQL(buildSchema(buildWiring()))
+        .queryExecutionStrategy(new AsyncExecutionStrategy())
+        .build();
+  }
+
+  /**
+   * Creates a {@link RuntimeWiring} object associating a specific {@link DataFetcher} to one of
+   * these GraphQL components:
+   *
+   * <ul>
+   *   <li>Interface
+   *   <li>Query
+   * </ul>
+   *
+   * @return a {@link RuntimeWiring} instance.
+   */
+  private RuntimeWiring buildWiring() {
+    return RuntimeWiring.newRuntimeWiring()
+        .scalar(new DateTimeScalar().graphQLScalarType())
+        .type(
+            newTypeWiring(Types.NODE_TYPE).enumValues(publicNodeDataFetchers.getNodeTypeResolver()))
+        .type(
+            newTypeWiring(Types.NODE_INTERFACE)
+                .typeResolver(publicNodeDataFetchers.getNodeInterfaceResolver()))
+        .type(
+            newTypeWiring(Types.NODE_PAGE)
+                .dataFetcher(NodePage.NODES, publicNodeDataFetchers.findNodesByNodePage()))
+        .type(
+            newTypeWiring("Query")
+                .dataFetcher(Queries.GET_NODE, publicNodeDataFetchers.getNodeByPublicLinkId())
+                .dataFetcher(Queries.FIND_NODES, publicNodeDataFetchers.findNodes()))
+        .build();
+  }
+
+  /**
+   * Imports the GraphQL schema file (from res folder) and creates the {@link GraphQLSchema} object
+   * associating the schema file with the RuntimeWiring object.
+   *
+   * @param wiring is a {@link RuntimeWiring} that contains the association between the GraphQL
+   *     components and their specific {@link DataFetcher}s.
+   * @return the {@link GraphQLSchema}.
+   */
+  private GraphQLSchema buildSchema(RuntimeWiring wiring) {
+    // Fetch the content of the GraphQL schema file into an InputStreamReader
+    InputStream inputStream = getClass().getResourceAsStream(SCHEMA_URL);
+
+    if (inputStream == null) {
+      throw new RuntimeException(String.format("The resource %s does not exist", SCHEMA_URL));
+    }
+
+    Reader schema = new InputStreamReader(inputStream);
+
+    // Create the GraphQLSchema object
+    return new SchemaGenerator().makeExecutableSchema(new SchemaParser().parse(schema), wiring);
+  }
+
+  public GraphQL getGraphQL() {
+    return this.graphQL;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.graphql.GraphQLRequest;
+import com.zextras.carbonio.files.graphql.PublicGraphQLProvider;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the entry-point of the Files Public GraphQL API that is accessible without
+ * authentication token. The main purpose is to:
+ *
+ * <ul>
+ *   <li>Receive a json request
+ *   <li>Parse the request creating a {@link GraphQLRequest}
+ *   <li>Execute the request via {@link GraphQL}
+ *   <li>Return the response with the JSON data requested or an error
+ * </ul>
+ */
+@ChannelHandler.Sharable
+@Singleton
+public class PublicGraphQLController extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PublicGraphQLController.class);
+
+  private final GraphQL publicGraphQL;
+
+  @Inject
+  public PublicGraphQLController(PublicGraphQLProvider publicGraphQLProvider) {
+    super(true);
+    this.publicGraphQL = publicGraphQLProvider.getGraphQL();
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext context, FullHttpRequest httpRequest) {
+    try {
+      GraphQLRequest request = parseRequest(httpRequest.content());
+      /*
+       * The ExecutionInput object represents the input of the request, it has the following fields:
+       *   - Query: the actual request to execute
+       *   - Variables: the input values of the request (optional)
+       *   - OperationName: the name of the request to execute (optional)
+       */
+      ExecutionInput input =
+          ExecutionInput.newExecutionInput()
+              .query(request.getRequest())
+              .variables(request.getVariables())
+              .operationName(request.getOperationName().orElse(""))
+              .build();
+
+      ExecutionResult executionResult = publicGraphQL.executeAsync(input).join();
+      String bodyResponse =
+          new ObjectMapper().writeValueAsString(executionResult.toSpecification());
+
+      FullHttpResponse response =
+          new DefaultFullHttpResponse(
+              httpRequest.protocolVersion(),
+              HttpResponseStatus.OK,
+              Unpooled.wrappedBuffer(bodyResponse.getBytes(StandardCharsets.UTF_8)));
+
+      response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+      response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+      httpRequest.retain();
+      context.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+
+    } catch (GraphQLRequest.InvalidPayloadRequestError | GraphQLException exception) {
+      logger.error("PublicGraphQLController catches an exception handling the request", exception);
+      context.fireExceptionCaught(new BadRequestException());
+    }
+    // Catching the RuntimeException and the JsonProcessingException
+    catch (Exception exception) {
+      logger.error("PublicGraphQLController catches an exception", exception);
+      context.fireExceptionCaught(exception);
+    }
+  }
+
+  private GraphQLRequest parseRequest(ByteBuf contentRequest)
+      throws GraphQLRequest.InvalidPayloadRequestError {
+    if (contentRequest == null || contentRequest.writerIndex() == 0) {
+      throw new GraphQLRequest.InvalidPayloadRequestError(
+          "The payload of a GraphQL request cannot be empty");
+    }
+    try {
+      String payloadString = contentRequest.toString(StandardCharsets.UTF_8);
+      return GraphQLRequest.buildFromPayload(payloadString);
+    } catch (Exception exception) {
+      throw new GraphQLRequest.InvalidPayloadRequestError(
+          "The payload of a GraphQL request cannot be parsed");
+    }
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
@@ -130,7 +130,7 @@ public class LinkDataFetcher {
         .has(SharePermission.READ_AND_SHARE)
         && nodeRepository.getNode(nodeId).get().getNodeType() != NodeType.FOLDER
       ) {
-        String publicId = RandomStringUtils.randomAlphanumeric(8);
+        String publicId = RandomStringUtils.randomAlphanumeric(32);
 
         Link createdLink = linkRepository.createLink(
           UUID.randomUUID().toString(),

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.datafetchers;
+
+import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.EnumValuesProvider;
+import java.util.Collections;
+import java.util.Map;
+
+public class PublicNodeDataFetchers {
+
+  /**
+   * This {@link TypeResolver} checks which type of Node was requested. The type can be a File or a
+   * Folder.
+   *
+   * @return a {@link TypeResolver} that resolve the type of Node requested.
+   */
+  public TypeResolver getNodeInterfaceResolver() {
+    return environment -> {
+      Map<String, Object> result = environment.getObject();
+      return (result.get(Files.GraphQL.Node.TYPE).equals(NodeType.FOLDER)
+              || result.get(Files.GraphQL.Node.TYPE).equals(NodeType.ROOT))
+          ? (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FOLDER)
+          : (GraphQLObjectType) environment.getSchema().getType(Files.GraphQL.Types.FILE);
+    };
+  }
+
+  public EnumValuesProvider getNodeTypeResolver() {
+    return NodeType::valueOf;
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> getNodeByPublicLinkId() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> findNodes() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+
+  public DataFetcher<DataFetcherResult<Map<String, String>>> findNodesByNodePage() {
+    return environment ->
+        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -69,7 +69,7 @@ public class PublicNodeDataFetchers {
               ResultPath path = environment.getExecutionStepInfo().getPath();
               String publicLinkId = environment.getArgument(GetPublicNode.NODE_LINK_ID);
               return linkRepository
-                  .getLinkByPublicId(publicLinkId)
+                  .getLinkByNotExpiredPublicId(publicLinkId)
                   .map(
                       publicLink ->
                           nodeRepository

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -4,17 +4,34 @@
 
 package com.zextras.carbonio.files.graphql.datafetchers;
 
+import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.GraphQL.InputParameters.GetPublicNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.graphql.errors.GraphQLResultErrors;
+import com.zextras.carbonio.files.graphql.types.PublicNode;
 import graphql.execution.DataFetcherResult;
+import graphql.execution.ResultPath;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.EnumValuesProvider;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class PublicNodeDataFetchers {
+
+  private final NodeRepository nodeRepository;
+  private final LinkRepository linkRepository;
+
+  @Inject
+  public PublicNodeDataFetchers(NodeRepository nodeRepository, LinkRepository linkRepository) {
+    this.nodeRepository = nodeRepository;
+    this.linkRepository = linkRepository;
+  }
 
   /**
    * This {@link TypeResolver} checks which type of Node was requested. The type can be a File or a
@@ -36,9 +53,35 @@ public class PublicNodeDataFetchers {
     return NodeType::valueOf;
   }
 
-  public DataFetcher<DataFetcherResult<Map<String, String>>> getNodeByPublicLinkId() {
+  public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, Object>>>>
+      getNodeByPublicLinkId() {
     return environment ->
-        DataFetcherResult.<Map<String, String>>newResult().data(Collections.emptyMap()).build();
+        CompletableFuture.supplyAsync(
+            () -> {
+              ResultPath path = environment.getExecutionStepInfo().getPath();
+              String publicLinkId = environment.getArgument(GetPublicNode.NODE_LINK_ID);
+              return linkRepository
+                  .getLinkByPublicId(publicLinkId)
+                  .map(
+                      publicLink ->
+                          nodeRepository
+                              .getNode(publicLink.getNodeId())
+                              .map(
+                                  node ->
+                                      DataFetcherResult.<Map<String, Object>>newResult()
+                                          .data(PublicNode.createFromNode(node).convertToMap())
+                                          .build())
+                              .orElse(
+                                  DataFetcherResult.<Map<String, Object>>newResult()
+                                      .error(
+                                          GraphQLResultErrors.nodeNotFound(
+                                              publicLink.getNodeId(), path))
+                                      .build()))
+                  .orElse(
+                      DataFetcherResult.<Map<String, Object>>newResult()
+                          .error(GraphQLResultErrors.linkNotFound(publicLinkId, path))
+                          .build());
+            });
   }
 
   public DataFetcher<DataFetcherResult<Map<String, String>>> findNodes() {

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/types/PublicNode.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/types/PublicNode.java
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.graphql.types;
+
+import com.zextras.carbonio.files.Files.GraphQL;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeCategory;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PublicNode {
+
+  private final String id;
+  private final long createdAt;
+  private final long updatedAt;
+  private final String name;
+  private final String extension;
+  private final NodeType type;
+  private final String mimeType;
+  private final Long size;
+
+  private PublicNode(
+      String id,
+      long createdAt,
+      long updatedAt,
+      String name,
+      String extension,
+      NodeType nodeType,
+      String mimeType,
+      Long size) {
+    this.id = id;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.name = name;
+    this.extension = extension;
+    this.type = nodeType;
+    this.mimeType = mimeType;
+    this.size = size;
+  }
+
+  public static PublicNode createFromNode(Node node) {
+    return new PublicNode(
+        node.getId(),
+        node.getCreatedAt(),
+        node.getUpdatedAt(),
+        node.getName(),
+        node.getExtension().orElse(null),
+        node.getNodeType(),
+        node.getNodeCategory().equals(NodeCategory.FILE)
+            ? node.getFileVersions().stream().findFirst().get().getMimeType()
+            : null,
+        node.getNodeCategory().equals(NodeCategory.FILE) ? node.getSize() : null);
+  }
+
+  public Map<String, Object> convertToMap() {
+    Map<String, Object> mapBuilder = new HashMap<>();
+    mapBuilder.put(GraphQL.PublicNode.ID, id);
+    mapBuilder.put(GraphQL.PublicNode.CREATED_AT, createdAt);
+    mapBuilder.put(GraphQL.PublicNode.UPDATED_AT, updatedAt);
+    mapBuilder.put(GraphQL.PublicNode.NAME, name);
+    mapBuilder.put(GraphQL.PublicNode.TYPE, type);
+
+    if (!(NodeType.FOLDER.equals(type) || NodeType.ROOT.equals(type))) {
+      mapBuilder.put(GraphQL.PublicNode.EXTENSION, extension);
+      mapBuilder.put(GraphQL.PublicNode.MIME_TYPE, mimeType);
+      mapBuilder.put(GraphQL.PublicNode.SIZE, size);
+    }
+
+    return mapBuilder;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -13,6 +13,7 @@ import com.zextras.carbonio.files.rest.controllers.HealthController;
 import com.zextras.carbonio.files.rest.controllers.MetricsController;
 import com.zextras.carbonio.files.rest.controllers.PreviewController;
 import com.zextras.carbonio.files.rest.controllers.ProcedureController;
+import com.zextras.carbonio.files.rest.controllers.PublicBlobController;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -33,6 +34,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
   private final HealthController            healthController;
   private final GraphQLController           graphQLController;
   private final BlobController              blobController;
+  private final PublicBlobController        publicBlobController;
   private final AuthenticationHandler       authenticationHandler;
   private final ExceptionsHandler           exceptionsHandler;
   private final PreviewController           previewController;
@@ -45,6 +47,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     HealthController healthController,
     GraphQLController graphQLController,
     BlobController blobController,
+    PublicBlobController publicBlobController,
     AuthenticationHandler authenticationHandler,
     ExceptionsHandler exceptionsHandler,
     PreviewController previewController,
@@ -58,6 +61,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     this.exceptionsHandler = exceptionsHandler;
     this.graphQLController = graphQLController;
     this.blobController = blobController;
+    this.publicBlobController = publicBlobController;
     this.previewController = previewController;
     this.procedureController = procedureController;
     this.collaborationLinkController = collaborationLinkController;
@@ -113,7 +117,7 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
       || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
       context.pipeline()
-        .addLast("rest-handler", blobController)
+        .addLast("rest-handler", publicBlobController)
         .addLast("exceptions-handler", exceptionsHandler);
       context.fireChannelRead(request);
       return;

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -110,7 +110,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
       return;
     }
 
-    if (Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+    if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
+      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("rest-handler", blobController)
         .addLast("exceptions-handler", exceptionsHandler);

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -119,7 +119,8 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
     }
 
     if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
-      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()) {
+      || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()
+      || Endpoints.DOWNLOAD_PUBLIC_FILE.matcher(request.uri()).matches()) {
       context.pipeline()
         .addLast("rest-handler", publicBlobController)
         .addLast("exceptions-handler", exceptionsHandler);

--- a/core/src/main/java/com/zextras/carbonio/files/netty/utilities/HttpResponseBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/utilities/HttpResponseBuilder.java
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.netty.utilities;
+
+import com.zextras.carbonio.files.rest.types.BlobResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.vavr.control.Try;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class HttpResponseBuilder {
+
+  /**
+   * Allows to create a {@link DefaultHttpResponse} containing all the following headers:
+   *
+   * <ul>
+   *   <li>{@link HttpHeaderNames#CONNECTION} to close
+   *   <li>{@link HttpHeaderNames#CONTENT_LENGTH} of the blob to download
+   *   <li>{@link HttpHeaderNames#CONTENT_TYPE} of the blob to download
+   *   <li>{@link HttpHeaderNames#CONTENT_DISPOSITION} with the filename of the blob to download
+   * </ul>
+   *
+   * @param blobResponse is a {@link BlobResponse} containing all the related attributes of the blob
+   *     to download.
+   * @return a {@link HttpResponse} containing all the necessary headers of the blob to download.
+   */
+  public static HttpResponse createSuccessDownloadHttpResponse(BlobResponse blobResponse) {
+    final String encodedFilename =
+        Try.of(() -> URLEncoder.encode(blobResponse.getFilename(), StandardCharsets.UTF_8))
+            .getOrElseThrow(
+                failure -> {
+                  String errorMessage =
+                      String.format(
+                          "Unable to encode node filename %s to download",
+                          blobResponse.getFilename());
+                  return new IllegalArgumentException(errorMessage, failure);
+                });
+
+    DefaultHttpHeaders headers = new DefaultHttpHeaders(true);
+    headers.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+    headers.add(HttpHeaderNames.CONTENT_LENGTH, blobResponse.getSize());
+    headers.add(HttpHeaderNames.CONTENT_TYPE, blobResponse.getMimeType());
+    headers.add(
+        HttpHeaderNames.CONTENT_DISPOSITION,
+        String.format("attachment; filename*=UTF-8''%s", encodedFilename));
+
+    return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, headers);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -82,6 +82,8 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         Matcher uploadMatcher = Endpoints.UPLOAD_FILE.matcher(uriRequest);
         Matcher uploadVersionMatcher = Endpoints.UPLOAD_FILE_VERSION.matcher(uriRequest);
         Matcher publicLinkMatcher = Endpoints.PUBLIC_LINK.matcher(uriRequest);
+        Matcher downloadViaPublicLinkMatcher =
+          Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(uriRequest);
 
         if (downloadMatcher.find()) {
           download(context, httpRequest, downloadMatcher);
@@ -89,6 +91,10 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
 
         if (publicLinkMatcher.find()) {
           downloadByLink(context, httpRequest, publicLinkMatcher);
+        }
+
+        if (downloadViaPublicLinkMatcher.find()) {
+          downloadByLink(context, httpRequest, downloadViaPublicLinkMatcher);
         }
 
         if (uploadMatcher.find()) {

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.controllers;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.files.Files.API.Endpoints;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.netty.utilities.HttpResponseBuilder;
+import com.zextras.carbonio.files.netty.utilities.NettyBufferWriter;
+import com.zextras.carbonio.files.rest.services.BlobService;
+import com.zextras.carbonio.files.rest.types.BlobResponse;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpRequest;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ChannelHandler.Sharable
+public class PublicBlobController extends SimpleChannelInboundHandler<HttpRequest> {
+
+  private static final Logger logger = LoggerFactory.getLogger(PublicBlobController.class);
+
+  private final BlobService blobService;
+
+  @Inject
+  public PublicBlobController(BlobService blobService) {
+    this.blobService = blobService;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext context, HttpRequest httpRequest) {
+    try {
+      final Matcher publicLinkMatcher = Endpoints.PUBLIC_LINK.matcher(httpRequest.uri());
+      final Matcher downloadViaPublicLinkMatcher =
+          Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(httpRequest.uri());
+
+      if (publicLinkMatcher.find()) {
+        downloadByPublicLink(context, httpRequest, publicLinkMatcher);
+        return;
+      }
+
+      if (downloadViaPublicLinkMatcher.find()) {
+        downloadByPublicLink(context, httpRequest, downloadViaPublicLinkMatcher);
+        return;
+      }
+
+      context.fireExceptionCaught(new BadRequestException());
+
+    } catch (Exception exception) {
+      logger.error("PublicBlobController catches an exception", exception);
+      context.fireExceptionCaught(exception);
+    }
+  }
+
+  void downloadByPublicLink(
+      ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched) {
+
+    final String publicLinkId = uriMatched.group(1);
+    final Optional<BlobResponse> blobResponse = blobService.downloadFileByLink(publicLinkId);
+
+    if (blobResponse.isPresent()) {
+      context.write(HttpResponseBuilder.createSuccessDownloadHttpResponse(blobResponse.get()));
+      new NettyBufferWriter(context)
+          .writeStream(blobResponse.get().getBlobStream(), context.newPromise());
+      return;
+    }
+
+    final String errorMessage =
+        String.format(
+            "Request %s: the link and/or the node associated to it does not exist",
+            httpRequest.uri());
+
+    context.fireExceptionCaught(new NoSuchElementException(errorMessage));
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -31,7 +31,6 @@ import com.zextras.filestore.api.Filestore;
 import com.zextras.filestore.api.UploadResponse;
 import com.zextras.filestore.model.FilesIdentifier;
 import io.ebean.Transaction;
-import io.ebean.annotation.Transactional;
 import io.vavr.control.Try;
 import java.util.Collections;
 import java.util.List;
@@ -120,6 +119,23 @@ public class BlobService {
   }
 
   /**
+   * Downloads from the {@link Filestore} a blob related to an identifier of a public node.
+   *
+   * @param nodeId    is a {@link String} representing the node identifier
+   * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
+   * itself) and all its metadata if the {@link Node} exists, and it is contained on a public folder.
+   * Otherwise, it returns an {@link Optional#empty()}.
+   *
+   * @throws DependencyException if the {@link Filestore} failed to download the blob
+   */
+  public Optional<BlobResponse> downloadPublicFileById(String nodeId) {
+    return nodeRepository
+      .getNode(nodeId)
+      .filter(linkRepository::hasNodeANotExpiredPublicLink)
+      .flatMap(node -> downloadFile(nodeId, null));
+  }
+
+  /**
    * Downloads from the {@link Filestore} a specific blob linked to a public link.
    *
    * @param linkId is a {@link String} representing the identifier of a {@link Link} that is linked
@@ -131,7 +147,7 @@ public class BlobService {
    */
   public Optional<BlobResponse> downloadFileByLink(String linkId) {
     return linkRepository
-      .getLinkByPublicId(linkId)
+      .getLinkByNotExpiredPublicId(linkId)
       .flatMap(link -> downloadFile(link.getNodeId(), null));
   }
 

--- a/core/src/main/resources/api/public-rest.yaml
+++ b/core/src/main/resources/api/public-rest.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+openapi: 3.0.3
+info:
+  title: Files API
+  description: Files API to download blobs and to retrieve a link of a specific node.
+  version: 0.3.0
+servers:
+  - url: 'https://example.com/services/files/public/'
+paths:
+
+  /download/{nodeId}:
+    get:
+      description: Downloads the last version of a node if it has a valid public link associated.
+      operationId: downloadNodeLastVersion
+      parameters:
+        - in: path
+          name: nodeId
+          description: The id of the node to download
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          $ref: '#/components/responses/200DownloadNode'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        503:
+          $ref: '#/components/responses/503BadGateway'
+
+  /link/download/{linkId}:
+    get:
+      description: Download the node associated to the specific link
+      operationId: downloadNodeLastVersionByPublicLink
+      parameters:
+        - in: path
+          name: linkId
+          description: The id of the existing link
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+            minLength: 8
+            maxLength: 8
+      responses:
+        200:
+          $ref: '#/components/responses/200DownloadNode'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        503:
+          $ref: '#/components/responses/503BadGateway'
+
+components:
+  parameters:
+    pathNodeId:
+      in: path
+      name: nodeId
+      schema:
+        title: Id
+        type: string
+      required: true
+  responses:
+    200DownloadNode:
+      description: The node to download
+      content:
+        application/octet-stream:
+          schema:
+            $ref: '#/components/schemas/NodeBinary'
+    400BadRequest:
+      description: The request was malformed
+    404NotFound:
+      description: The resource was not found
+    502BadGateway:
+      description: The service was unavailable
+  schemas:
+    NodeBinary:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary

--- a/core/src/main/resources/api/public-schema.graphql
+++ b/core/src/main/resources/api/public-schema.graphql
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Public Files API - GraphQL Schema v. 0.0.1
+
+# The Scalar type represents the date on the timestamp EPOCH format
+scalar DateTime
+
+#Definition of NodeType enumerator. This is used for discriminating the specific type of a node
+enum NodeType {
+    IMAGE
+    VIDEO
+    AUDIO
+    TEXT
+    SPREADSHEET
+    PRESENTATION
+    FOLDER
+    APPLICATION
+    MESSAGE
+    OTHER
+}
+
+# Definition of the Node interface
+interface Node {
+    # Unique identifier of the node
+    id: ID!
+
+    # Node creation timestamp
+    created_at: DateTime!
+
+    # Node update timestamp
+    updated_at: DateTime!
+
+    # Name of the node
+    name: String!
+
+    # Type of the node
+    type: NodeType!
+}
+
+# Definition of the Folder type which implements the Node interface
+type Folder implements Node {
+    # Unique identifier of the folder
+    id: ID!
+
+    # Folder creation timestamp
+    created_at: DateTime!
+
+    # Folder update timestamp
+    updated_at: DateTime!
+
+    # Name of the folder
+    name: String!
+
+    # Type of the folder
+    type: NodeType!
+}
+
+# Definition of the File type which implements the Node interface
+type File implements Node {
+    # Unique identifier of the file
+    id: ID!
+
+    # File creation timestamp
+    created_at: DateTime!
+
+    # File update timestamp
+    updated_at: DateTime!
+
+    # Name of the file
+    name: String!
+
+    # Extension of the file
+    extension: String
+
+    # Type of the file
+    type: NodeType!
+
+    # Mime type of the file
+    mime_type: String!
+
+    # Size of the file
+    size: Float!
+}
+
+# Represents a page of node list. It contains a list of nodes of the current page
+# and a token necessary to request the next page of nodes
+type NodePage {
+    # The list of nodes of the requested page
+    nodes: [Node]!
+
+    # The token to use as a cursor for requesting the next page of nodes
+    page_token: String
+}
+
+type Query {
+    # <strong>Returns a Node associated to a given public link identifier</strong>
+    getPublicNode(
+        node_link_id: String!
+    ) : Node
+
+    # <strong>Returns a NodePage based on the given criteria</strong>
+    findNodes(
+        # It searches nodes starting from the given folder
+        folder_id: ID!
+        # If valued it limits the number of nodes to return per page
+        limit: Int
+        # If valued it will return the next page of nodes based on the given page_token,
+        # if this param is passed all other params will be ignored
+        page_token: String
+    ) : NodePage
+}
+
+schema {
+    query: Query
+}

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -69,29 +69,6 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
-  /link/{linkId}:
-    get:
-      description: Download the node associated to the specific link
-      operationId: linkDownload
-      parameters:
-        - in: path
-          name: linkId
-          description: The id of the existing link
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
-            minLength: 8
-            maxLength: 8
-      responses:
-        200:
-          $ref: '#/components/responses/200DownloadNode'
-        400:
-          $ref: '#/components/responses/400BadRequest'
-        403:
-          $ref: '#/components/responses/403Forbidden'
-        404:
-          $ref: '#/components/responses/404NotFound'
   /upload:
     post:
       description: Uploads a new node
@@ -253,7 +230,7 @@ paths:
         - Preview
       summary: Get pdf preview
       description: |
-        Creates and returns a preview of the pdf fetched by id and version, 
+        Creates and returns a preview of the pdf fetched by id and version,
         the pdf file will contain the first and last page given. With default values
         it will return a pdf with all the pages.
         - **nodeId**: UUID of the pdf

--- a/core/src/main/resources/sql/postgresql_3.sql
+++ b/core/src/main/resources/sql/postgresql_3.sql
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+BEGIN;
+
+ALTER TABLE link ALTER COLUMN public_id TYPE VARCHAR(32);
+
+UPDATE db_info SET version = 3;
+
+COMMIT;

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Files.Config.Database;
+import com.zextras.carbonio.files.Files.Config.Storages;
+import com.zextras.carbonio.files.Files.Config.UserManagement;
+import com.zextras.carbonio.files.Files.ServiceDiscover.Config.Db;
+import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.config.FilesModule;
+import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.netty.HttpRoutingHandler;
+import com.zextras.carbonio.usermanagement.entities.UserId;
+import com.zextras.carbonio.usermanagement.entities.UserInfo;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpMethod;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Properties;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Cookie;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.JsonBody;
+import org.mockserver.model.Parameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.com.trilead.ssh2.crypto.Base64;
+
+@Testcontainers
+public class Simulator implements AutoCloseable {
+
+  private static final Logger logger = LoggerFactory.getLogger(Simulator.class);
+  private Injector injector;
+  private PostgreSQLContainer<?> postgreSQLContainer;
+  private EbeanDatabaseManager ebeanDatabaseManager;
+  private ClientAndServer clientAndServer;
+  private MockServerClient serviceDiscoverMock;
+  private MockServerClient userManagementMock;
+  private MockServerClient storagesMock;
+
+  //
+  // Private methods
+  //
+
+  private Simulator createInjector() {
+    injector = Guice.createInjector(new FilesModule(new FilesConfig()));
+    return this;
+  }
+
+  private Simulator startDatabase() {
+    if (postgreSQLContainer == null) {
+      postgreSQLContainer = new PostgreSQLContainer<>("postgres:12.14");
+    }
+
+    postgreSQLContainer.start();
+
+    // Set the System.properties for the dynamic database url and port
+    System.setProperty(Database.URL, postgreSQLContainer.getHost());
+    System.setProperty(Database.PORT, String.valueOf(postgreSQLContainer.getFirstMappedPort()));
+
+    return this;
+  }
+
+  private Simulator startEbeanDatabaseManager() {
+    if (ebeanDatabaseManager == null) {
+      ebeanDatabaseManager = injector.getInstance(EbeanDatabaseManager.class);
+      ebeanDatabaseManager.start();
+    }
+
+    return this;
+  }
+
+  private Simulator startServiceDiscover() {
+    startMockServer();
+    serviceDiscoverMock = new MockServerClient("localhost", 8500);
+
+    String dbName;
+    String dbUsername;
+    String dbPassword;
+
+    if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
+      dbName = postgreSQLContainer.getDatabaseName();
+      dbUsername = postgreSQLContainer.getUsername();
+      dbPassword = postgreSQLContainer.getPassword();
+    } else {
+      logger.warn(
+          "The ServiceDiscover will be mocked without a database container. The database "
+              + "credentials are the default one specified in the Constants class");
+
+      dbName = Db.NAME;
+      dbUsername = Db.USERNAME;
+      dbPassword = Db.PASSWORD;
+    }
+
+    final String encodedDbName = new String(Base64.encode(dbName.getBytes()));
+    final String encodedDbUsername = new String(Base64.encode(dbUsername.getBytes()));
+    final String encodedDbPassword = new String(Base64.encode(dbPassword.getBytes()));
+    final String bodyPayloadFormat = "[{\"Key\":\"%s\",\"Value\":\"%s\"}]";
+
+    serviceDiscoverMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/db-name")
+                .withHeader("X-Consul-Token", ""))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(
+                    String.format(bodyPayloadFormat, "carbonio-files/db-name", encodedDbName)));
+
+    serviceDiscoverMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/db-username")
+                .withHeader("X-Consul-Token", ""))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(
+                    String.format(
+                        bodyPayloadFormat, "carbonio-files/db-username", encodedDbUsername)));
+
+    serviceDiscoverMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/db-password")
+                .withHeader("X-Consul-Token", ""))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(
+                    String.format(
+                        bodyPayloadFormat, "carbonio-files/db-password", encodedDbPassword)));
+
+    return this;
+  }
+
+  private Simulator startUserManagement() {
+    startMockServer();
+
+    final FilesConfig filesConfig = injector.getInstance(FilesConfig.class);
+    userManagementMock =
+        new MockServerClient(
+            filesConfig.getProperties().getProperty(UserManagement.URL),
+            Integer.parseInt(filesConfig.getProperties().getProperty(UserManagement.PORT)));
+
+    return this;
+  }
+
+  private void validateUser(String cookie, String userId) {
+    userManagementMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/auth/token/" + cookie))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody("{\"userId\":\"" + userId + "\"}"));
+  }
+
+  private void getUser(String cookie, String userId) {
+    final UserInfo userInfo =
+        new UserInfo(new UserId(userId), "fake-email@example.com", "Fake User", "example.com");
+
+    userManagementMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/users/id/" + userId)
+                .withCookie(Cookie.cookie("ZM_AUTH_TOKEN", cookie)))
+        .respond(HttpResponse.response().withStatusCode(200).withBody(JsonBody.json(userInfo)));
+  }
+
+  private Simulator startStorages() {
+    startMockServer();
+
+    final FilesConfig filesConfig = injector.getInstance(FilesConfig.class);
+    storagesMock =
+        new MockServerClient(
+            filesConfig.getProperties().getProperty(Storages.URL),
+            Integer.parseInt(filesConfig.getProperties().getProperty(Storages.PORT)));
+
+    return this;
+  }
+
+  private void startMockServer() {
+    if (clientAndServer == null) {
+      final Properties properties = injector.getInstance(FilesConfig.class).getProperties();
+      final int userManagementPort = Integer.parseInt(properties.getProperty(UserManagement.PORT));
+      final int storagesPort = Integer.parseInt(properties.getProperty(Storages.PORT));
+      clientAndServer =
+          ClientAndServer.startClientAndServer(8500, userManagementPort, storagesPort);
+    }
+  }
+
+  private void stopDatabase() {
+    if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
+      postgreSQLContainer.stop();
+    }
+  }
+
+  private void stopEbeanDatabaseManager() {
+    if (ebeanDatabaseManager != null) {
+      ebeanDatabaseManager.stop();
+    }
+  }
+
+  private void stopServiceDiscover() {
+    if (serviceDiscoverMock != null && serviceDiscoverMock.hasStarted()) {
+      serviceDiscoverMock.stop();
+    }
+  }
+
+  private void stopUserManagement() {
+    if (userManagementMock != null && userManagementMock.hasStarted()) {
+      userManagementMock.stop();
+    }
+  }
+
+  //
+  // Public methods
+  //
+
+  public Simulator() {}
+
+  public Simulator start() {
+    return startEbeanDatabaseManager();
+  }
+
+  public void stopAll() {
+    stopUserManagement();
+    stopServiceDiscover();
+    stopDatabase();
+    stopEbeanDatabaseManager();
+  }
+
+  @Override
+  public void close() {
+    stopAll();
+  }
+
+  public Injector getInjector() {
+    return injector;
+  }
+
+  public MockServerClient getServiceDiscoverMock() {
+    return serviceDiscoverMock;
+  }
+
+  public MockServerClient getUserManagementMock() {
+    return userManagementMock;
+  }
+
+  public EmbeddedChannel getNettyChannel() {
+    return new EmbeddedChannel(injector.getInstance(HttpRoutingHandler.class));
+  }
+
+  public void resetDatabase() {
+    ebeanDatabaseManager.getEbeanDatabase().find(Node.class).delete();
+  }
+
+  public void getBlob(String nodeId, int version) {
+    storagesMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download")
+                .withQueryStringParameter(Parameter.param("node", nodeId))
+                .withQueryStringParameter(Parameter.param("version", String.valueOf(version)))
+                .withQueryStringParameter(Parameter.param("type", "files")))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody((nodeId + version).getBytes(StandardCharsets.UTF_8)));
+  }
+
+  public static class SimulatorBuilder {
+
+    private Simulator simulator;
+
+    public static SimulatorBuilder aSimulator() {
+      return new SimulatorBuilder();
+    }
+
+    public SimulatorBuilder init() {
+      simulator = new Simulator();
+      simulator.createInjector();
+      return this;
+    }
+
+    public SimulatorBuilder withDatabase() {
+      simulator.startDatabase();
+      return this;
+    }
+
+    public SimulatorBuilder withServiceDiscover() {
+      simulator.startServiceDiscover();
+      return this;
+    }
+
+    public SimulatorBuilder withUserManagement(Map<String, String> users) {
+      simulator.startUserManagement();
+      users.forEach(
+          (cookie, userId) -> {
+            simulator.validateUser(cookie, userId);
+            simulator.getUser(cookie, userId);
+          });
+      return this;
+    }
+
+    public SimulatorBuilder withStorages() {
+      simulator.startStorages();
+      return this;
+    }
+
+    public Simulator build() {
+      return simulator;
+    }
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -264,6 +264,10 @@ public class Simulator implements AutoCloseable {
     return userManagementMock;
   }
 
+  public MockServerClient getStoragesMock() {
+    return storagesMock;
+  }
+
   public EmbeddedChannel getNettyChannel() {
     return new EmbeddedChannel(injector.getInstance(HttpRoutingHandler.class));
   }

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TestUtils {
+
+  public static String queryPayload(String query) {
+    return String.format("{\"query\":\"%s\"}", query);
+  }
+
+  public static String mutationPayload(String mutation) {
+    return String.format("{\"mutation\":\"%s\"}", mutation);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> jsonResponseToMap(String json, String operation) {
+    try {
+      final Map<String, Object> result = new ObjectMapper().readValue(json, HashMap.class);
+
+      if (result.get("data") != null) {
+        final Map<String, Object> data = (Map<String, Object>) result.get("data");
+
+        if (data.get(operation) != null) {
+          return (Map<String, Object>) data.get(operation);
+        }
+      }
+      return Collections.emptyMap();
+
+    } catch (JsonProcessingException exception) {
+      return Collections.emptyMap();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<Map<String, Object>> jsonResponseToList(String json, String operation) {
+    try {
+      final Map<String, Object> result = new ObjectMapper().readValue(json, Map.class);
+
+      if (result.get("data") != null) {
+        final Map<String, Object> data = (Map<String, Object>) result.get("data");
+
+        if (data.get(operation) != null) {
+          return (List<Map<String, Object>>) data.get(operation);
+        }
+      }
+      return Collections.emptyList();
+
+    } catch (JsonProcessingException exception) {
+      return Collections.emptyList();
+    }
+  }
+
+  public static Optional<String> jsonResponseToString(String json, String operation) {
+    try {
+      final Map<String, Object> result = new ObjectMapper().readValue(json, Map.class);
+
+      if (result.get("data") != null) {
+        final Map<String, Object> data = (Map<String, Object>) result.get("data");
+
+        return Optional.ofNullable((String) data.get(operation));
+      }
+      return Optional.empty();
+
+    } catch (JsonProcessingException exception) {
+      return Optional.empty();
+    }
+  }
+
+  public static List<String> jsonResponseToErrors(String json) {
+    try {
+      final Map<String, Object> result = new ObjectMapper().readValue(json, Map.class);
+
+      if (result.get("errors") != null) {
+        final List<Map<String, Object>> errors = (List<Map<String, Object>>) result.get("errors");
+
+        return errors.stream()
+            .map(error -> (String) error.get("message"))
+            .collect(Collectors.toList());
+      }
+    } catch (JsonProcessingException exception) {
+      return Collections.emptyList();
+    }
+    return Collections.emptyList();
+  }
+
+  public static HttpResponse sendRequest(HttpRequest request, EmbeddedChannel nettyChannel) {
+
+    final ByteBuf payloadBuffer =
+        Unpooled.wrappedBuffer(
+            queryPayload(request.getBodyPayload().orElse("")).getBytes(StandardCharsets.UTF_8));
+
+    DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+
+    if (request.getCookie().isPresent()) {
+      httpHeaders.add(HttpHeaderNames.COOKIE, request.getCookie().get());
+    }
+
+    final FullHttpRequest fullHttpRequest =
+        new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1,
+            HttpMethod.valueOf(request.getMethod()),
+            request.getEndpoint(),
+            payloadBuffer,
+            httpHeaders,
+            httpHeaders);
+
+    fullHttpRequest.retain(1);
+    nettyChannel.writeInbound(fullHttpRequest);
+
+    final FullHttpResponse fullHttpResponse = nettyChannel.readOutbound();
+
+    return HttpResponse.of(
+        fullHttpResponse.status().code(),
+        fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -12,9 +12,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
@@ -131,10 +132,14 @@ public class TestUtils {
     fullHttpRequest.retain(1);
     nettyChannel.writeInbound(fullHttpRequest);
 
-    final FullHttpResponse fullHttpResponse = nettyChannel.readOutbound();
+    final DefaultHttpResponse defaultHttpResponse = nettyChannel.readOutbound();
 
-    return HttpResponse.of(
-        fullHttpResponse.status().code(),
-        fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+    if (defaultHttpResponse instanceof DefaultFullHttpResponse fullHttpResponse) {
+      return HttpResponse.of(
+          fullHttpResponse.status().code(),
+          fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+    }
+
+    return HttpResponse.of(defaultHttpResponse.status().code(), null);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -109,7 +109,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .hasSize("example.com/services/files/link/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", 5)
@@ -153,7 +153,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .hasSize("example.com/services/files/link/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", null)

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CreatePublicLinkApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static ShareRepository shareRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token",
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "fake-token-account-for-sharing",
+                    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+            .build()
+            .start();
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    shareRepository = injector.getInstance(ShareRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  void createFile(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "fake.txt", "", NodeType.TEXT, "LOCAL_ROOT", 1L);
+
+    fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
+  }
+
+  void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    shareRepository.upsertShare(
+        nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
+  }
+
+  @Test
+  void givenAFileIdAndAllLinkFieldsTheCreateLinkShouldCreateANewPublicLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "mutation { "
+            + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\", expires_at: 5, description: \\\"super-description\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> createdLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+
+    Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
+    Assertions.assertThat((String) createdLink.get("url"))
+        .startsWith("example.com/services/files/link/")
+        .hasSize("example.com/services/files/link/".length() + 8);
+
+    Assertions.assertThat(createdLink)
+        .containsEntry("expires_at", 5)
+        .containsEntry("description", "super-description");
+
+    Assertions.assertThat((Map<String, Object>) createdLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenAFileIdAndOnlyMandatoryLinkFieldsTheCreateLinkShouldCreateANewPublicLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "mutation { "
+            + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> createdLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+
+    Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
+    Assertions.assertThat((String) createdLink.get("url"))
+        .startsWith("example.com/services/files/link/")
+        .hasSize("example.com/services/files/link/".length() + 8);
+
+    Assertions.assertThat(createdLink)
+        .containsEntry("expires_at", null)
+        .containsEntry("description", null);
+
+    Assertions.assertThat((Map<String, Object>) createdLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenAFileIdAndAnExpiresAtToZeroTheCreateLinkShouldCreateANewPublicLinkWithoutExpiration() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "mutation { "
+            + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\", expires_at: 0) {"
+            + "id "
+            + "expires_at "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> createdLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+
+    Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
+
+    Assertions.assertThat(createdLink).containsEntry("expires_at", null);
+  }
+
+  @Test
+  void givenANotExistingNodeIdTheCreateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    final String bodyPayload =
+        "mutation { createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: 00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenAnExistingNodeSharedToAUserWithShareRightsTheCreateLinkShouldReturnANewPublicLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_AND_SHARE);
+
+    final String bodyPayload =
+        "mutation { createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> createdLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+
+    Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
+  }
+
+  @Test
+  void
+      givenAnExistingNodeSharedToAUserWithoutShareRightsTheCreateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_ONLY);
+
+    final String bodyPayload =
+        "mutation { createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: 00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void
+      givenAnExistingNodeAndAUserWithoutPermissionsTheCreateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "mutation { createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: 00000000-0000-0000-0000-000000000000");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -70,6 +70,11 @@ class CreatePublicLinkApiIT {
     fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
   }
 
+  void createFolder(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+  }
+
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
     shareRepository.upsertShare(
         nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
@@ -108,8 +113,8 @@ class CreatePublicLinkApiIT {
 
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 32);
+        .startsWith("example.com/services/files/public/link/download/")
+        .hasSize("example.com/services/files/public/link/download/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", 5)
@@ -152,8 +157,8 @@ class CreatePublicLinkApiIT {
 
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 32);
+        .startsWith("example.com/services/files/public/link/download/")
+        .hasSize("example.com/services/files/public/link/download/".length() + 32);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", null)
@@ -164,7 +169,51 @@ class CreatePublicLinkApiIT {
   }
 
   @Test
-  void givenAFileIdAndAnExpiresAtToZeroTheCreateLinkShouldCreateANewPublicLinkWithoutExpiration() {
+  void givenAFolderIdAndOnlyMandatoryLinkFieldsTheCreateLinkShouldCreateANewPublicLink() {
+    // Given
+    createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "mutation { "
+            + "createLink(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> createdLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+
+    Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
+    Assertions.assertThat((String) createdLink.get("url"))
+        .startsWith("example.com/files/public/link/access/")
+        .hasSize("example.com/files/public/link/access/".length() + 32);
+
+    Assertions.assertThat(createdLink)
+        .containsEntry("expires_at", null)
+        .containsEntry("description", null);
+
+    Assertions.assertThat((Map<String, Object>) createdLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenANodeIdAndAnExpiresAtToZeroTheCreateLinkShouldCreateANewPublicLinkWithoutExpiration() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockserver.model.HttpError;
+import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
+
+public class DownloadByPublicLinkApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            .withStorages()
+            .build()
+            .start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+    simulator.getStoragesMock().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "abcd1234,/public/link/download/,",
+    "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,",
+    "abcd1234,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,fake-token",
+    "abcd1234abcd1234abcd1234abcd1234,/link/,fake-token",
+  })
+  void
+      givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedTheDownloadByPublicLinkShouldReturnTheBlob(
+          String publicLinkId, String publicLinkEndpoint, String userToken) {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "test.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        10L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        10L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        publicLinkId,
+        Optional.empty(),
+        Optional.empty());
+
+    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+
+    final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
+    HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download")
+                .withQueryStringParameter(
+                    Parameter.param("node", "00000000-0000-0000-0000-000000000000"))
+                .withQueryStringParameter(Parameter.param("version", "1"))
+                .withQueryStringParameter(Parameter.param("type", "files")),
+            VerificationTimes.once());
+  }
+
+  @Test
+  void givenANotExistingLinkTheDownloadByPublicLinkShouldReturnA404StatusCode() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "file.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        1L);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        "000000",
+        Optional.empty(),
+        Optional.empty());
+
+    HttpRequest httpRequest = HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"),
+            VerificationTimes.never());
+  }
+
+  @Test
+  void givenANotExistingNodeTheDownloadByPublicLinkShouldReturnA404StatusCode() {
+    // Given
+    HttpRequest httpRequest = HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+
+    simulator
+        .getStoragesMock()
+        .verify(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"),
+            VerificationTimes.never());
+  }
+
+  @Test
+  void t() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "test.txt",
+        "",
+        NodeType.TEXT,
+        "LOCAL_ROOT",
+        10L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        10L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "94103c01-e701-4f3d-9dc9-54b79064ad76",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd1234abcd1234abcd1234abcd",
+        Optional.empty(),
+        Optional.empty());
+
+    simulator
+        .getStoragesMock()
+        .when(
+            org.mockserver.model.HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download"))
+        .error(HttpError.error().withDropConnection(true));
+
+    // When
+    HttpRequest httpRequest =
+        HttpRequest.of("GET", "/public/link/download/1234abcd1234abcd1234abcd1234abcd", null, null);
+
+    // Then
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
@@ -74,6 +74,11 @@ class GetPublicLinksApiIT {
     fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
   }
 
+  void createFolder(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+  }
+
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
     shareRepository.upsertShare(
         nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
@@ -81,7 +86,7 @@ class GetPublicLinksApiIT {
 
   @Test
   void
-      givenAnExistingNodeWithTwoExistingLinksTheGetLinksShouldReturnAListOfAssociatedLinksOrderedByCreationDescending() {
+      givenAnExistingFileWithTwoExistingLinksTheGetLinksShouldReturnAListOfAssociatedLinksOrderedByCreationDescending() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
@@ -128,7 +133,9 @@ class GetPublicLinksApiIT {
 
     Assertions.assertThat(publicLinks.get(0))
         .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
-        .containsEntry("url", "example.com/services/files/link/00001234abcd1234abcd1234abcd1234")
+        .containsEntry(
+            "url",
+            "example.com/services/files/public/link/download/00001234abcd1234abcd1234abcd1234")
         .containsEntry("expires_at", null)
         .containsEntry("description", null);
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
@@ -136,7 +143,59 @@ class GetPublicLinksApiIT {
 
     Assertions.assertThat(publicLinks.get(1))
         .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
-        .containsEntry("url", "example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234")
+        .containsEntry(
+            "url",
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234")
+        .containsEntry("expires_at", 5)
+        .containsEntry("description", "super-description");
+    Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void
+      givenAnExistingFolderWithOneExistingLinkTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
+    // Given
+    createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "query { "
+            + "getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { id } "
+            + "} "
+            + "} ";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<Map<String, Object>> publicLinks =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+
+    Assertions.assertThat(publicLinks).hasSize(1);
+
+    Assertions.assertThat(publicLinks.get(0))
+        .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
+        .containsEntry(
+            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description");
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
@@ -292,41 +351,41 @@ class GetPublicLinksApiIT {
   }
 
   @Test
-  void givenAnExistingNodeAndAnAssociatedLegacyPublicLinkWithAn8CharsPublicIdentifierTheGetLinksShouldReturnItCorrectly() {
+  void
+      givenAnExistingFileAndAnAssociatedLegacyPublicLinkWithAn8CharsPublicIdentifierTheGetLinksShouldReturnItCorrectly() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
-      "00000000-0000-0000-0000-000000000000",
-      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-      SharePermission.READ_ONLY);
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_ONLY);
 
     linkRepository.createLink(
-      "0c04783b-bdfb-446f-870c-625f5ae02a0a",
-      "00000000-0000-0000-0000-000000000000",
-      "abcd1234",
-      Optional.empty(),
-      Optional.empty());
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234",
+        Optional.empty(),
+        Optional.empty());
 
     final String bodyPayload =
-      "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id url }}";
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id url }}";
 
     final HttpRequest httpRequest =
-      HttpRequest.of(
-        "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
     final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
     final List<Map<String, Object>> publicLinks =
-      TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
 
     Assertions.assertThat(publicLinks).hasSize(1);
     Assertions.assertThat(publicLinks.get(0))
-      .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
-      .containsEntry("url", "example.com/services/files/link/abcd1234");
+        .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
+        .containsEntry("url", "example.com/services/files/public/link/download/abcd1234");
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class GetPublicLinksApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+  static ShareRepository shareRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token",
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "fake-token-account-for-sharing",
+                    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+            .build()
+            .start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+    shareRepository = injector.getInstance(ShareRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  void createFile(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "fake.txt", "", NodeType.TEXT, "LOCAL_ROOT", 1L);
+
+    fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
+  }
+
+  void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    shareRepository.upsertShare(
+        nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
+  }
+
+  @Test
+  void
+      givenAnExistingNodeWithTwoExistingLinksTheGetLinksShouldReturnAListOfAssociatedLinksOrderedByCreationDescending() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    linkRepository.createLink(
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "0000aaaa",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { "
+            + "getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { id } "
+            + "} "
+            + "} ";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<Map<String, Object>> publicLinks =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+
+    Assertions.assertThat(publicLinks).hasSize(2);
+
+    Assertions.assertThat(publicLinks.get(0))
+        .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a")
+        .containsEntry("url", "example.com/services/files/link/0000aaaa")
+        .containsEntry("expires_at", null)
+        .containsEntry("description", null);
+    Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+
+    Assertions.assertThat(publicLinks.get(1))
+        .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
+        .containsEntry("url", "example.com/services/files/link/1234abcd")
+        .containsEntry("expires_at", 5)
+        .containsEntry("description", "super-description");
+    Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenAnExistingNodeWithoutLinksTheGetLinksShouldReturnAnEmptyList() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    final String bodyPayload =
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id }}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks"))
+        .isEmpty();
+  }
+
+  // TODO it should return an error message
+  @Test
+  void givenANotExistingNodeTheGetLinksShouldReturn200StatusCodeAndNull() {
+    // Given
+    final String bodyPayload =
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id }}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks"))
+        .first()
+        .isNull();
+  }
+
+  // TODO it should return an error message
+  @Test
+  void
+      givenAnExistingNodeALinkAssociatedAndAUserWithoutPermissionsTheGetLinksShouldReturn200StatusCodeAndNull() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "0000aaaa",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id }}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks"))
+        .first()
+        .isNull();
+  }
+
+  // TODO it should return an error message
+  @Test
+  void
+      givenAnExistingNodeSharedToAUserWithoutShareRightsAndAnExistingLinkTheGetLinksShouldReturn200CodeAndNull() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_ONLY);
+
+    linkRepository.createLink(
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "0000aaaa",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id }}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks"))
+        .first()
+        .isNull();
+  }
+
+  @Test
+  void
+      givenAnExistingNodeSharedToAUserWithShareRightsAndAnExistingLinkTheGetLinksShouldReturnAListOfAssociatedLinks() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_AND_SHARE);
+
+    linkRepository.createLink(
+        "0c04783b-bdfb-446f-870c-625f5ae02a0a",
+        "00000000-0000-0000-0000-000000000000",
+        "0000aaaa",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { getLinks(node_id: \\\"00000000-0000-0000-0000-000000000000\\\") { id }}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<Map<String, Object>> publicLinks =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getLinks");
+
+    Assertions.assertThat(publicLinks).hasSize(1);
+    Assertions.assertThat(publicLinks.get(0))
+        .containsEntry("id", "0c04783b-bdfb-446f-870c-625f5ae02a0a");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class GetPublicNodeApiIT {
+
+  static Simulator simulator;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  @Test
+  void givenAPublicLinkIdAndAnExistingNodeTheGetPublicNodeShouldReturnTheNode() {
+    // Given
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
+            + "id "
+            + "created_at "
+            + "updated_at "
+            + "name "
+            + "type "
+            + "} "
+            + "}";
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(
+            TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode"))
+        .isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -201,4 +201,46 @@ public class GetPublicNodeApiIT {
         .hasSize(1)
         .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
   }
+
+  @Test
+  void
+      givenAnExpiredPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(1L),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { id }}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errorMessages =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errorMessages)
+        .hasSize(1)
+        .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
+  }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicNodeApiIT.java
@@ -4,24 +4,47 @@
 
 package com.zextras.carbonio.files.api;
 
+import com.google.inject.Injector;
 import com.zextras.carbonio.files.Simulator;
 import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class GetPublicNodeApiIT {
 
   static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static LinkRepository linkRepository;
+  static FileVersionRepository fileVersionRepository;
 
   @BeforeAll
   static void init() {
     simulator =
         SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
   }
 
   @AfterAll
@@ -30,8 +53,27 @@ public class GetPublicNodeApiIT {
   }
 
   @Test
-  void givenAPublicLinkIdAndAnExistingNodeTheGetPublicNodeShouldReturnTheNode() {
+  void givenAPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturnThePublicFolder() {
     // Given
+    final Node folder =
+        nodeRepository.createNewNode(
+            "00000000-0000-0000-0000-000000000000",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "LOCAL_ROOT",
+            "folder",
+            "",
+            NodeType.FOLDER,
+            "LOCAL_ROOT",
+            0L);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
     final String bodyPayload =
         "query { "
             + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
@@ -42,6 +84,7 @@ public class GetPublicNodeApiIT {
             + "type "
             + "} "
             + "}";
+
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
@@ -49,8 +92,113 @@ public class GetPublicNodeApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    Assertions.assertThat(
-            TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode"))
-        .isEmpty();
+
+    final Map<String, Object> publicNode =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode");
+
+    Assertions.assertThat(publicNode.get("id")).isEqualTo("00000000-0000-0000-0000-000000000000");
+    Assertions.assertThat(publicNode.get("created_at")).isEqualTo(folder.getCreatedAt());
+    Assertions.assertThat(publicNode.get("updated_at")).isEqualTo(folder.getUpdatedAt());
+    Assertions.assertThat(publicNode.get("name")).isEqualTo("folder");
+    Assertions.assertThat(publicNode.get("type")).isEqualTo(NodeType.FOLDER.toString());
+  }
+
+  @Test
+  void givenAPublicLinkIdAndAnExistingFileTheGetPublicNodeShouldReturnThePublicFile() {
+    // Given
+    final Node file =
+        nodeRepository.createNewNode(
+            "00000000-0000-0000-0000-000000000000",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "LOCAL_ROOT",
+            "test.txt",
+            "",
+            NodeType.TEXT,
+            "LOCAL_ROOT",
+            5L);
+
+    fileVersionRepository.createNewFileVersion(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        1,
+        "text/plain",
+        5L,
+        "",
+        false);
+
+    linkRepository.createLink(
+        "8cac6df0-3ecb-451d-a953-10c3ac5e3ebc",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { "
+            + "id "
+            + "created_at "
+            + "updated_at "
+            + "name "
+            + "type "
+            + "... on File { extension mime_type size }"
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> publicNode =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getPublicNode");
+
+    Assertions.assertThat(publicNode.get("id")).isEqualTo("00000000-0000-0000-0000-000000000000");
+    Assertions.assertThat(publicNode.get("created_at")).isEqualTo(file.getCreatedAt());
+    Assertions.assertThat(publicNode.get("updated_at")).isEqualTo(file.getUpdatedAt());
+    Assertions.assertThat(publicNode.get("name")).isEqualTo("test");
+    Assertions.assertThat(publicNode.get("extension")).isEqualTo("txt");
+    Assertions.assertThat(publicNode.get("type")).isEqualTo(NodeType.TEXT.toString());
+    Assertions.assertThat(publicNode.get("mime_type")).isEqualTo("text/plain");
+    Assertions.assertThat(publicNode.get("size")).isEqualTo(5.0);
+  }
+
+  @Test
+  void
+      givenANotExistingPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    final String bodyPayload =
+        "query { "
+            + "getPublicNode(node_link_id: \\\"abcd1234abcd1234abcd1234abcd1234\\\") { id }}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errorMessages =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errorMessages)
+        .hasSize(1)
+        .containsExactly("Could not find link with id abcd1234abcd1234abcd1234abcd1234");
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicFindNodesApiIT.java
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PublicFindNodesApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  void createFolderTree() {
+    String ownerId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        ownerId,
+        ownerId,
+        "LOCAL_ROOT",
+        "public folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    nodeRepository.createNewNode(
+        "11111111-1111-1111-1111-111111111111",
+        ownerId,
+        ownerId,
+        "00000000-0000-0000-0000-000000000000",
+        "folder child",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT,00000000-0000-0000-0000-000000000000",
+        0L);
+
+    final List<String> childrenFileIds =
+        Arrays.asList(
+            "22222222-2222-2222-2222-222222222222",
+            "33333333-3333-3333-3333-333333333333",
+            "44444444-4444-4444-4444-444444444444",
+            "55555555-5555-5555-5555-555555555555");
+
+    childrenFileIds.forEach(
+        fileId -> {
+          nodeRepository.createNewNode(
+              fileId,
+              ownerId,
+              ownerId,
+              "00000000-0000-0000-0000-000000000000",
+              "file child id " + fileId.charAt(0) + ".txt",
+              "",
+              NodeType.TEXT,
+              "LOCAL_ROOT,00000000-0000-0000-0000-000000000000",
+              5L);
+
+          fileVersionRepository.createNewFileVersion(
+              fileId, ownerId, 1, "text/plain", 5L, "", false);
+        });
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder with five nodes inside, a valid public link associated, a limit of
+    three elements per page: the findNodes should return the first page containing three nodes
+    ordered by category and alphabetically and the page_token for the next page""")
+  @Test
+  void givenAnExistingFolderAndAValidPublicLinkTheFindNodesShouldReturnTheFirstPage() {
+    // Given
+    createFolderTree();
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\", limit: 3) { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+    Assertions.assertThat(page.get("page_token")).isNotNull();
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+    Assertions.assertThat(nodes).hasSize(3);
+    Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "11111111-1111-1111-1111-111111111111")
+        .containsEntry("name", "folder child");
+    Assertions.assertThat(nodes.get(1))
+        .containsEntry("id", "22222222-2222-2222-2222-222222222222")
+        .containsEntry("name", "file child id 2");
+    Assertions.assertThat(nodes.get(2))
+        .containsEntry("id", "33333333-3333-3333-3333-333333333333")
+        .containsEntry("name", "file child id 3");
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder with five nodes inside, a valid public link associated, a limit of
+    three elements per page and a page token for the second page: the findNodes should return the
+    second page containing two nodes and a null page_token""")
+  @Test
+  void givenAnExistingFolderAndAValidLinkTheFindNodesShouldReturnTheSecondPage() {
+    // Given
+    createFolderTree();
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    // Start request first page of the folder content
+    final String firstBodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\", limit: 3) { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest firstHttpRequest =
+        HttpRequest.of("POST", "/public/graphql/", null, firstBodyPayload);
+    final HttpResponse firstHttpResponse =
+        TestUtils.sendRequest(firstHttpRequest, simulator.getNettyChannel());
+
+    Assertions.assertThat(firstHttpResponse.getStatus()).isEqualTo(200);
+    String pageToken =
+        (String)
+            TestUtils.jsonResponseToMap(firstHttpResponse.getBodyPayload(), "findNodes")
+                .get("page_token");
+    // End request first page of the folder content
+
+    final String bodyPayload =
+        "query { findNodes("
+            + "folder_id: \\\"00000000-0000-0000-0000-000000000000\\\", "
+            + "limit: 3, "
+            + "page_token: \\\""
+            + pageToken
+            + "\\\") { "
+            + "nodes {id name}, page_token }"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+    Assertions.assertThat(page.get("page_token")).isNull();
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+    Assertions.assertThat(nodes).hasSize(2);
+    Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "44444444-4444-4444-4444-444444444444")
+        .containsEntry("name", "file child id 4");
+    Assertions.assertThat(nodes.get(1))
+        .containsEntry("id", "55555555-5555-5555-5555-555555555555")
+        .containsEntry("name", "file child id 5");
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder with five nodes inside, a valid public link associated, a limit of
+    six elements per page: the findNodes should return the first page containing five nodes ordered
+    by category and alphabetically and a null page_token since there is no more pages to fetch""")
+  @Test
+  void givenAnExistingFolderAndAValidPublicLinkTheFindNodesShouldReturnTheOnlyPageExisting() {
+    // Given
+    createFolderTree();
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\", limit: 6) { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+    Assertions.assertThat(page.get("page_token")).isNull();
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+    Assertions.assertThat(nodes).hasSize(5);
+    Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "11111111-1111-1111-1111-111111111111")
+        .containsEntry("name", "folder child");
+    Assertions.assertThat(nodes.get(1))
+        .containsEntry("id", "22222222-2222-2222-2222-222222222222")
+        .containsEntry("name", "file child id 2");
+    Assertions.assertThat(nodes.get(2))
+        .containsEntry("id", "33333333-3333-3333-3333-333333333333")
+        .containsEntry("name", "file child id 3");
+    Assertions.assertThat(nodes.get(3))
+        .containsEntry("id", "44444444-4444-4444-4444-444444444444")
+        .containsEntry("name", "file child id 4");
+    Assertions.assertThat(nodes.get(4))
+        .containsEntry("id", "55555555-5555-5555-5555-555555555555")
+        .containsEntry("name", "file child id 5");
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder without nodes inside, a valid public link associated: the findNodes
+    should return an empty first page and a null page_token""")
+  @Test
+  void givenAnExistingEmptyFolderAndAValidPublicLinkTheFindNodesShouldReturnAnEmptyFirstPage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "public folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+    Assertions.assertThat(page.get("page_token")).isNull();
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+    Assertions.assertThat(nodes).isEmpty();
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder without nodes inside, a valid public link associated: the findNodes
+    should return an empty first page and a null page_token""")
+  @Test
+  void
+      givenAnExistingFolderAndAnExpiredPublicLinkTheFindNodesShouldReturn200CodeAndAnErrorMessage() {
+    // Given
+    nodeRepository.createNewNode(
+        "00000000-0000-0000-0000-000000000000",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "public folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(1L), // The link is already expired
+        Optional.empty());
+
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id 00000000-0000-0000-0000-000000000000");
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder with five nodes inside, a not existing public link associated: the
+    findNodes should return 200 status code and an error message""")
+  @Test
+  void
+      givenAnExistingFolderAndANotExistingPublicLinkTheFindNodesShouldReturnAn200StatusWithAnErrorMessage() {
+    // Given
+    createFolderTree();
+
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id 00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenANotExistingFolderTheFindNodesShouldReturnAn200StatusWithAnErrorMessage() {
+    // Given
+    final String bodyPayload =
+        "query { findNodes(folder_id: \\\"00000000-0000-0000-0000-000000000000\\\") { "
+            + "nodes {id name},"
+            + "page_token"
+            + "}"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id 00000000-0000-0000-0000-000000000000");
+  }
+
+  @DisplayName(
+      """
+    Given an existing folder with five nodes inside, a valid public link associated, another folder
+    not public and an hacked page token that is formed to try access a private node: the findNodes
+    should return an empty page""")
+  @Test
+  void givenAnHackedPageTokenTheFindNodesShouldReturnAnEmptyList() {
+    // Given
+    createFolderTree();
+
+    linkRepository.createLink(
+        "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    // Another folder not public
+    nodeRepository.createNewNode(
+        "77777777-7777-7777-7777-777777777777",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "LOCAL_ROOT",
+        "not public folder",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT",
+        0L);
+
+    nodeRepository.createNewNode(
+        "88888888-8888-8888-8888-888888888888",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "77777777-7777-7777-7777-777777777777",
+        "folder child",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT,77777777-7777-7777-7777-777777777777",
+        0L);
+
+    nodeRepository.createNewNode(
+        "99999999-9999-9999-9999-999999999999",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "77777777-7777-7777-7777-777777777777",
+        "folder child 2",
+        "",
+        NodeType.FOLDER,
+        "LOCAL_ROOT,77777777-7777-7777-7777-777777777777",
+        0L);
+
+    String pageTokenHacked =
+        """
+    {
+      "limit": 1,
+      "keywords": [],
+      "keySet": "(node_category > 1) OR (node_category = 1 AND LOWER(name)>'folder child') OR (node_category = 1 AND LOWER(name) = 'folder child' AND t0.node_id > '88888888-8888-8888-8888-888888888888')",
+      "sort": "NAME_ASC",
+      "flagged": null,
+      "folderId": "77777777-7777-7777-7777-777777777777",
+      "cascade": null,
+      "sharedWithMe": null,
+      "sharedByMe": null,
+      "directShare": null,
+      "nodeType": null,
+      "ownerId": null
+    }""";
+
+    final String bodyPayload =
+        "query { findNodes("
+            + "folder_id: \\\"00000000-0000-0000-0000-000000000000\\\", "
+            + "limit: 1, "
+            + "page_token: \\\""
+            + Base64.getEncoder().encodeToString(pageTokenHacked.getBytes())
+            + "\\\") { "
+            + "nodes {id}, page_token }"
+            + "}";
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+    Assertions.assertThat(page.get("page_token")).isNull();
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+    Assertions.assertThat(nodes).isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -73,13 +73,19 @@ class UpdatePublicLinkApiIT {
     fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
   }
 
+  void createFolder(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "folder", "", NodeType.FOLDER, "LOCAL_ROOT", 0L);
+  }
+
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
     shareRepository.upsertShare(
         nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
   }
 
   @Test
-  void givenAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
+  void
+      givenAnExistingFileAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
@@ -117,7 +123,8 @@ class UpdatePublicLinkApiIT {
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat((String) updatedLink.get("url"))
-        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
+        .isEqualTo(
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -129,7 +136,8 @@ class UpdatePublicLinkApiIT {
   }
 
   @Test
-  void givenAnExistingLinkAndNoFieldsToUpdateTheUpdateLinkShouldReturnTheUntouchedLink() {
+  void
+      givenAnExistingFileAnExistingLinkAndNoFieldsToUpdateTheUpdateLinkShouldReturnTheUntouchedLink() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
@@ -168,12 +176,64 @@ class UpdatePublicLinkApiIT {
 
     Assertions.assertThat((String) updatedLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) updatedLink.get("url"))
-        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
+        .isEqualTo(
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description");
+
+    Assertions.assertThat((Map<String, Object>) updatedLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void
+      givenAnExistingFolderAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
+    // Given
+    createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.empty(),
+        Optional.empty());
+
+    final String bodyPayload =
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 10, description: \\\"another-description\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> updatedLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+
+    Assertions.assertThat((String) updatedLink.get("url"))
+        .isEqualTo("example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234");
+
+    Assertions.assertThat(updatedLink)
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", 10)
+        .containsEntry("description", "another-description");
 
     Assertions.assertThat((Map<String, Object>) updatedLink.get("node"))
         .containsEntry("id", "00000000-0000-0000-0000-000000000000");
@@ -235,6 +295,43 @@ class UpdatePublicLinkApiIT {
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
         .containsEntry("description", "");
+  }
+
+  @Test
+  void
+      givenAnExistingNodeAnExistingLinkWithExpirationAndAnExpiresAtToZeroTheUpdateLinkShouldReturnAnUpdatedLinkWithoutExpiration() {
+    // Given
+    createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "abcd1234abcd1234abcd1234abcd1234",
+        Optional.of(5L),
+        Optional.empty());
+
+    final String bodyPayload =
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 0) {"
+            + "id "
+            + "expires_at"
+            + "}"
+            + "}";
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> updatedLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+
+    Assertions.assertThat(updatedLink)
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", null);
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -86,7 +86,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -117,8 +117,7 @@ class UpdatePublicLinkApiIT {
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat((String) updatedLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -137,7 +136,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -169,8 +168,7 @@ class UpdatePublicLinkApiIT {
 
     Assertions.assertThat((String) updatedLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) updatedLink.get("url"))
-        .startsWith("example.com/services/files/link/")
-        .hasSize("example.com/services/files/link/".length() + 8);
+        .isEqualTo("example.com/services/files/link/abcd1234abcd1234abcd1234abcd1234");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -215,7 +213,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -252,7 +250,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 
@@ -284,7 +282,7 @@ class UpdatePublicLinkApiIT {
     linkRepository.createLink(
         "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
         "00000000-0000-0000-0000-000000000000",
-        "1234abcd",
+        "abcd1234abcd1234abcd1234abcd1234",
         Optional.of(5L),
         Optional.of("super-description"));
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class UpdatePublicLinkApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+  static ShareRepository shareRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token",
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "fake-token-account-for-sharing",
+                    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+            .build()
+            .start();
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+    shareRepository = injector.getInstance(ShareRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  void createFile(String nodeId, String ownerId) {
+    nodeRepository.createNewNode(
+        nodeId, ownerId, ownerId, "LOCAL_ROOT", "fake.txt", "", NodeType.TEXT, "LOCAL_ROOT", 1L);
+
+    fileVersionRepository.createNewFileVersion(nodeId, ownerId, 1, "text/plain", 1L, "", false);
+  }
+
+  void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    shareRepository.upsertShare(
+        nodeId, targetUserId, ACL.decode(permission), true, false, Optional.empty());
+  }
+
+  @Test
+  void givenAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", expires_at: 10, description: \\\"another-description\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> updatedLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+
+    Assertions.assertThat((String) updatedLink.get("url"))
+        .startsWith("example.com/services/files/link/")
+        .hasSize("example.com/services/files/link/".length() + 8);
+
+    Assertions.assertThat(updatedLink)
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", 10)
+        .containsEntry("description", "another-description");
+
+    Assertions.assertThat((Map<String, Object>) updatedLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenAnExistingLinkAndNoFieldsToUpdateTheUpdateLinkShouldReturnTheUntouchedLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "mutation { "
+            + "updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\") {"
+            + "id "
+            + "url "
+            + "expires_at "
+            + "created_at "
+            + "description "
+            + "node { "
+            + "  id "
+            + "} "
+            + "} "
+            + "}";
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> updatedLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+
+    Assertions.assertThat((String) updatedLink.get("id")).isNotNull().hasSize(36);
+    Assertions.assertThat((String) updatedLink.get("url"))
+        .startsWith("example.com/services/files/link/")
+        .hasSize("example.com/services/files/link/".length() + 8);
+
+    Assertions.assertThat(updatedLink)
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("expires_at", 5)
+        .containsEntry("description", "super-description");
+
+    Assertions.assertThat((Map<String, Object>) updatedLink.get("node"))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  void givenANotExistingLinkTheUpdateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    final String bodyPayload =
+        "mutation { updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly("Could not find link with id cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b");
+  }
+
+  @Test
+  void
+      givenAnExistingNodeSharedToAUserWithShareRightsAndAnExistingLinkTheUpdateLinkShouldReturnAnUpdatedLink() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_AND_SHARE);
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "mutation { updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\", description: \\\"\\\") {id description}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final Map<String, Object> updatedLink =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
+
+    Assertions.assertThat(updatedLink)
+        .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
+        .containsEntry("description", "");
+  }
+
+  @Test
+  void
+      givenAnExistingNodeSharedToAUserWithoutShareRightsAndAnExistingLinkTheUpdateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    createShare(
+        "00000000-0000-0000-0000-000000000000",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        SharePermission.READ_ONLY);
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "mutation { updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly("Could not find link with id cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b");
+  }
+
+  @Test
+  void
+      givenAnExistingNodeAndAUserWithoutPermissionsAndAnExistingLinkTheUpdateLinkShouldReturn200CodeWithAnErrorMessage() {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    linkRepository.createLink(
+        "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
+        "00000000-0000-0000-0000-000000000000",
+        "1234abcd",
+        Optional.of(5L),
+        Optional.of("super-description"));
+
+    final String bodyPayload =
+        "mutation { updateLink(link_id: \\\"cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b\\\") {id}}";
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    final List<String> errorResponse =
+        TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+        .hasSize(1)
+        .containsExactly("Could not find link with id cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -11,6 +11,7 @@ import com.zextras.carbonio.files.rest.controllers.HealthController;
 import com.zextras.carbonio.files.rest.controllers.MetricsController;
 import com.zextras.carbonio.files.rest.controllers.PreviewController;
 import com.zextras.carbonio.files.rest.controllers.ProcedureController;
+import com.zextras.carbonio.files.rest.controllers.PublicBlobController;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -32,6 +33,7 @@ class HttpRoutingHandlerTest {
   private HealthController healthControllerMock;
   private GraphQLController graphQLControllerMock;
   private BlobController blobControllerMock;
+  private PublicBlobController publicBlobController;
   private AuthenticationHandler authenticationHandlerMock;
   private ExceptionsHandler exceptionsHandlerMock;
   private PreviewController previewControllerMock;
@@ -48,6 +50,7 @@ class HttpRoutingHandlerTest {
     healthControllerMock = Mockito.mock(HealthController.class);
     graphQLControllerMock = Mockito.mock(GraphQLController.class);
     blobControllerMock = Mockito.mock(BlobController.class);
+    publicBlobController = Mockito.mock(PublicBlobController.class);
     authenticationHandlerMock = Mockito.mock(AuthenticationHandler.class);
     exceptionsHandlerMock = Mockito.mock(ExceptionsHandler.class);
     previewControllerMock = Mockito.mock(PreviewController.class);
@@ -68,6 +71,7 @@ class HttpRoutingHandlerTest {
             healthControllerMock,
             graphQLControllerMock,
             blobControllerMock,
+            publicBlobController,
             authenticationHandlerMock,
             exceptionsHandlerMock,
             previewControllerMock,
@@ -201,7 +205,7 @@ class HttpRoutingHandlerTest {
 
     // Then
     Mockito.verify(channelPipelineMock, Mockito.times(1))
-        .addLast("rest-handler", blobControllerMock);
+        .addLast("rest-handler", publicBlobController);
     Mockito.verify(channelPipelineMock, Mockito.times(1))
         .addLast("exceptions-handler", exceptionsHandlerMock);
     Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -30,19 +29,19 @@ import org.mockito.Mockito;
 
 class HttpRoutingHandlerTest {
 
-  private HealthController            healthControllerMock;
-  private GraphQLController           graphQLControllerMock;
-  private BlobController              blobControllerMock;
-  private AuthenticationHandler       authenticationHandlerMock;
-  private ExceptionsHandler           exceptionsHandlerMock;
-  private PreviewController           previewControllerMock;
-  private ProcedureController         procedureControllerMock;
+  private HealthController healthControllerMock;
+  private GraphQLController graphQLControllerMock;
+  private BlobController blobControllerMock;
+  private AuthenticationHandler authenticationHandlerMock;
+  private ExceptionsHandler exceptionsHandlerMock;
+  private PreviewController previewControllerMock;
+  private ProcedureController procedureControllerMock;
   private CollaborationLinkController collaborationLinkControllerMock;
-  private MetricsController           metricsControllerMock;
-  private ChannelHandlerContext       channelHandlerContextMock;
-  private ChannelPipeline             channelPipelineMock;
-  private HttpRequest                 httpRequestMock;
-  private HttpRoutingHandler          httpRoutingHandler;
+  private MetricsController metricsControllerMock;
+  private ChannelHandlerContext channelHandlerContextMock;
+  private ChannelPipeline channelPipelineMock;
+  private HttpRequest httpRequestMock;
+  private HttpRoutingHandler httpRoutingHandler;
 
   @BeforeEach
   void initTest() {
@@ -60,335 +59,288 @@ class HttpRoutingHandlerTest {
     httpRequestMock = Mockito.mock(HttpRequest.class);
 
     Mockito.when(channelHandlerContextMock.pipeline()).thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.anyString(), Mockito.any(ChannelHandler.class)))
-      .thenReturn(channelPipelineMock);
+    Mockito.when(
+            channelPipelineMock.addLast(Mockito.anyString(), Mockito.any(ChannelHandler.class)))
+        .thenReturn(channelPipelineMock);
 
-    httpRoutingHandler = new HttpRoutingHandler(
-      healthControllerMock,
-      graphQLControllerMock,
-      blobControllerMock,
-      authenticationHandlerMock,
-      exceptionsHandlerMock,
-      previewControllerMock,
-      procedureControllerMock,
-      collaborationLinkControllerMock,
-      metricsControllerMock
-    );
+    httpRoutingHandler =
+        new HttpRoutingHandler(
+            healthControllerMock,
+            graphQLControllerMock,
+            blobControllerMock,
+            authenticationHandlerMock,
+            exceptionsHandlerMock,
+            previewControllerMock,
+            procedureControllerMock,
+            collaborationLinkControllerMock,
+            metricsControllerMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/metrics/", "/metrics"})
-  void givenAMetricsRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAMetricsRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("metrics-handler", metricsControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("metrics-handler", metricsControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/health/",
-    "/health",
-    "/health/live",
-    "/health/live/",
-    "/health/ready",
-    "/health/ready/"
-  })
-  void givenAnHealthRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/health/",
+        "/health",
+        "/health/live",
+        "/health/live/",
+        "/health/ready",
+        "/health/ready/"
+      })
+  void givenAnHealthRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("health-handler", healthControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("health-handler", healthControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/graphql/", "/graphql"})
-  void givenAGraphqlRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAGraphqlRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(HttpObjectAggregator.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(ChunkedWriteHandler.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("graphql-handler", graphQLControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(HttpObjectAggregator.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(ChunkedWriteHandler.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("graphql-handler", graphQLControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/upload",
-    "/upload/",
-    "/upload-version",
-    "/upload-version/"
-  })
-  void givenAnUploadOrDownloadRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/upload",
+        "/upload/",
+        "/upload-version",
+        "/upload-version/"
+      })
+  void
+      givenAnUploadOrDownloadRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+          String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("rest-handler", blobControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("rest-handler", blobControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/link/abcd1234",
-    "/link/abcd1234/",
-    "/link/abcd1234abcd1234abcd1234abcd1234",
-    "/link/abcd1234abcd1234abcd1234abcd1234/"
-  })
-  void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/link/abcd1234",
+        "/link/abcd1234/",
+        "/link/abcd1234abcd1234abcd1234abcd1234",
+        "/link/abcd1234abcd1234abcd1234abcd1234/",
+        "/public/link/download/abcd1234",
+        "/public/link/download/abcd1234/",
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
+      })
+  void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("rest-handler", blobControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("rest-handler", blobControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/invite/abcd1234",
-    "/invite/abcd1234/"
-  })
-  void givenAnInvitationLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(strings = {"/invite/abcd1234", "/invite/abcd1234/"})
+  void givenAnInvitationLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("collaboration-link-handler", collaborationLinkControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("collaboration-link-handler", collaborationLinkControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   // The main regex for the Preview endpoint is "/preview/(.*)"
   // However I listed all the acceptable url even if the pattern accepts everything
-  @ValueSource(strings = {
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-    "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/"
-  })
-  void givenAPreviewRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  @ValueSource(
+      strings = {
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/"
+      })
+  void givenAPreviewRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("preview-handler", previewControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("preview-handler", previewControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"/upload-to/", "/upload-to"})
-  void givenAnUploadToModuleRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
+  void givenAnUploadToModuleRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
+      String uri) {
     // Given
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
-      .thenReturn(channelPipelineMock);
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(uri);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(HttpObjectAggregator.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(channelPipelineMock.addLast(Mockito.any(ChunkedWriteHandler.class)))
+        .thenReturn(channelPipelineMock);
+    Mockito.when(httpRequestMock.uri()).thenReturn(uri);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(HttpObjectAggregator.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast(Mockito.any(ChunkedWriteHandler.class));
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("auth-handler", authenticationHandlerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("procedure-handler", procedureControllerMock);
-    Mockito
-      .verify(channelPipelineMock, Mockito.times(1))
-      .addLast("exceptions-handler", exceptionsHandlerMock);
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .fireChannelRead(httpRequestMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(HttpObjectAggregator.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast(Mockito.any(ChunkedWriteHandler.class));
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("auth-handler", authenticationHandlerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("procedure-handler", procedureControllerMock);
+    Mockito.verify(channelPipelineMock, Mockito.times(1))
+        .addLast("exceptions-handler", exceptionsHandlerMock);
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).fireChannelRead(httpRequestMock);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    "/invalid/endpoint",
-    "/metrics/invalid",
-    "/health/invalid",
-    "/health/live/invalid",
-    "/health/ready/invalid",
-    "/graphql/invalid",
-    "/download/invalid",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/invalid",
-    "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/invalid",
-    "/upload/invalid",
-    "/upload-version/invalid",
-    "/link/abcd1234/invalid",
-    "/link/seven00",
-    "/link/seven00/",
-    "/link/nine00000",
-    "/link/nine00000/",
-    "/link/thirtythreethirtythreethirtythree",
-    "/link/thirtythreethirtythreethirtythree/",
-    "/invite/abcd1234/invalid",
-    "/upload-to/invalid"
-  })
+  @ValueSource(
+      strings = {
+        "/invalid/endpoint",
+        "/metrics/invalid",
+        "/health/invalid",
+        "/health/live/invalid",
+        "/health/ready/invalid",
+        "/graphql/invalid",
+        "/download/invalid",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/invalid",
+        "/download/8caeef71-6f72-439c-847a-38e90efd0965/1/invalid",
+        "/upload/invalid",
+        "/upload-version/invalid",
+        "/link/abcd1234/invalid",
+        "/link/seven00",
+        "/link/seven00/",
+        "/link/nine00000",
+        "/link/nine00000/",
+        "/link/thirtythreethirtythreethirtythree",
+        "/link/thirtythreethirtythreethirtythree/",
+        "/public/link/download/abcd1234/invalid",
+        "/public/link/download/seven00",
+        "/public/link/download/seven00/",
+        "/public/link/download/nine00000",
+        "/public/link/download/nine00000/",
+        "/public/link/download/thirtythreethirtythreethirtythree",
+        "/public/link/download/thirtythreethirtythreethirtythree/",
+        "/invite/abcd1234/invalid",
+        "/upload-to/invalid"
+      })
   void givenAnInvalidEndpointRequestHttpRoutingHandlerShouldRespondWith404(String invalidUri) {
     // Given
-    Mockito
-      .when(httpRequestMock.uri())
-      .thenReturn(invalidUri);
-    Mockito
-      .when(httpRequestMock.protocolVersion())
-      .thenReturn(HttpVersion.HTTP_1_1);
+    Mockito.when(httpRequestMock.uri()).thenReturn(invalidUri);
+    Mockito.when(httpRequestMock.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
 
-    ArgumentCaptor<FullHttpResponse> captorHttpResponse = ArgumentCaptor.forClass(FullHttpResponse.class);
+    ArgumentCaptor<FullHttpResponse> captorHttpResponse =
+        ArgumentCaptor.forClass(FullHttpResponse.class);
 
     // When
     httpRoutingHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
 
     // Then
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .writeAndFlush(captorHttpResponse.capture());
-    Mockito
-      .verify(channelHandlerContextMock, Mockito.times(1))
-      .close();
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1))
+        .writeAndFlush(captorHttpResponse.capture());
+    Mockito.verify(channelHandlerContextMock, Mockito.times(1)).close();
 
-    Assertions
-      .assertThat(captorHttpResponse.getValue().protocolVersion())
-      .isEqualTo(HttpVersion.HTTP_1_1);
-    Assertions
-      .assertThat(captorHttpResponse.getValue().status())
-      .isEqualTo(HttpResponseStatus.NOT_FOUND);
+    Assertions.assertThat(captorHttpResponse.getValue().protocolVersion())
+        .isEqualTo(HttpVersion.HTTP_1_1);
+    Assertions.assertThat(captorHttpResponse.getValue().status())
+        .isEqualTo(HttpResponseStatus.NOT_FOUND);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -223,7 +223,9 @@ class HttpRoutingHandlerTest {
         "/public/link/download/abcd1234",
         "/public/link/download/abcd1234/",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
-        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/"
+        "/public/link/download/abcd1234abcd1234abcd1234abcd1234/",
+        "/public/download/00000000-0000-0000-0000-000000000000",
+        "/public/download/00000000-0000-0000-0000-000000000000/"
       })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
       String uri) {
@@ -353,6 +355,8 @@ class HttpRoutingHandlerTest {
         "/public/link/download/nine00000/",
         "/public/link/download/thirtythreethirtythreethirtythree",
         "/public/link/download/thirtythreethirtythreethirtythree/",
+        "/public/download/invalid",
+        "/public/download/00000000-0000-0000-0000-000000000000/invalid",
         "/invite/abcd1234/invalid",
         "/upload-to/invalid"
       })

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -206,7 +206,9 @@ class HttpRoutingHandlerTest {
   @ParameterizedTest
   @ValueSource(strings = {
     "/link/abcd1234",
-    "/link/abcd1234/"
+    "/link/abcd1234/",
+    "/link/abcd1234abcd1234abcd1234abcd1234",
+    "/link/abcd1234abcd1234abcd1234abcd1234/"
   })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(String uri) {
     // Given
@@ -351,6 +353,12 @@ class HttpRoutingHandlerTest {
     "/upload/invalid",
     "/upload-version/invalid",
     "/link/abcd1234/invalid",
+    "/link/seven00",
+    "/link/seven00/",
+    "/link/nine00000",
+    "/link/nine00000/",
+    "/link/thirtythreethirtythreethirtythree",
+    "/link/thirtythreethirtythreethirtythree/",
     "/invite/abcd1234/invalid",
     "/upload-to/invalid"
   })

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpRequest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpRequest.java
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.utilities.http;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class HttpRequest {
+  private final String method;
+  private final String endpoint;
+
+  @Nullable private final String cookie;
+  @Nullable private final String bodyPayload;
+
+  private HttpRequest(
+      String method, String endpoint, @Nullable String cookie, @Nullable String bodyPayload) {
+    this.method = method;
+    this.endpoint = endpoint;
+    this.cookie = cookie;
+    this.bodyPayload = bodyPayload;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public Optional<String> getCookie() {
+    return Optional.ofNullable(cookie);
+  }
+
+  public Optional<String> getBodyPayload() {
+    return Optional.ofNullable(bodyPayload);
+  }
+
+  public static HttpRequest of(
+      String method, String endpoint, @Nullable String cookie, @Nullable String bodyPayload) {
+    return new HttpRequest(method, endpoint, cookie, bodyPayload);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpResponse.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpResponse.java
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.utilities.http;
+
+public class HttpResponse {
+  private final int status;
+  private final String bodyPayload;
+
+  private HttpResponse(int status, String bodyPayload) {
+    this.status = status;
+    this.bodyPayload = bodyPayload;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getBodyPayload() {
+    return bodyPayload;
+  }
+
+  public static HttpResponse of(int status, String bodyPayload) {
+    return new HttpResponse(status, bodyPayload);
+  }
+}

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+  <logger name="org.mockserver.log.MockServerEventLog" level="WARN"/>
+</configuration>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -20,4 +20,6 @@ SPDX-License-Identifier: AGPL-3.0-only
   <logger name="com.github.dockerjava" level="WARN"/>
   <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
   <logger name="org.mockserver.log.MockServerEventLog" level="WARN"/>
+
+  <!--<logger name="io.ebean.SQL" level="TRACE"/> -->
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <logback-classic.version>1.4.8</logback-classic.version>
     <micrometer.version>1.11.2</micrometer.version>
     <mockito.version>5.4.0</mockito.version>
+    <mock-server.version>5.15.0</mock-server.version>
     <netty.version>4.1.94.Final</netty.version>
     <postgresql.version>42.6.0</postgresql.version>
     <testcontainers.version>1.18.3</testcontainers.version>
@@ -268,6 +269,20 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>io.ebean</groupId>
         <artifactId>ebean-platform-hsqldb</artifactId>
         <version>${ebean.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-netty-no-dependencies</artifactId>
+        <version>${mock-server.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-client-java-no-dependencies</artifactId>
+        <version>${mock-server.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/yap.license
+++ b/yap.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
:warning:  DO NOT SQUASH THIS

- [test: add ITs for CreateLink, UpdateLink and GetLinks APIs (#83)](https://github.com/zextras/carbonio-files-ce/pull/83)
- [feat: increase the length of the hash of a public link to 32 characters (#84)](https://github.com/zextras/carbonio-files-ce/pull/84)
- [feat: enable the creation of public link to folders (#85)](https://github.com/zextras/carbonio-files-ce/pull/85)
- [refactor: move download blob via public link on a separate controller (#86)](https://github.com/zextras/carbonio-files-ce/pull/86)
- [feat: expose public GraphQL schema (#87)](https://github.com/zextras/carbonio-files-ce/pull/87)
- [feat: implement GetPublicNode API (#88)](https://github.com/zextras/carbonio-files-ce/pull/88)
- [feat: implement FindNodes API (#89)](https://github.com/zextras/carbonio-files-ce/pull/89)
- [feat: implement public download API (#90)](https://github.com/zextras/carbonio-files-ce/pull/90)

Refs: ZIF-745