### PR TITLE
build: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 exclude: "mvnw|package-lock.json|go.sum"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: [--maxkb=2048]
@@ -31,19 +31,19 @@ repos:
       - id: docker-compose-check
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: []
 
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.1
+    rev: v3.0.2
     hooks:
       - id: reuse
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.12.0
+    rev: v2.13.0
     hooks:
       - id: pretty-format-java
         args: [--autofix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 exclude: "mvnw|package-lock.json|go.sum"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
         args: [--maxkb=2048]
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.22
+    rev: v0.1.23
     hooks:
       - id: shellcheck
 
@@ -31,33 +31,25 @@ repos:
       - id: docker-compose-check
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: []
 
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v2.1.0
+    rev: v3.0.1
     hooks:
       - id: reuse
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.10.0
+    rev: v2.12.0
     hooks:
       - id: pretty-format-java
         args: [--autofix]
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.37.0
-    hooks:
-      - id: markdownlint
-        language_version: 16.0.0
-      - id: markdownlint-fix
-        language_version: 16.0.0
-
   - repo: https://github.com/ejba/pre-commit-maven
-    rev: v0.3.3
+    rev: v0.3.4
     hooks:
       - id: maven
         args: [ 'compile' ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', [[pattern: 'core/target/jacoco-full-report/jacoco.xml']])
+                recordCoverage(tools: [[parser: 'JACOCO', pattern: 'core/target/jacoco-full-report/jacoco.xml']], sourceCodeRetention: 'MODIFIED')
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [['core/target/jacoco-full-report/jacoco.xml']])
+                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED')
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED')
+                recordCoverage(tools: [[parser: 'JACOCO']],sourceCodeRetention: 'MODIFIED')
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED')
+                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', [[pattern: 'core/target/jacoco-full-report/jacoco.xml']])
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']],sourceCodeRetention: 'MODIFIED')
+                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: 'core/target/jacoco-full-report/jacoco.xml')
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO', pattern: 'core/target/jacoco-full-report/jacoco.xml']], sourceCodeRetention: 'MODIFIED')
+                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED')
             }
         }
         stage('Dependency check'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stage('Coverage') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml verify -P generate-jacoco-full-report'
-                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: 'core/target/jacoco-full-report/jacoco.xml')
+                recordCoverage(tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [['core/target/jacoco-full-report/jacoco.xml']])
             }
         }
         stage('Dependency check'){

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.11.1-1</version>
+    <version>0.11.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.11.1-1</version>
+    <version>0.11.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-files-ce"
-pkgver="0.11.1"
-pkgrel="1"
+pkgver="0.11.2"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <java-compiler.version>17</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.coverage.jacoco.xmlReportPaths>
-      ../core/target/jacoco-full-report/jacoco.xml
+      ./core/target/jacoco-full-report/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
     <sonar.dependencyCheck.htmlReportPath>
       ./dependency-check-report.html

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.files</groupId>
   <artifactId>carbonio-files-ce</artifactId>
-  <version>0.11.1-1</version>
+  <version>0.11.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-files-ce</name>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <java-compiler.version>17</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.coverage.jacoco.xmlReportPaths>
-      core/target/jacoco-full-report/jacoco.xml
+      ../core/target/jacoco-full-report/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
     <sonar.dependencyCheck.htmlReportPath>
       ./dependency-check-report.html

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <java-compiler.version>17</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.coverage.jacoco.xmlReportPaths>
-      ./core/target/jacoco-full-report/jacoco.xml
+      core/target/jacoco-full-report/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
     <sonar.dependencyCheck.htmlReportPath>
       ./dependency-check-report.html


### PR DESCRIPTION
All pre-commit hooks are updated to their last version:
- pre-commit-hooks: 4.4.0 -> 4.6.0
- pre-commit: 0.1.22 -> 0.1.23
- conventional-pre-commit: 2.4.0 -> 3.2.0
- reuse-tool: 2.1.0 -> 3.0.2
- language-formatters-pre-commit-hooks: 2.10.0 -> 2.13.0
- pre-commit-maven: 0.3.3 -> 0.3.4

Bumped version to SNAPSHOT