### PR TITLE
fix: support the upload to the mailbox of file with cyrillic filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ core/.settings/
 .idea/
 *.iml
 
+# Misc
+workspace/
+jdt.ls-java-project/
+.metadata/
+*.swp
+
 # Unit test reports
 TEST*.xml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     rev: v2.10.0
     hooks:
       - id: pretty-format-java
+        args: [--autofix]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.37.0

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -17,6 +17,14 @@ public final class Files {
 
   private Files() {}
 
+  public static final class Service {
+
+    private Service() {}
+
+    public static final String IP = "127.78.0.2";
+    public static final int PORT = 10_000;
+  }
+
   public static final class Config {
 
     private Config() {}

--- a/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/MailboxHttpClient.java
@@ -4,79 +4,80 @@
 
 package com.zextras.carbonio.files.clients;
 
+import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
 import com.zextras.carbonio.files.exceptions.RequestEntityTooLargeException;
 import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
 import io.vavr.control.Try;
 import java.io.InputStream;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.mime.HttpMultipartMode;
-import org.apache.http.entity.mime.MultipartEntity;
-import org.apache.http.entity.mime.content.InputStreamBody;
-import org.apache.http.entity.mime.content.StringBody;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 
 /**
  * Http client to make http requests to the mailbox. The mailbox is reached via service discover.
  */
 public class MailboxHttpClient {
 
-  private final String        mailboxURL;
-  private static final String UPLOAD_FILE_ENDPOINT = "/service/upload?fmt=raw";
+  private static final String UPLOAD_FILE_ENDPOINT = "service/upload?fmt=raw";
 
-  MailboxHttpClient(String mailboxURL) {
-    this.mailboxURL = mailboxURL;
-  }
+  private final String mailboxURL;
+  private final CloseableHttpClient httpClient;
 
-  public static MailboxHttpClient atURL(String mailboxURL) {
-    return new MailboxHttpClient(mailboxURL);
+  @Inject
+  public MailboxHttpClient(CloseableHttpClient httpClient, FilesConfig filesConfig) {
+    this.httpClient = httpClient;
+    this.mailboxURL = filesConfig.getMailboxUrl();
   }
 
   /**
    * Allows to upload a file to the mailbox store. The attachment id returned should be attached to
    * a carbonio item (e.g. an already existing mail draft). This method can be used for the
    * following target module:
+   *
    * <ul>
-   *   <li>{@link TargetModule#MAILS}</li>
-   *   <li>{@link TargetModule#CALENDARS}</li>
-   *   <li>{@link TargetModule#CONTACTS}</li>
+   *   <li>{@link TargetModule#MAILS}
+   *   <li>{@link TargetModule#CALENDARS}
+   *   <li>{@link TargetModule#CONTACTS}
    * </ul>
    *
    * @param cookies is a {@link String} representing the cookies of the requesters who wants to
-   * upload the node to the mailbox.
+   *     upload the node to the mailbox.
    * @param fullFilename is a {@link String} representing the node filename with its extension.
    * @param mimeType is a {@link String} representing the mime-type of the node to upload.
    * @param file is the {@link InputStream} of the node to upload.
-   *
+   * @param fileLength is a {@link Long} representing the size of the blob to upload.
    * @return a {@link Try} containing a {@link String} representing the mailbox attachment id
-   * uploaded or a {@link Throwable} if something goes wrong.
+   *     uploaded or a {@link Throwable} if something goes wrong.
    */
   public Try<String> uploadFile(
-    String cookies,
-    String fullFilename,
-    String mimeType,
-    InputStream file
-  ) {
+      String cookies, String fullFilename, String mimeType, InputStream file, Long fileLength) {
 
-    try(CloseableHttpClient client = HttpClients.createMinimal()) {
-      MultipartEntity multipartEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
-      multipartEntity.addPart("file", new InputStreamBody(file, fullFilename));
-      multipartEntity.addPart("filename", new StringBody(fullFilename));
-      multipartEntity.addPart("ct", new StringBody(mimeType));
-
-      HttpPost request = new HttpPost(mailboxURL + UPLOAD_FILE_ENDPOINT);
-      request.setHeader("Cookie", cookies);
+    try {
+      final HttpPost request = new HttpPost(mailboxURL + UPLOAD_FILE_ENDPOINT);
+      request.addHeader("Cookie", cookies);
+      request.addHeader(
+          "Content-Disposition",
+          "attachment; filename=\""
+              + fullFilename
+              + "\"; filename*=UTF-8''"
+              + URLEncoder.encode(fullFilename, StandardCharsets.UTF_8));
       request.setProtocolVersion(new ProtocolVersion("HTTP", 1, 1));
-      request.setEntity(multipartEntity);
 
-      CloseableHttpResponse mailboxResponse = client.execute(request);
+      final InputStreamEntity body =
+          new InputStreamEntity(file, fileLength, ContentType.getByMimeType(mimeType));
+      request.setEntity(body);
+
+      final CloseableHttpResponse mailboxResponse = httpClient.execute(request);
       if (mailboxResponse.getStatusLine().getStatusCode() == 200) {
         /*
         This is the mailbox response:
@@ -88,30 +89,30 @@ public class MailboxHttpClient {
           - Remove the first two elements('200', 'null')
           - Remove the ' and the \n characters
          */
-        String[] responseBody = IOUtils
-          .toString(mailboxResponse.getEntity().getContent(), StandardCharsets.UTF_8)
-          .split(",");
+        final String[] responseBody =
+            IOUtils.toString(mailboxResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+                .split(",");
 
         if ("200".equals(responseBody[0])) {
-          return Arrays
-            .stream(responseBody)
-            .reduce((first, last) -> last)
-            .map(aid -> aid.replaceAll("'", "").replaceAll("\n", ""))
-            .map(Try::success)
-            .orElseGet(() -> Try.failure(
-                new InternalServerErrorException("Unable to deserialize mailbox upload response")
-              )
-            );
+          return Arrays.stream(responseBody)
+              .reduce((first, last) -> last)
+              .map(aid -> aid.replaceAll("'", "").replaceAll("\n", ""))
+              .map(Try::success)
+              .orElseGet(
+                  () ->
+                      Try.failure(
+                          new InternalServerErrorException(
+                              "Unable to deserialize mailbox upload response")));
         }
 
         return Try.failure(new RequestEntityTooLargeException("Upload to mailbox failed"));
       }
 
-      String errorMessage = MessageFormat.format(
-        "Upload to mailbox failed: {0} {1}",
-        mailboxResponse.getStatusLine().getStatusCode(),
-        mailboxResponse.getStatusLine().getReasonPhrase()
-      );
+      final String errorMessage =
+          MessageFormat.format(
+              "Upload to mailbox failed: {0} {1}",
+              mailboxResponse.getStatusLine().getStatusCode(),
+              mailboxResponse.getStatusLine().getReasonPhrase());
       return Try.failure(new InternalServerErrorException(errorMessage));
 
     } catch (Exception exception) {

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.config;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Config.Database;
+import com.zextras.carbonio.files.Files.Config.Mailbox;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.preview.PreviewClient;
@@ -26,11 +27,11 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class FilesConfig {
 
-  private static final Logger     logger = LoggerFactory.getLogger(FilesConfig.class);
-  private final        Properties properties;
-  private              String     userManagementURL;
-  private              String     fileStoreURL;
-  private              String     previewURL;
+  private static final Logger logger = LoggerFactory.getLogger(FilesConfig.class);
+  private final Properties properties;
+  private String userManagementURL;
+  private String fileStoreURL;
+  private String previewURL;
 
   public FilesConfig() {
     properties = new Properties();
@@ -41,35 +42,35 @@ public class FilesConfig {
     try {
       File configFile = new File("/etc/carbonio/files/config.properties");
 
-      if(configFile.exists()) {
-        try(InputStream inputStream = new FileInputStream(configFile)) {
+      if (configFile.exists()) {
+        try (InputStream inputStream = new FileInputStream(configFile)) {
           properties.load(inputStream);
         }
       } else {
         properties.load(
-          getClass().getClassLoader().getResourceAsStream("carbonio-files.properties"));
+            getClass().getClassLoader().getResourceAsStream("carbonio-files.properties"));
       }
     } catch (IOException exception) {
       logger.error("Fail to load the configuration file");
     }
 
-    userManagementURL = MessageFormat.format(
-      "http://{0}:{1}",
-      properties.getProperty(Files.Config.UserManagement.URL, "127.78.0.2"),
-      properties.getProperty(Files.Config.UserManagement.PORT, "20001")
-    );
+    userManagementURL =
+        MessageFormat.format(
+            "http://{0}:{1}",
+            properties.getProperty(Files.Config.UserManagement.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.UserManagement.PORT, "20001"));
 
-    fileStoreURL = MessageFormat.format(
-      "http://{0}:{1}/",
-      properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
-      properties.getProperty(Files.Config.Storages.PORT, "20002")
-    );
+    fileStoreURL =
+        MessageFormat.format(
+            "http://{0}:{1}/",
+            properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.Storages.PORT, "20002"));
 
-    previewURL = MessageFormat.format(
-      "http://{0}:{1}",
-      properties.getProperty(Files.Config.Preview.URL, "127.78.0.2"),
-      properties.getProperty(Files.Config.Preview.PORT, "20003")
-    );
+    previewURL =
+        MessageFormat.format(
+            "http://{0}:{1}",
+            properties.getProperty(Files.Config.Preview.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.Preview.PORT, "20003"));
   }
 
   public Properties getProperties() {
@@ -86,10 +87,9 @@ public class FilesConfig {
 
   public String getFileStoreUrl() {
     return String.format(
-      "http://%s:%s/",
-      properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
-      properties.getProperty(Files.Config.Storages.PORT, "20002")
-    );
+        "http://%s:%s/",
+        properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+        properties.getProperty(Files.Config.Storages.PORT, "20002"));
   }
 
   public PreviewClient getPreviewClient() {
@@ -97,21 +97,28 @@ public class FilesConfig {
   }
 
   public int getMaxNumberOfFileVersion() {
-    return Integer.parseInt(ServiceDiscoverHttpClient
-      .defaultURL(ServiceDiscover.SERVICE_NAME)
-      .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
-      .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
+    return Integer.parseInt(
+        ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+            .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
+            .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
   }
 
   public String getDatabaseUrl() {
-    final String databaseHost = Optional
-      .ofNullable(System.getProperty(Database.URL))
-      .orElse(getProperties().getProperty(Database.URL, "127.78.0.2"));
+    final String databaseHost =
+        Optional.ofNullable(System.getProperty(Database.URL))
+            .orElse(getProperties().getProperty(Database.URL, "127.78.0.2"));
 
-    final String databasePort = Optional
-      .ofNullable(System.getProperty(Database.PORT))
-      .orElse(getProperties().getProperty(Database.PORT, "20000"));
+    final String databasePort =
+        Optional.ofNullable(System.getProperty(Database.PORT))
+            .orElse(getProperties().getProperty(Database.PORT, "20000"));
 
     return String.format("%s:%s", databaseHost, databasePort);
+  }
+
+  public String getMailboxUrl() {
+    return String.format(
+        "http://%s:%s/",
+        properties.getProperty(Mailbox.URL, "127.78.0.2"),
+        properties.getProperty(Mailbox.PORT, "20004"));
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -57,19 +57,19 @@ public class FilesConfig {
     userManagementURL =
         MessageFormat.format(
             "http://{0}:{1}",
-            properties.getProperty(Files.Config.UserManagement.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.UserManagement.URL, Files.Service.IP),
             properties.getProperty(Files.Config.UserManagement.PORT, "20001"));
 
     fileStoreURL =
         MessageFormat.format(
             "http://{0}:{1}/",
-            properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.Storages.URL, Files.Service.IP),
             properties.getProperty(Files.Config.Storages.PORT, "20002"));
 
     previewURL =
         MessageFormat.format(
             "http://{0}:{1}",
-            properties.getProperty(Files.Config.Preview.URL, "127.78.0.2"),
+            properties.getProperty(Files.Config.Preview.URL, Files.Service.IP),
             properties.getProperty(Files.Config.Preview.PORT, "20003"));
   }
 
@@ -88,7 +88,7 @@ public class FilesConfig {
   public String getFileStoreUrl() {
     return String.format(
         "http://%s:%s/",
-        properties.getProperty(Files.Config.Storages.URL, "127.78.0.2"),
+        properties.getProperty(Files.Config.Storages.URL, Files.Service.IP),
         properties.getProperty(Files.Config.Storages.PORT, "20002"));
   }
 
@@ -106,7 +106,7 @@ public class FilesConfig {
   public String getDatabaseUrl() {
     final String databaseHost =
         Optional.ofNullable(System.getProperty(Database.URL))
-            .orElse(getProperties().getProperty(Database.URL, "127.78.0.2"));
+            .orElse(getProperties().getProperty(Database.URL, Files.Service.IP));
 
     final String databasePort =
         Optional.ofNullable(System.getProperty(Database.PORT))
@@ -118,7 +118,7 @@ public class FilesConfig {
   public String getMailboxUrl() {
     return String.format(
         "http://%s:%s/",
-        properties.getProperty(Mailbox.URL, "127.78.0.2"),
+        properties.getProperty(Mailbox.URL, Files.Service.IP),
         properties.getProperty(Mailbox.PORT, "20004"));
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -7,18 +7,17 @@ package com.zextras.carbonio.files.config;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.zextras.carbonio.files.cache.CacheHandlerFactory;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.FileVersionRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.CollaborationLinkRepositoryEbean;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.FileVersionRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.LinkRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.NodeRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.ShareRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.TombstoneRepositoryEbean;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.UserRepositoryRest;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.CollaborationLinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
@@ -28,6 +27,8 @@ import com.zextras.carbonio.files.graphql.validators.GenericControllerEvaluatorF
 import com.zextras.filestore.api.Filestore;
 import com.zextras.storages.api.StoragesClient;
 import java.time.Clock;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 
 public class FilesModule extends AbstractModule {
 
@@ -57,5 +58,10 @@ public class FilesModule extends AbstractModule {
   @Provides
   public Filestore getFileStore() {
     return StoragesClient.atUrl(filesConfig.getFileStoreUrl());
+  }
+
+  @Provides
+  public CloseableHttpClient getGenericHttpClient() {
+    return HttpClients.createDefault();
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
-import java.text.MessageFormat;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -206,9 +205,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         Boolean.parseBoolean(httpRequest.headers().getAsString(Headers.UPLOAD_OVERWRITE_VERSION));
     long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
-    logger.debug(
-        MessageFormat.format(
-            "Uploading new version of node with id: {0}, overwrite: {1}", nodeId, overwrite));
+    logger.debug("Uploading new version of node with id: {}, overwrite: {}", nodeId, overwrite);
 
     initializeFileStream(context);
 

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -25,7 +25,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -36,9 +35,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
-import io.vavr.control.Try;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -54,26 +50,20 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
   private static final Logger logger = LoggerFactory.getLogger(BlobController.class);
 
   private static final AttributeKey<BufferInputStream> fileStreamReader =
-    AttributeKey.valueOf("FileStreamReader");
+      AttributeKey.valueOf("FileStreamReader");
 
   private final BlobService blobService;
   private final PrometheusService prometheusService;
 
   @Inject
-  public BlobController(
-    BlobService blobService,
-    PrometheusService prometheusService
-  ) {
+  public BlobController(BlobService blobService, PrometheusService prometheusService) {
     super(true);
     this.blobService = blobService;
     this.prometheusService = prometheusService;
   }
 
   @Override
-  protected void channelRead0(
-    ChannelHandlerContext context,
-    HttpObject httpObject
-  ) {
+  protected void channelRead0(ChannelHandlerContext context, HttpObject httpObject) {
     try {
       if (httpObject instanceof HttpRequest) {
         HttpRequest httpRequest = (HttpRequest) httpObject;
@@ -98,22 +88,14 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
       } else if (httpObject instanceof HttpContent) {
 
         HttpContent httpContent = (HttpContent) httpObject;
-        Optional.ofNullable(
-          context
-            .channel()
-            .attr(fileStreamReader)
-            .get()
-        ).ifPresent((buffer -> buffer.addContent(httpContent.content())));
+        Optional.ofNullable(context.channel().attr(fileStreamReader).get())
+            .ifPresent((buffer -> buffer.addContent(httpContent.content())));
 
         httpContent.content().clear();
 
         if (httpObject instanceof LastHttpContent) {
-          Optional.ofNullable(
-            context
-              .channel()
-              .attr(fileStreamReader)
-              .get()
-          ).ifPresent(BufferInputStream::finishWrite);
+          Optional.ofNullable(context.channel().attr(fileStreamReader).get())
+              .ifPresent(BufferInputStream::finishWrite);
         }
         return;
       }
@@ -126,27 +108,22 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     }
   }
 
-  private void download(
-    ChannelHandlerContext context,
-    HttpRequest request,
-    Matcher uriMatched
-  ) {
+  private void download(ChannelHandlerContext context, HttpRequest request, Matcher uriMatched) {
     User requester = (User) context.channel().attr(AttributeKey.valueOf("requester")).get();
 
     String nodeId = uriMatched.group(1);
-    Integer version = Optional
-      .ofNullable(uriMatched.group(2))
-      .map(Integer::parseInt)
-      .orElse(null);
+    Integer version = Optional.ofNullable(uriMatched.group(2)).map(Integer::parseInt).orElse(null);
 
-    BlobResponse blobResponse = blobService
-      .downloadFileById(nodeId, version, requester)
-      .orElseThrow(() -> new NoSuchElementException(String.format(
-        "Request %s: node %s requested by %s does not exist or it does not have the permission to read it",
-        request.uri(),
-        nodeId,
-        requester.getId()
-      )));
+    BlobResponse blobResponse =
+        blobService
+            .downloadFileById(nodeId, version, requester)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        String.format(
+                            "Request %s: node %s requested by %s does not exist or it does not have"
+                                + " the permission to read it",
+                            request.uri(), nodeId, requester.getId())));
 
     context.write(HttpResponseBuilder.createSuccessDownloadHttpResponse(blobResponse));
     // Create netty buffer and start to fill it with the bytes arriving from the blob stream
@@ -154,35 +131,28 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
   }
 
   private void initializeFileStream(ChannelHandlerContext context) {
-    context
-      .channel()
-      .attr(fileStreamReader)
-      .set(new BufferInputStream(context.channel().config()));
+    context.channel().attr(fileStreamReader).set(new BufferInputStream(context.channel().config()));
   }
 
-  private void uploadFile(
-    ChannelHandlerContext context,
-    HttpRequest httpRequest
-  ) {
+  private void uploadFile(ChannelHandlerContext context, HttpRequest httpRequest) {
     User requester = (User) context.channel().attr(AttributeKey.valueOf("requester")).get();
 
-    String parentId = Optional
-      .ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_PARENT_ID))
-      .orElse(Files.Db.RootId.LOCAL_ROOT);
-    String description = Optional
-      .ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_DESCRIPTION))
-      .orElse("");
+    String parentId =
+        Optional.ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_PARENT_ID))
+            .orElse(Files.Db.RootId.LOCAL_ROOT);
+    String description =
+        Optional.ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_DESCRIPTION))
+            .orElse("");
     long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
     String encodedFilename = httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_FILENAME);
     String decodedFilename =
-      encodedFilename == null || !Base64.isBase64(encodedFilename)
-        ? null
-        : new String(Base64.decodeBase64(encodedFilename));
+        encodedFilename == null || !Base64.isBase64(encodedFilename)
+            ? null
+            : new String(Base64.decodeBase64(encodedFilename));
 
     if (decodedFilename == null
-      || decodedFilename.trim().isEmpty()
-      || decodedFilename.trim().length() > 1024
-    ) {
+        || decodedFilename.trim().isEmpty()
+        || decodedFilename.trim().length() > 1024) {
       context.fireExceptionCaught(new IllegalArgumentException());
       return;
     }
@@ -190,86 +160,85 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     initializeFileStream(context);
 
     CompletableFuture.runAsync(
-      () -> {
-        String nodeId = blobService.uploadFile(
-          requester,
-          context.channel().attr(fileStreamReader).get(),
-          blobLength,
-          parentId,
-          decodedFilename,
-          description
-        ).orElseThrow(NoSuchElementException::new);
+            () -> {
+              String nodeId =
+                  blobService
+                      .uploadFile(
+                          requester,
+                          context.channel().attr(fileStreamReader).get(),
+                          blobLength,
+                          parentId,
+                          decodedFilename,
+                          description)
+                      .orElseThrow(NoSuchElementException::new);
 
-        sendSuccessUploadResponse(context, nodeId, 1);
+              sendSuccessUploadResponse(context, nodeId, 1);
 
-        prometheusService.getUploadCounter().increment();
-        context.flush().close();
-      }
-    ).exceptionally(throwable -> { // It is necessary because CompletableFuture eats exceptions
-      context.fireExceptionCaught(throwable);
-      return null;
-    });
+              prometheusService.getUploadCounter().increment();
+              context.flush().close();
+            })
+        .exceptionally(
+            throwable -> { // It is necessary because CompletableFuture eats exceptions
+              context.fireExceptionCaught(throwable);
+              return null;
+            });
   }
 
-  public void uploadFileVersion(
-    ChannelHandlerContext context,
-    HttpRequest httpRequest
-  ) {
+  public void uploadFileVersion(ChannelHandlerContext context, HttpRequest httpRequest) {
 
     String nodeId = httpRequest.headers().getAsString(Headers.UPLOAD_NODE_ID);
     String encodedFilename = httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_FILENAME);
     String decodedFilename =
-      encodedFilename == null || !Base64.isBase64(encodedFilename)
-        ? null
-        : new String(Base64.decodeBase64(encodedFilename));
+        encodedFilename == null || !Base64.isBase64(encodedFilename)
+            ? null
+            : new String(Base64.decodeBase64(encodedFilename));
 
     if (nodeId == null
-      || decodedFilename == null
-      || decodedFilename.trim().isEmpty()
-      || decodedFilename.trim().length() > 1024
-    ) {
+        || decodedFilename == null
+        || decodedFilename.trim().isEmpty()
+        || decodedFilename.trim().length() > 1024) {
       context.fireExceptionCaught(new IllegalArgumentException());
       return;
     }
 
     User requester = (User) context.channel().attr(AttributeKey.valueOf("requester")).get();
-    boolean overwrite = Boolean.parseBoolean(
-      httpRequest.headers().getAsString(Headers.UPLOAD_OVERWRITE_VERSION)
-    );
+    boolean overwrite =
+        Boolean.parseBoolean(httpRequest.headers().getAsString(Headers.UPLOAD_OVERWRITE_VERSION));
     long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
-    logger.debug(MessageFormat.format(
-      "Uploading new version of node with id: {0}, overwrite: {1}", nodeId, overwrite
-    ));
+    logger.debug(
+        MessageFormat.format(
+            "Uploading new version of node with id: {0}, overwrite: {1}", nodeId, overwrite));
 
     initializeFileStream(context);
 
-    CompletableFuture.runAsync(() -> {
-        Integer version = blobService.uploadFileVersion(
-          requester,
-          context.channel().attr(fileStreamReader).get(),
-          blobLength,
-          nodeId,
-          decodedFilename,
-          overwrite
-        ).orElseThrow(NoSuchElementException::new);
+    CompletableFuture.runAsync(
+            () -> {
+              Integer version =
+                  blobService
+                      .uploadFileVersion(
+                          requester,
+                          context.channel().attr(fileStreamReader).get(),
+                          blobLength,
+                          nodeId,
+                          decodedFilename,
+                          overwrite)
+                      .orElseThrow(NoSuchElementException::new);
 
-        sendSuccessUploadResponse(context, nodeId, version);
+              sendSuccessUploadResponse(context, nodeId, version);
 
-        prometheusService.getUploadVersionCounter().increment();
-        context.flush().close();
-      }
-    ).exceptionally(throwable -> { // It is necessary because CompletableFuture eats exceptions
-      context.fireExceptionCaught(throwable);
-      return null;
-    });
+              prometheusService.getUploadVersionCounter().increment();
+              context.flush().close();
+            })
+        .exceptionally(
+            throwable -> { // It is necessary because CompletableFuture eats exceptions
+              context.fireExceptionCaught(throwable);
+              return null;
+            });
   }
 
   private void sendSuccessUploadResponse(
-    ChannelHandlerContext context,
-    String nodeId,
-    int version
-  ) {
+      ChannelHandlerContext context, String nodeId, int version) {
 
     UploadVersionResponse response = new UploadVersionResponse();
     response.setNodeId(nodeId);
@@ -277,9 +246,10 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
 
     byte[] jsonByteArray;
     try {
-      jsonByteArray = new ObjectMapper()
-        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-        .writeValueAsBytes(response);
+      jsonByteArray =
+          new ObjectMapper()
+              .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+              .writeValueAsBytes(response);
     } catch (JsonProcessingException exception) {
       context.fireExceptionCaught(exception);
       return;
@@ -289,12 +259,12 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     headers.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
     headers.add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
 
-    context.write(new DefaultFullHttpResponse(
-      HttpVersion.HTTP_1_0,
-      HttpResponseStatus.OK,
-      Unpooled.wrappedBuffer(jsonByteArray),
-      headers,
-      new DefaultHttpHeaders()
-    ));
+    context.write(
+        new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_0,
+            HttpResponseStatus.OK,
+            Unpooled.wrappedBuffer(jsonByteArray),
+            headers,
+            new DefaultHttpHeaders()));
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/ProcedureService.java
@@ -5,10 +5,7 @@
 package com.zextras.carbonio.files.rest.services;
 
 import com.google.inject.Inject;
-import com.zextras.carbonio.files.Files.Config.Mailbox;
-import com.zextras.carbonio.files.Files.Config.Storages;
 import com.zextras.carbonio.files.clients.MailboxHttpClient;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.User;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
@@ -18,79 +15,63 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.exceptions.BadRequestException;
 import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
 import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import com.zextras.filestore.api.Filestore;
 import com.zextras.filestore.model.FilesIdentifier;
-import com.zextras.storages.api.StoragesClient;
 import io.vavr.control.Try;
 import java.io.InputStream;
 import java.text.MessageFormat;
-import java.util.Properties;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Handles all the procedures to perform on external services.
- */
+/** Handles all the procedures to perform on external services. */
 public class ProcedureService {
 
   private static final Logger logger = LoggerFactory.getLogger(ProcedureService.class);
 
-  private final NodeRepository        nodeRepository;
+  private final NodeRepository nodeRepository;
   private final FileVersionRepository fileVersionRepository;
-  private final String                mailboxUrl;
-  private final String                storagesUrl;
+  private final MailboxHttpClient mailboxHttpClient;
+  private final Filestore fileStoreClient;
 
   @Inject
   public ProcedureService(
-    NodeRepository nodeRepository,
-    FileVersionRepository fileVersionRepository,
-    FilesConfig filesConfig
-  ) {
+      NodeRepository nodeRepository,
+      FileVersionRepository fileVersionRepository,
+      Filestore fileStoreClient,
+      MailboxHttpClient mailboxHttpClient) {
     this.nodeRepository = nodeRepository;
     this.fileVersionRepository = fileVersionRepository;
-
-    Properties properties = filesConfig.getProperties();
-    mailboxUrl = "http://"
-      + properties.getProperty(Mailbox.URL, "127.78.0.2")
-      + ":"
-      + properties.getProperty(Mailbox.PORT, "20004");
-    storagesUrl = "http://"
-      + properties.getProperty(Storages.URL, "127.78.0.2")
-      + ":"
-      + properties.getProperty(Storages.PORT, "20002")
-      + "/";
+    this.fileStoreClient = fileStoreClient;
+    this.mailboxHttpClient = mailboxHttpClient;
   }
 
   /**
    * Allows to upload the {@param nodeId} to the carbonio mailbox store. These are the target module
    * supported:
+   *
    * <ul>
-   *   <li>{@link TargetModule#MAILS}</li>
-   *   <li>{@link TargetModule#CALENDARS}</li>
-   *   <li>{@link TargetModule#CONTACTS}</li>
+   *   <li>{@link TargetModule#MAILS}
+   *   <li>{@link TargetModule#CALENDARS}
+   *   <li>{@link TargetModule#CONTACTS}
    * </ul>
    *
    * @param nodeId is a {@link String} of the node id to upload.
    * @param targetModule is a {@link TargetModule} representing the module to upload.
    * @param requester is a {@link User} representing the requester of this operation.
    * @param cookiesRequester is a {@link String} representing the requester cookies necessary to
-   * perform the upload operation.
-   *
+   *     perform the upload operation.
    * @return a {@link Try} containing a {@link String} representing the mailbox attachment id
-   * uploaded or a {@link Throwable} if something goes wrong. These are the possible failures:
-   * <ul>
-   *   <li>{@link BadRequestException} when the node is not a file</li>
-   *   <li>{@link Exception} when the download of the blob to upload fails</li>
-   *   <li>{@link Exception} when the {@link TargetModule} is {@link TargetModule#CHATS} because,
-   *   for now, it is not supported</li>
-   * </ul>
+   *     uploaded or a {@link Throwable} if something goes wrong. These are the possible failures:
+   *     <ul>
+   *       <li>{@link BadRequestException} when the node is not a file
+   *       <li>{@link Exception} when the download of the blob to upload fails
+   *       <li>{@link Exception} when the {@link TargetModule} is {@link TargetModule#CHATS}
+   *           because, for now, it is not supported
+   *     </ul>
    */
   public Try<String> uploadToModule(
-    UUID nodeId,
-    TargetModule targetModule,
-    User requester,
-    String cookiesRequester
-  ) {
+      UUID nodeId, TargetModule targetModule, User requester, String cookiesRequester) {
 
     if (!targetModule.equals(TargetModule.CHATS)) {
       Node nodeToUpload = nodeRepository.getNode(nodeId.toString()).get();
@@ -99,34 +80,28 @@ public class ProcedureService {
         FileVersion fileVersion = fileVersionRepository.getLastFileVersion(nodeId.toString()).get();
         InputStream blob;
         try {
-          blob = StoragesClient
-            .atUrl(storagesUrl)
-            .download(FilesIdentifier.of(
-              nodeId.toString(),
-              nodeToUpload.getCurrentVersion(),
-              requester.getId())
-            );
+          blob =
+              fileStoreClient.download(
+                  FilesIdentifier.of(
+                      nodeId.toString(), nodeToUpload.getCurrentVersion(), requester.getId()));
         } catch (Exception exception) {
           logger.error(MessageFormat.format("Failed to download the node: {0}", nodeId));
           return Try.failure(new InternalServerErrorException(exception));
         }
 
-        return MailboxHttpClient
-          .atURL(mailboxUrl)
-          .uploadFile(
+        return mailboxHttpClient.uploadFile(
             cookiesRequester,
             nodeToUpload.getFullName(),
             fileVersion.getMimeType(),
-            blob
-          );
+            blob,
+            fileVersion.getSize());
       }
       logger.error(MessageFormat.format("Folder cannot be uploaded to {0} store", targetModule));
       return Try.failure(new BadRequestException());
     }
 
-    return Try.failure(new InternalServerErrorException(
-        MessageFormat.format("{0} not supported", TargetModule.CHATS)
-      )
-    );
+    return Try.failure(
+        new InternalServerErrorException(
+            MessageFormat.format("{0} not supported", TargetModule.CHATS)));
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/clients/MailboxHttpClientTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/clients/MailboxHttpClientTest.java
@@ -68,8 +68,8 @@ class MailboxHttpClientTest {
 
     // Assert request
     final HttpPost postRequest = httpRequestCaptor.getValue();
-    Assertions.assertThat(postRequest.getURI().toString())
-        .isEqualTo("http://127.78.0.2:20004/service/upload?fmt=raw");
+    Assertions.assertThat(postRequest.getURI())
+        .hasToString("http://127.78.0.2:20004/service/upload?fmt=raw");
     Assertions.assertThat(postRequest.getFirstHeader("Cookie").getValue()).isEqualTo("fake-cookie");
     Assertions.assertThat(postRequest.getFirstHeader("Content-Disposition").getValue())
         .isEqualTo("attachment; filename=\"test.txt\"; filename*=UTF-8''test.txt");

--- a/core/src/test/java/com/zextras/carbonio/files/clients/MailboxHttpClientTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/clients/MailboxHttpClientTest.java
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.clients;
+
+import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import io.vavr.control.Try;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class MailboxHttpClientTest {
+
+  private CloseableHttpClient httpClientMock;
+  private MailboxHttpClient mailboxHttpClient;
+
+  @BeforeEach
+  void setUp() {
+    httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    mailboxHttpClient = new MailboxHttpClient(httpClientMock, new FilesConfig());
+  }
+
+  @Test
+  void
+      givenAFileToUploadWithAnEnglishFilenameTheUploadFileShouldUploadTheBlobCorrectlyAndReturnTheAttachmentId()
+          throws Exception {
+    // Given
+    final String contentFile = "text file";
+    final String contentResponse =
+        "200,'null','85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c'";
+
+    final CloseableHttpResponse httpResponseMock =
+        Mockito.mock(CloseableHttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(httpResponseMock.getStatusLine().getStatusCode()).thenReturn(200);
+    Mockito.when(httpResponseMock.getEntity().getContent())
+        .thenReturn(IOUtils.toInputStream(contentResponse, StandardCharsets.UTF_8));
+
+    Mockito.when(httpClientMock.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponseMock);
+
+    final ArgumentCaptor<HttpPost> httpRequestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+    Mockito.when(httpClientMock.execute(httpRequestCaptor.capture())).thenReturn(httpResponseMock);
+
+    // When
+    final Try<String> tryAttachmentId =
+        mailboxHttpClient.uploadFile(
+            "fake-cookie",
+            "test.txt",
+            "text/plain",
+            IOUtils.toInputStream(contentFile, StandardCharsets.UTF_8),
+            Long.valueOf(contentFile.length()));
+
+    // Then
+    // Assert response
+    Assertions.assertThat(tryAttachmentId.isSuccess()).isTrue();
+    Assertions.assertThat(tryAttachmentId.get())
+        .isEqualTo("85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c");
+
+    // Assert request
+    final HttpPost postRequest = httpRequestCaptor.getValue();
+    Assertions.assertThat(postRequest.getURI().toString())
+        .isEqualTo("http://127.78.0.2:20004/service/upload?fmt=raw");
+    Assertions.assertThat(postRequest.getFirstHeader("Cookie").getValue()).isEqualTo("fake-cookie");
+    Assertions.assertThat(postRequest.getFirstHeader("Content-Disposition").getValue())
+        .isEqualTo("attachment; filename=\"test.txt\"; filename*=UTF-8''test.txt");
+    Assertions.assertThat(postRequest.getProtocolVersion().getMajor()).isOne();
+    Assertions.assertThat(postRequest.getProtocolVersion().getMinor()).isOne();
+
+    final HttpEntity httpEntity = postRequest.getEntity();
+    Assertions.assertThat(httpEntity.getContentLength()).isEqualTo(9L);
+    Assertions.assertThat(httpEntity.getContentType().getValue()).contains("text/plain");
+    Assertions.assertThat(IOUtils.toString(httpEntity.getContent(), StandardCharsets.UTF_8))
+        .isEqualTo("text file");
+  }
+
+  @Test
+  void
+      givenAFileToUploadWithACyrillicFilenameTheUploadFileShouldUploadTheBlobCorrectlyAndReturnTheAttachmentId()
+          throws Exception {
+    // Given
+    final String contentResponse =
+        "200,'null','85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c'";
+
+    final CloseableHttpResponse httpResponseMock =
+        Mockito.mock(CloseableHttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(httpResponseMock.getStatusLine().getStatusCode()).thenReturn(200);
+    Mockito.when(httpResponseMock.getEntity().getContent())
+        .thenReturn(IOUtils.toInputStream(contentResponse, StandardCharsets.UTF_8));
+
+    Mockito.when(httpClientMock.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponseMock);
+
+    final ArgumentCaptor<HttpPost> httpRequestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+    Mockito.when(httpClientMock.execute(httpRequestCaptor.capture())).thenReturn(httpResponseMock);
+
+    // When
+    final Try<String> tryAttachmentId =
+        mailboxHttpClient.uploadFile(
+            "fake-cookie",
+            "синий файл.txt",
+            "text/plain",
+            IOUtils.toInputStream("a", StandardCharsets.UTF_8),
+            1L);
+
+    // Then
+    // Assert response
+    Assertions.assertThat(tryAttachmentId.isSuccess()).isTrue();
+    Assertions.assertThat(tryAttachmentId.get())
+        .isEqualTo("85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c");
+
+    // Assert request
+    Assertions.assertThat(
+            httpRequestCaptor.getValue().getFirstHeader("Content-Disposition").getValue())
+        .isEqualTo(
+            "attachment; filename=\"синий файл.txt\";"
+                + " filename*=UTF-8''%D1%81%D0%B8%D0%BD%D0%B8%D0%B9+%D1%84%D0%B0%D0%B9%D0%BB.txt");
+  }
+
+  @Test
+  void givenAFileToUploadAndAnUnreachableMailboxTheUploadFileShouldReturnATryFailure()
+      throws Exception {
+    // Given
+    final CloseableHttpResponse httpResponseMock =
+        Mockito.mock(CloseableHttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(httpResponseMock.getStatusLine().getStatusCode()).thenReturn(500);
+    Mockito.when(httpResponseMock.getStatusLine().getReasonPhrase()).thenReturn("Generic error");
+
+    Mockito.when(httpClientMock.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponseMock);
+
+    // When
+    final Try<String> tryAttachmentId =
+        mailboxHttpClient.uploadFile(
+            "fake-cookie",
+            "синий файл.txt",
+            "text/plain",
+            IOUtils.toInputStream("a", StandardCharsets.UTF_8),
+            1L);
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessage("Upload to mailbox failed: 500 Generic error");
+  }
+
+  @Test
+  void givenAFileToUploadAndAnErrorFromTheMailboxTheUploadFileShouldReturnATryFailure()
+      throws Exception {
+    // Given
+    final String contentResponse = "500,'null'";
+
+    final CloseableHttpResponse httpResponseMock =
+        Mockito.mock(CloseableHttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(httpResponseMock.getStatusLine().getStatusCode()).thenReturn(200);
+    Mockito.when(httpResponseMock.getEntity().getContent())
+        .thenReturn(IOUtils.toInputStream(contentResponse, StandardCharsets.UTF_8));
+
+    Mockito.when(httpClientMock.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponseMock);
+
+    // When
+    final Try<String> tryAttachmentId =
+        mailboxHttpClient.uploadFile(
+            "fake-cookie",
+            "test.txt",
+            "text/plain",
+            IOUtils.toInputStream("a", StandardCharsets.UTF_8),
+            1L);
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .hasMessage("Upload to mailbox failed");
+  }
+
+  @Test
+  void givenAFileToUploadAndAnExceptionDuringTheRequestBuildTheUploadFileShouldReturnATryFailure()
+      throws Exception {
+    // Given
+    Mockito.when(httpClientMock.execute(Mockito.any(HttpPost.class)))
+        .thenThrow(new IOException("fake-exception"));
+
+    // When
+    final Try<String> tryAttachmentId =
+        mailboxHttpClient.uploadFile(
+            "fake-cookie",
+            "test.txt",
+            "text/plain",
+            IOUtils.toInputStream("a", StandardCharsets.UTF_8),
+            1L);
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("fake-exception");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class FilesConfigTest {
+
+  @BeforeEach
+  void setUp() {}
+
+  // This test will pass when the config.ini is removed or when the FilesConfig
+  // uses also the System.getEnv() to retrieve the configuration values.
+  @Disabled
+  @Test
+  void
+      givenAMailboxUrlAndAPortSetInPropertiesTheGetMailboxUrlShouldReturnTheFullMailboxUrlString() {
+    // Given
+    System.setProperty("carbonio.mailbox.url", "1.2.3.4");
+    System.setProperty("carbonio.mailbox.port", "9999");
+
+    FilesConfig filesConfig = new FilesConfig();
+
+    // When
+    String mailboxUrl = filesConfig.getMailboxUrl();
+
+    // Then
+    Assertions.assertThat(mailboxUrl).isEqualTo("http://1.2.3.4:9999/");
+  }
+
+  @Test
+  void givenEmptyPropertiesTheGetMailboxUrlShouldReturnTheDefaultFullMailboxUrlString() {
+    // Given
+    FilesConfig filesConfig = new FilesConfig();
+
+    // When
+    String mailboxUrl = filesConfig.getMailboxUrl();
+
+    // Then
+    Assertions.assertThat(mailboxUrl).isEqualTo("http://127.78.0.2:20004/");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
@@ -16,7 +16,7 @@ class FilesConfigTest {
 
   // This test will pass when the config.ini is removed or when the FilesConfig
   // uses also the System.getEnv() to retrieve the configuration values.
-  @Disabled
+  @Disabled("Disabled until a refactor on the FilesConfig is done")
   @Test
   void
       givenAMailboxUrlAndAPortSetInPropertiesTheGetMailboxUrlShouldReturnTheFullMailboxUrlString() {

--- a/core/src/test/java/com/zextras/carbonio/files/rest/services/ProcedureServiceTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/rest/services/ProcedureServiceTest.java
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.rest.services;
+
+import com.zextras.carbonio.files.clients.MailboxHttpClient;
+import com.zextras.carbonio.files.dal.dao.User;
+import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
+import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import com.zextras.filestore.api.Filestore;
+import com.zextras.filestore.model.FilesIdentifier;
+import io.vavr.control.Try;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.io.IOUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ProcedureServiceTest {
+
+  private NodeRepository nodeRepositoryMock;
+  private FileVersionRepository fileVersionRepositoryMock;
+  private Filestore fileStoreClientMock;
+  private MailboxHttpClient mailboxHttpClientMock;
+  private ProcedureService procedureService;
+
+  @BeforeEach
+  void setUp() {
+    nodeRepositoryMock = Mockito.mock(NodeRepository.class);
+    fileVersionRepositoryMock = Mockito.mock(FileVersionRepository.class);
+    fileStoreClientMock = Mockito.mock(Filestore.class);
+    mailboxHttpClientMock = Mockito.mock(MailboxHttpClient.class);
+
+    procedureService =
+        new ProcedureService(
+            nodeRepositoryMock,
+            fileVersionRepositoryMock,
+            fileStoreClientMock,
+            mailboxHttpClientMock);
+  }
+
+  @Test
+  void
+      givenADownloadableFileAndTheMailsTargetModuleTheUploadToShouldReturnTheAttachmentIdOfTheFileUploadedToMails()
+          throws Exception {
+    // Given
+    final User requester = new User("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "", "", "");
+
+    final Node nodeMock = Mockito.mock(Node.class);
+    Mockito.when(nodeMock.getNodeType()).thenReturn(NodeType.TEXT);
+    Mockito.when(nodeMock.getFullName()).thenReturn("test.txt");
+    Mockito.when(nodeMock.getCurrentVersion()).thenReturn(2);
+
+    final FileVersion fileVersionMock = Mockito.mock(FileVersion.class);
+    Mockito.when(fileVersionMock.getMimeType()).thenReturn("text/plain");
+    Mockito.when(fileVersionMock.getSize()).thenReturn(5L);
+
+    final InputStream blob = IOUtils.toInputStream("content", StandardCharsets.UTF_8);
+
+    Mockito.when(nodeRepositoryMock.getNode("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(nodeMock));
+
+    Mockito.when(
+            fileVersionRepositoryMock.getLastFileVersion("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(fileVersionMock));
+
+    Mockito.when(
+            fileStoreClientMock.download(
+                FilesIdentifier.of(
+                    "00000000-0000-0000-0000-000000000000",
+                    2,
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")))
+        .thenReturn(blob);
+
+    Mockito.when(
+            mailboxHttpClientMock.uploadFile("fake-cookie", "test.txt", "text/plain", blob, 5L))
+        .thenReturn(Try.success("fake-attachmentId"));
+
+    // When
+    final Try<String> tryAttachmentId =
+        procedureService.uploadToModule(
+            UUID.fromString("00000000-0000-0000-0000-000000000000"),
+            TargetModule.MAILS,
+            requester,
+            "fake-cookie");
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isSuccess()).isTrue();
+    Assertions.assertThat(tryAttachmentId.get()).isEqualTo("fake-attachmentId");
+  }
+
+  @Test
+  void givenANotDownloadableFileTheUploadToShouldReturnATryFailure() throws Exception {
+    // Given
+    final User requester = new User("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "", "", "");
+
+    final Node nodeMock = Mockito.mock(Node.class);
+    Mockito.when(nodeMock.getNodeType()).thenReturn(NodeType.TEXT);
+    Mockito.when(nodeMock.getCurrentVersion()).thenReturn(2);
+
+    final FileVersion fileVersionMock = Mockito.mock(FileVersion.class);
+    Mockito.when(fileVersionMock.getSize()).thenReturn(5L);
+
+    Mockito.when(nodeRepositoryMock.getNode("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(nodeMock));
+
+    Mockito.when(
+            fileVersionRepositoryMock.getLastFileVersion("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(fileVersionMock));
+
+    Mockito.when(
+            fileStoreClientMock.download(
+                FilesIdentifier.of(
+                    "00000000-0000-0000-0000-000000000000",
+                    2,
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")))
+        .thenThrow(Exception.class);
+
+    // When
+    Try<String> tryAttachmentId =
+        procedureService.uploadToModule(
+            UUID.fromString("00000000-0000-0000-0000-000000000000"),
+            TargetModule.MAILS,
+            requester,
+            "fake-cookie");
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(InternalServerErrorException.class);
+
+    Mockito.verifyNoInteractions(mailboxHttpClientMock);
+  }
+
+  @Test
+  void givenADownloadableFileAndAnUnreachableMailboxTheUploadToShouldReturnATryFailure()
+      throws Exception {
+    // Given
+    final User requester = new User("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "", "", "");
+
+    final Node nodeMock = Mockito.mock(Node.class);
+    Mockito.when(nodeMock.getNodeType()).thenReturn(NodeType.TEXT);
+    Mockito.when(nodeMock.getFullName()).thenReturn("test.txt");
+    Mockito.when(nodeMock.getCurrentVersion()).thenReturn(2);
+
+    final FileVersion fileVersionMock = Mockito.mock(FileVersion.class);
+    Mockito.when(fileVersionMock.getMimeType()).thenReturn("text/plain");
+    Mockito.when(fileVersionMock.getSize()).thenReturn(5L);
+
+    final InputStream blob = IOUtils.toInputStream("content", StandardCharsets.UTF_8);
+
+    Mockito.when(nodeRepositoryMock.getNode("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(nodeMock));
+
+    Mockito.when(
+            fileVersionRepositoryMock.getLastFileVersion("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(fileVersionMock));
+
+    Mockito.when(
+            fileStoreClientMock.download(
+                FilesIdentifier.of(
+                    "00000000-0000-0000-0000-000000000000",
+                    2,
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")))
+        .thenReturn(blob);
+
+    Mockito.when(
+            mailboxHttpClientMock.uploadFile("fake-cookie", "test.txt", "text/plain", blob, 5L))
+        .thenReturn(Try.failure(new InternalServerErrorException(new Exception())));
+
+    // When
+    final Try<String> tryAttachmentId =
+        procedureService.uploadToModule(
+            UUID.fromString("00000000-0000-0000-0000-000000000000"),
+            TargetModule.MAILS,
+            requester,
+            "fake-cookie");
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(InternalServerErrorException.class);
+  }
+
+  @Test
+  void givenTheChatTargetModuleTheUploadToShouldReturnATryFailureBecauseNotSupported() {
+    // Given & When
+    final Try<String> tryAttachmentId =
+        procedureService.uploadToModule(
+            UUID.fromString("00000000-0000-0000-0000-000000000000"),
+            TargetModule.CHATS,
+            Mockito.mock(User.class),
+            "fake-cookie");
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessage("CHATS not supported");
+
+    Mockito.verifyNoInteractions(nodeRepositoryMock);
+    Mockito.verifyNoInteractions(fileVersionRepositoryMock);
+    Mockito.verifyNoInteractions(fileStoreClientMock);
+    Mockito.verifyNoInteractions(mailboxHttpClientMock);
+  }
+
+  @Test
+  void
+      givenAFolderAndTheMailsTargetModuleTheUploadToShouldReturnATryFailureBecauseAFolderCannotBeUploaded() {
+    // Given
+    final Node nodeMock = Mockito.mock(Node.class);
+    Mockito.when(nodeMock.getNodeType()).thenReturn(NodeType.FOLDER);
+
+    Mockito.when(nodeRepositoryMock.getNode("00000000-0000-0000-0000-000000000000"))
+        .thenReturn(Optional.of(nodeMock));
+
+    // When
+    final Try<String> tryAttachmentId =
+        procedureService.uploadToModule(
+            UUID.fromString("00000000-0000-0000-0000-000000000000"),
+            TargetModule.MAILS,
+            Mockito.mock(User.class),
+            "fake-cookie");
+
+    // Then
+    Assertions.assertThat(tryAttachmentId.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(() -> tryAttachmentId.get())
+        .isInstanceOf(BadRequestException.class);
+
+    Mockito.verifyNoInteractions(fileVersionRepositoryMock);
+    Mockito.verifyNoInteractions(fileStoreClientMock);
+    Mockito.verifyNoInteractions(mailboxHttpClientMock);
+  }
+}


### PR DESCRIPTION
When the user wants to upload to the mailbox a file having a cyrillic filename, the system now encodes the filename correctly.

- Used the URLEncorder#encode method to encode the filename of the file to upload.
- Refactored the MailboxHttpClient class using the apache HttpClient. Now it accepts the client in the constructor and the class si more testable
- Added unit tests for FilesConfig, MailboxHttpClient and ProcedureService classes

Refs: FILES-669