### PR TITLE
ci: add timestamp in the artifact pkgrel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,8 +97,9 @@ pipeline {
                     }
                     steps {
                         sh'''
+                            export TIMESTAMP=$(date +%s)
                             export GIT_COMMIT_SHORT=$(git rev-parse HEAD | head -c 8)
-                            sed -i "s/pkgrel=\\"SNAPSHOT\\"/pkgrel=\\"$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
+                            sed -i "s/pkgrel=\\"SNAPSHOT\\"/pkgrel=\\"$TIMESTAMP+$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
                         '''
                     }
                 }


### PR DESCRIPTION
- Added the timestamp in the pkgrel so it can be used together with the git commit hash to replace the `SNAPSHOT` value and avoid to overwrite artifacts in the artifactory `develop` repository each time a new PR is merged.