### PR TITLE
feat: expose docs-connector liveness in health API

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -77,6 +77,14 @@ public final class Files {
       public static final String PORT = "carbonio.mailbox.port";
     }
 
+    public static final class DocsConnector {
+
+      private DocsConnector() {}
+
+      public static final String URL  = "carbonio.docs-connector.url";
+      public static final String PORT = "carbonio.docs-connector.port";
+    }
+
     public static final class Pagination {
 
       private Pagination() {}

--- a/core/src/main/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClient.java
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.clients;
+
+import com.zextras.carbonio.files.config.FilesConfig;
+import javax.inject.Inject;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/** Http client to make http requests to the docs-connector using the service discover. */
+public class DocsConnectorHttpClient {
+
+  private static final String HEALTH_LIVE_ENDPOINT = "/health/live/";
+  private static final int TIMEOUT_IN_MS = 2 * 1000;
+
+  private final String docsConnectorUrl;
+  private final CloseableHttpClient httpClient;
+
+  @Inject
+  public DocsConnectorHttpClient(CloseableHttpClient httpClient, FilesConfig filesConfig) {
+    this.httpClient = httpClient;
+    this.docsConnectorUrl = filesConfig.getDocsConnectorUrl();
+  }
+
+  /**
+   * Allows to check the liveness of carbonio-docs-connector service.
+   *
+   * @return a <code>true</code> if the carbonio-docs-connector is live, false otherwise.
+   */
+  public boolean healthLiveCheck() {
+    final HttpGet request = new HttpGet(docsConnectorUrl + HEALTH_LIVE_ENDPOINT);
+
+    final RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout(TIMEOUT_IN_MS)
+            .setSocketTimeout(TIMEOUT_IN_MS)
+            .build();
+    request.setConfig(requestConfig);
+
+    try (final CloseableHttpResponse docsConnectorResponse = httpClient.execute(request)) {
+      return docsConnectorResponse.getStatusLine().getStatusCode() == 204;
+    } catch (Exception exception) {
+      return false;
+    }
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -9,6 +9,9 @@ import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Config.Database;
 import com.zextras.carbonio.files.Files.Config.DocsConnector;
 import com.zextras.carbonio.files.Files.Config.Mailbox;
+import com.zextras.carbonio.files.Files.Config.Preview;
+import com.zextras.carbonio.files.Files.Config.Storages;
+import com.zextras.carbonio.files.Files.Config.UserManagement;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
 import com.zextras.carbonio.preview.PreviewClient;
@@ -19,7 +22,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.MessageFormat;
 import java.util.Optional;
 import java.util.Properties;
 import org.slf4j.Logger;
@@ -39,6 +41,13 @@ public class FilesConfig {
     loadConfig();
   }
 
+  private String buildUrlFromProperties(String urlPropertyName, String portPropertyName, String defaultPort) {
+    return String.format(
+        "http://%s:%s",
+        properties.getProperty(urlPropertyName, Files.Service.IP),
+        properties.getProperty(portPropertyName, defaultPort));
+  }
+
   public void loadConfig() {
     try {
       File configFile = new File("/etc/carbonio/files/config.properties");
@@ -55,24 +64,10 @@ public class FilesConfig {
       logger.error("Fail to load the configuration file");
     }
 
-    userManagementURL =
-        MessageFormat.format(
-            "http://{0}:{1}",
-            properties.getProperty(Files.Config.UserManagement.URL, Files.Service.IP),
-            properties.getProperty(Files.Config.UserManagement.PORT, "20001"));
-
-    fileStoreURL =
-        MessageFormat.format(
-            "http://{0}:{1}/",
-            properties.getProperty(Files.Config.Storages.URL, Files.Service.IP),
-            properties.getProperty(Files.Config.Storages.PORT, "20002"));
-
-    previewURL =
-        MessageFormat.format(
-            "http://{0}:{1}",
-            properties.getProperty(Files.Config.Preview.URL, Files.Service.IP),
-            properties.getProperty(Files.Config.Preview.PORT, "20003"));
-  }
+    userManagementURL = buildUrlFromProperties(UserManagement.URL, UserManagement.PORT, "20001");
+    fileStoreURL = buildUrlFromProperties(Storages.URL, Storages.PORT, "20002") + "/";
+    previewURL = buildUrlFromProperties(Preview.URL, Preview.PORT, "20003");
+ }
 
   public Properties getProperties() {
     return properties;
@@ -87,10 +82,7 @@ public class FilesConfig {
   }
 
   public String getFileStoreUrl() {
-    return String.format(
-        "http://%s:%s/",
-        properties.getProperty(Files.Config.Storages.URL, Files.Service.IP),
-        properties.getProperty(Files.Config.Storages.PORT, "20002"));
+    return fileStoreURL;
   }
 
   public PreviewClient getPreviewClient() {
@@ -117,16 +109,10 @@ public class FilesConfig {
   }
 
   public String getMailboxUrl() {
-    return String.format(
-        "http://%s:%s/",
-        properties.getProperty(Mailbox.URL, Files.Service.IP),
-        properties.getProperty(Mailbox.PORT, "20004"));
+    return buildUrlFromProperties(Mailbox.URL, Mailbox.PORT, "20004");
   }
 
   public String getDocsConnectorUrl() {
-    return String.format(
-        "http://%s:%s/",
-        properties.getProperty(DocsConnector.URL, Files.Service.IP),
-        properties.getProperty(DocsConnector.PORT, "20005"));
+    return buildUrlFromProperties(DocsConnector.URL, DocsConnector.PORT, "20005");
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -109,7 +109,7 @@ public class FilesConfig {
   }
 
   public String getMailboxUrl() {
-    return buildUrlFromProperties(Mailbox.URL, Mailbox.PORT, "20004");
+    return buildUrlFromProperties(Mailbox.URL, Mailbox.PORT, "20004") + "/";
   }
 
   public String getDocsConnectorUrl() {

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.config;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.Config.Database;
+import com.zextras.carbonio.files.Files.Config.DocsConnector;
 import com.zextras.carbonio.files.Files.Config.Mailbox;
 import com.zextras.carbonio.files.Files.ServiceDiscover;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
@@ -120,5 +121,12 @@ public class FilesConfig {
         "http://%s:%s/",
         properties.getProperty(Mailbox.URL, Files.Service.IP),
         properties.getProperty(Mailbox.PORT, "20004"));
+  }
+
+  public String getDocsConnectorUrl() {
+    return String.format(
+        "http://%s:%s/",
+        properties.getProperty(DocsConnector.URL, Files.Service.IP),
+        properties.getProperty(DocsConnector.PORT, "20005"));
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -28,11 +28,8 @@ import com.zextras.carbonio.files.graphql.validators.GenericControllerEvaluatorF
 import com.zextras.filestore.api.Filestore;
 import com.zextras.storages.api.StoragesClient;
 import java.time.Clock;
-import org.apache.http.HttpConnectionFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
 public class FilesModule extends AbstractModule {
 

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.config;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.zextras.carbonio.files.cache.CacheHandlerFactory;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.CollaborationLinkRepositoryEbean;
@@ -27,8 +28,11 @@ import com.zextras.carbonio.files.graphql.validators.GenericControllerEvaluatorF
 import com.zextras.filestore.api.Filestore;
 import com.zextras.storages.api.StoragesClient;
 import java.time.Clock;
+import org.apache.http.HttpConnectionFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
 public class FilesModule extends AbstractModule {
 
@@ -60,8 +64,9 @@ public class FilesModule extends AbstractModule {
     return StoragesClient.atUrl(filesConfig.getFileStoreUrl());
   }
 
+  @Singleton
   @Provides
-  public CloseableHttpClient getGenericHttpClient() {
-    return HttpClients.createDefault();
+  public CloseableHttpClient getGenericHttpClientPool() {
+    return HttpClientBuilder.create().setMaxConnPerRoute(10).setMaxConnTotal(30).build();
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
@@ -171,6 +171,12 @@ public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
    *          "name" : "carbonio-preview",
    *          "ready" : true,
    *          "type" : "OPTIONAL"
+   *       },
+   *       {
+   *          "live" : true,
+   *          "name" : "carbonio-docs-connector",
+   *          "ready" : true,
+   *          "type" : "OPTIONAL"
    *       }
    *    ],
    *    "ready" : true

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/HealthController.java
@@ -96,7 +96,7 @@ public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
     context
       .writeAndFlush(new DefaultFullHttpResponse(
         httpRequest.protocolVersion(),
-        HttpResponseStatus.OK)
+        HttpResponseStatus.NO_CONTENT)
       )
       .addListener(ChannelFutureListener.CLOSE);
   }
@@ -123,7 +123,7 @@ public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
     boolean fileStoreIsUp = healthService.isStoragesLive();
 
     HttpResponseStatus responseStatus = (databaseIsUp && userManagementIsUp && fileStoreIsUp)
-      ? HttpResponseStatus.OK
+      ? HttpResponseStatus.NO_CONTENT
       : HttpResponseStatus.INTERNAL_SERVER_ERROR;
 
     logger.info(MessageFormat.format("carbonio files status: {0}", responseStatus));
@@ -190,6 +190,7 @@ public class HealthController extends SimpleChannelInboundHandler<HttpRequest> {
     dependencies.add(healthService.getUserManagementHealth());
     dependencies.add(healthService.getStoragesHealth());
     dependencies.add(healthService.getPreviewHealth());
+    dependencies.add(healthService.getDocsConnectorHealth());
 
     boolean filesIsReady = dependencies
       .stream()

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files.rest.services;
 
 import com.google.inject.Inject;
+import com.zextras.carbonio.files.clients.DocsConnectorHttpClient;
 import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.DbInfo;
@@ -15,26 +16,24 @@ import com.zextras.filestore.api.Filestore.Liveness;
 public class HealthService {
 
   private final EbeanDatabaseManager ebeanDatabaseManager;
-  private final FilesConfig          filesConfig;
+  private final FilesConfig filesConfig;
+  private final DocsConnectorHttpClient docsConnectorHttpClient;
 
   @Inject
   public HealthService(
-    EbeanDatabaseManager ebeanDatabaseManager,
-    FilesConfig filesConfig
-  ) {
+      EbeanDatabaseManager ebeanDatabaseManager,
+      FilesConfig filesConfig,
+      DocsConnectorHttpClient docsConnectorHttpClient) {
     this.ebeanDatabaseManager = ebeanDatabaseManager;
     this.filesConfig = filesConfig;
+    this.docsConnectorHttpClient = docsConnectorHttpClient;
   }
 
   /**
    * @return true if the database is reachable, false otherwise.
    */
   public boolean isDatabaseLive() {
-    return ebeanDatabaseManager
-      .getEbeanDatabase()
-      .find(DbInfo.class)
-      .findOneOrEmpty()
-      .isPresent();
+    return ebeanDatabaseManager.getEbeanDatabase().find(DbInfo.class).findOneOrEmpty().isPresent();
   }
 
   /**
@@ -60,54 +59,67 @@ public class HealthService {
 
   /**
    * @return a {@link ServiceHealth} representing the status of the database service. This
-   * dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   *     dependency is {@link DependencyType#REQUIRED} for carbonio-files.
    */
   public ServiceHealth getDatabaseHealth() {
     boolean databaseIsLive = isDatabaseLive();
 
     return new ServiceHealth()
-      .setName("database")
-      .setType(DependencyType.REQUIRED)
-      .setLive(databaseIsLive)
-      .setReady(databaseIsLive);
+        .setName("database")
+        .setType(DependencyType.REQUIRED)
+        .setLive(databaseIsLive)
+        .setReady(databaseIsLive);
   }
 
   /**
    * @return a {@link ServiceHealth} representing the status of the carbonio-user-management
-   * service. This dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   *     service. This dependency is {@link DependencyType#REQUIRED} for carbonio-files.
    */
   public ServiceHealth getUserManagementHealth() {
     boolean userManagementIsLive = isUserManagementLive();
     return new ServiceHealth()
-      .setName("carbonio-user-management")
-      .setType(DependencyType.REQUIRED)
-      .setLive(userManagementIsLive)
-      .setReady(userManagementIsLive);
+        .setName("carbonio-user-management")
+        .setType(DependencyType.REQUIRED)
+        .setLive(userManagementIsLive)
+        .setReady(userManagementIsLive);
   }
 
   /**
    * @return a {@link ServiceHealth} representing the status of the carbonio-storages service. This
-   * dependency is {@link DependencyType#REQUIRED} for carbonio-files.
+   *     dependency is {@link DependencyType#REQUIRED} for carbonio-files.
    */
   public ServiceHealth getStoragesHealth() {
     boolean fileStoreIsLive = isStoragesLive();
     return new ServiceHealth()
-      .setName("carbonio-storages")
-      .setType(DependencyType.REQUIRED)
-      .setLive(fileStoreIsLive)
-      .setReady(fileStoreIsLive);
+        .setName("carbonio-storages")
+        .setType(DependencyType.REQUIRED)
+        .setLive(fileStoreIsLive)
+        .setReady(fileStoreIsLive);
   }
 
   /**
    * @return a {@link ServiceHealth} representing the status of the carbonio-preview service. This
-   * dependency is {@link DependencyType#OPTIONAL} for carbonio-files.
+   *     dependency is {@link DependencyType#OPTIONAL} for carbonio-files.
    */
   public ServiceHealth getPreviewHealth() {
     boolean previewIsUp = isPreviewLive();
     return new ServiceHealth()
-      .setName("carbonio-preview")
-      .setType(DependencyType.OPTIONAL)
-      .setLive(previewIsUp)
-      .setReady(previewIsUp);
+        .setName("carbonio-preview")
+        .setType(DependencyType.OPTIONAL)
+        .setLive(previewIsUp)
+        .setReady(previewIsUp);
+  }
+
+  /**
+   * @return a {@link ServiceHealth} representing the status of the carbonio-docs-connector service.
+   *     This dependency is {@link DependencyType#OPTIONAL} for carbonio-files.
+   */
+  public ServiceHealth getDocsConnectorHealth() {
+    boolean docsConnectorIsUp = docsConnectorHttpClient.healthLiveCheck();
+    return new ServiceHealth()
+        .setName("carbonio-docs-connector")
+        .setType(DependencyType.OPTIONAL)
+        .setLive(docsConnectorIsUp)
+        .setReady(docsConnectorIsUp);
   }
 }

--- a/core/src/main/resources/carbonio-files.properties
+++ b/core/src/main/resources/carbonio-files.properties
@@ -16,3 +16,6 @@ carbonio.preview.port=20003
 # Carbonio Mailbox
 carbonio.mailbox.url=127.78.0.2
 carbonio.mailbox.port=20004
+# Carbonio DocsConnector
+carbonio.docs-connector.url=127.78.0.2
+carbonio.docs-connector.port=20005

--- a/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
@@ -20,7 +20,7 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-public class HealthApiIT {
+class HealthApiIT {
 
   @Test
   void givenAnHealthServiceTheHealthLiveShouldReturn204StatusCode() {

--- a/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.rest.types.health.DependencyType;
+import com.zextras.carbonio.files.rest.types.health.HealthResponse;
+import com.zextras.carbonio.files.rest.types.health.ServiceHealth;
+import io.netty.handler.codec.http.HttpMethod;
+import java.util.Collections;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+public class HealthApiIT {
+
+  @Test
+  void givenAnHealthServiceTheHealthLiveShouldReturn204StatusCode() {
+    // Given
+    SimulatorBuilder simulatorBUilder =
+        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover();
+
+    try (Simulator simulator = simulatorBUilder.build().start()) {
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/live/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+      Assertions.assertThat(httpResponse.getBodyPayload()).isEmpty();
+    }
+  }
+
+  @Test
+  void givenAllDependenciesHealthyTheHealthShouldReturn200CodeWithTheHealthStatusOfEachDependency()
+      throws Exception {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Collections.emptyMap())
+            .withStorages()
+            .withPreview()
+            .withDocsConnector();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      // UserManagement
+      MockServerClient userManagementServiceMock = simulator.getUserManagementMock();
+
+      userManagementServiceMock
+          .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // Storages
+      MockServerClient storagesMock = simulator.getStoragesMock();
+
+      storagesMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // Preview
+      MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+
+      previewServiceMock
+          .when(
+              HttpRequest.request()
+                  .withMethod(HttpMethod.GET.toString())
+                  .withPath("/health/ready/"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // DocsConnector
+      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorServiceMock();
+
+      docsConnectorServiceMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live/"))
+          .respond(HttpResponse.response().withStatusCode(204));
+
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      HealthResponse healthStatus =
+          new ObjectMapper().readValue(httpResponse.getBodyPayload(), HealthResponse.class);
+
+      Assertions.assertThat(healthStatus.isReady()).isTrue();
+      List<ServiceHealth> dependenciesHealth = healthStatus.getDependencies();
+      Assertions.assertThat(dependenciesHealth).hasSize(5);
+
+      Assertions.assertThat(dependenciesHealth.get(0).getName()).isEqualTo("database");
+      Assertions.assertThat(dependenciesHealth.get(0).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(1).getName())
+          .isEqualTo("carbonio-user-management");
+      Assertions.assertThat(dependenciesHealth.get(1).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(1).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(1).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(2).getName()).isEqualTo("carbonio-storages");
+      Assertions.assertThat(dependenciesHealth.get(2).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(2).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(2).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(3).getName()).isEqualTo("carbonio-preview");
+      Assertions.assertThat(dependenciesHealth.get(3).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(3).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(3).getType()).isEqualTo(DependencyType.OPTIONAL);
+
+      Assertions.assertThat(dependenciesHealth.get(4).getName())
+          .isEqualTo("carbonio-docs-connector");
+      Assertions.assertThat(dependenciesHealth.get(4).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(4).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(4).getType()).isEqualTo(DependencyType.OPTIONAL);
+    }
+  }
+
+  @Test
+  void
+      givenUserManagementUnreachableAndOtherDependenciesHealthyTheHealthShouldReturn500CodeWithTheHealthStatusOfEachDependency()
+          throws Exception {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Collections.emptyMap())
+            .withStorages()
+            .withPreview()
+            .withDocsConnector();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      // UserManagement
+      MockServerClient userManagementServiceMock = simulator.getUserManagementMock();
+
+      userManagementServiceMock
+          .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/"))
+          .respond(HttpResponse.response().withStatusCode(500));
+
+      // Storages
+      MockServerClient storagesMock = simulator.getStoragesMock();
+
+      storagesMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // Preview
+      MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+
+      previewServiceMock
+          .when(
+              HttpRequest.request()
+                  .withMethod(HttpMethod.GET.toString())
+                  .withPath("/health/ready/"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // DocsConnector
+      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorServiceMock();
+
+      docsConnectorServiceMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live/"))
+          .respond(HttpResponse.response().withStatusCode(204));
+
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+
+      HealthResponse healthStatus =
+          new ObjectMapper().readValue(httpResponse.getBodyPayload(), HealthResponse.class);
+
+      Assertions.assertThat(healthStatus.isReady()).isFalse();
+      List<ServiceHealth> dependenciesHealth = healthStatus.getDependencies();
+      Assertions.assertThat(dependenciesHealth).hasSize(5);
+
+      Assertions.assertThat(dependenciesHealth.get(0).getName()).isEqualTo("database");
+      Assertions.assertThat(dependenciesHealth.get(0).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(1).getName())
+          .isEqualTo("carbonio-user-management");
+      Assertions.assertThat(dependenciesHealth.get(1).isLive()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(1).isReady()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(1).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(2).getName()).isEqualTo("carbonio-storages");
+      Assertions.assertThat(dependenciesHealth.get(2).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(2).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(2).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(3).getName()).isEqualTo("carbonio-preview");
+      Assertions.assertThat(dependenciesHealth.get(3).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(3).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(3).getType()).isEqualTo(DependencyType.OPTIONAL);
+
+      Assertions.assertThat(dependenciesHealth.get(4).getName())
+          .isEqualTo("carbonio-docs-connector");
+      Assertions.assertThat(dependenciesHealth.get(4).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(4).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(4).getType()).isEqualTo(DependencyType.OPTIONAL);
+    }
+  }
+
+  @Test
+  void givenAllMandatoryDependenciesHealthyTheHealthReadyShouldReturn204StatusCode() {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Collections.emptyMap())
+            .withStorages();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      // UserManagement
+      MockServerClient userManagementServiceMock = simulator.getUserManagementMock();
+
+      userManagementServiceMock
+          .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // Storages
+      MockServerClient storagesMock = simulator.getStoragesMock();
+
+      storagesMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/ready/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+      Assertions.assertThat(httpResponse.getBodyPayload()).isEmpty();
+    }
+  }
+
+  @Test
+  void
+      givenUserManagementUnreachableAndOtherMandatoryDependenciesReachableTheHealthReadyShouldReturn502StatusCode() {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Collections.emptyMap())
+            .withStorages();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      // UserManagement
+      MockServerClient userManagementServiceMock = simulator.getUserManagementMock();
+
+      userManagementServiceMock
+          .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/"))
+          .respond(HttpResponse.response().withStatusCode(502));
+
+      // Storages
+      MockServerClient storagesMock = simulator.getStoragesMock();
+
+      storagesMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/ready/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+      Assertions.assertThat(httpResponse.getBodyPayload()).isEmpty();
+    }
+  }
+
+  @Test
+  void
+      givenStoragesUnreachableAndOtherMandatoryDependenciesReachableTheHealthReadyShouldReturn502StatusCode() {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Collections.emptyMap())
+            .withStorages();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      // UserManagement
+      MockServerClient userManagementServiceMock = simulator.getUserManagementMock();
+
+      userManagementServiceMock
+          .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/"))
+          .respond(HttpResponse.response().withStatusCode(200));
+
+      // Storages
+      MockServerClient storagesMock = simulator.getStoragesMock();
+
+      storagesMock
+          .when(
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+          .respond(HttpResponse.response().withStatusCode(502));
+
+      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
+          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
+              HttpMethod.GET.toString(), "/health/ready/", null, null);
+
+      // When
+      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+      Assertions.assertThat(httpResponse.getBodyPayload()).isEmpty();
+    }
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.clients;
+
+import com.zextras.carbonio.files.config.FilesConfig;
+import java.io.IOException;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class DocsConnectorHttpClientTest {
+
+  private CloseableHttpClient httpClientMock;
+
+  private DocsConnectorHttpClient docsConnectorHttpClient;
+
+  @BeforeEach
+  void setup() {
+    httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    FilesConfig filesConfigMock = Mockito.mock(FilesConfig.class);
+    Mockito.when(filesConfigMock.getDocsConnectorUrl()).thenReturn("http://127.78.0.2:20005");
+
+    docsConnectorHttpClient = new DocsConnectorHttpClient(httpClientMock, filesConfigMock);
+  }
+
+  @Test
+  void givenADocsConnectorHealthyTheHealthLiveCheckShouldReturnTrue() throws IOException {
+    // Given
+    CloseableHttpResponse httpResponseMock = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpResponseMock.getStatusLine())
+        .thenReturn(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 204, ""));
+
+    ArgumentCaptor<HttpGet> httpRequestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+    Mockito.when(httpClientMock.execute(httpRequestCaptor.capture())).thenReturn(httpResponseMock);
+
+    // When
+    boolean isDocsConnectorLive = docsConnectorHttpClient.healthLiveCheck();
+
+    // Then
+    Assertions.assertThat(isDocsConnectorLive).isTrue();
+
+    HttpGet httpRequest = httpRequestCaptor.getValue();
+    Assertions.assertThat(httpRequest.getMethod()).isEqualTo("GET");
+    Assertions.assertThat(httpRequest.getURI().toString())
+        .isEqualTo("http://127.78.0.2:20005/health/live/");
+
+    Assertions.assertThat(httpRequest.getConfig().getConnectTimeout()).isEqualTo(2000L);
+    Assertions.assertThat(httpRequest.getConfig().getSocketTimeout()).isEqualTo(2000L);
+  }
+
+  @Test
+  void givenADocsConnectorUnreachableTheHealthLiveCheckShouldReturnFalse() throws IOException {
+    // Given
+    CloseableHttpResponse httpResponseMock = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpResponseMock.getStatusLine())
+        .thenReturn(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 500, ""));
+
+    ArgumentCaptor<HttpGet> httpRequestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+    Mockito.when(httpClientMock.execute(httpRequestCaptor.capture())).thenReturn(httpResponseMock);
+
+    // When
+    boolean isDocsConnectorLive = docsConnectorHttpClient.healthLiveCheck();
+
+    // Then
+    Assertions.assertThat(isDocsConnectorLive).isFalse();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
@@ -17,10 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-public class DocsConnectorHttpClientTest {
+class DocsConnectorHttpClientTest {
 
   private CloseableHttpClient httpClientMock;
-
   private DocsConnectorHttpClient docsConnectorHttpClient;
 
   @BeforeEach
@@ -51,7 +50,7 @@ public class DocsConnectorHttpClientTest {
     HttpGet httpRequest = httpRequestCaptor.getValue();
     Assertions.assertThat(httpRequest.getMethod()).isEqualTo("GET");
     Assertions.assertThat(httpRequest.getURI().toString())
-        .isEqualTo("http://127.78.0.2:20005/health/live/");
+        .hasToString("http://127.78.0.2:20005/health/live/");
 
     Assertions.assertThat(httpRequest.getConfig().getConnectTimeout()).isEqualTo(2000L);
     Assertions.assertThat(httpRequest.getConfig().getSocketTimeout()).isEqualTo(2000L);

--- a/package/carbonio-files.hcl
+++ b/package/carbonio-files.hcl
@@ -56,6 +56,11 @@ services {
             destination_name   = "carbonio-mailbox"
             local_bind_address = "127.78.0.2"
             local_bind_port    = 20004
+          },
+          {
+            destination_name   = "carbonio-docs-connector"
+            local_bind_address = "127.78.0.2"
+            local_bind_port    = 20005
           }
         ]
       }


### PR DESCRIPTION
- Added docs-connector as an optional dependency in the /health/ API
- Implemented a DocsConnector HTTP client to ping the service
- Added a global HttpClients pool to reuse the clients avoiding their creation each time
- Added integration tests for the Health APIs
- Added unit tests for the DocsConnectorHttpClient
- Bumped version to SNAPSHOT

Refs: FILES-786