### PR TITLE
fix: rename node if duplicate when restoring

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/dao/ebean/Node.java
@@ -236,6 +236,11 @@ public class Node {
     return this;
   }
 
+  public Node setFullName(String fullName) {
+    mName = fullName;
+    return this;
+  }
+
   public Optional<String> getExtension() {
     if (!this.getNodeType().equals(FOLDER)
         && !this.getNodeType().equals(ROOT)

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/NodeRepository.java
@@ -39,7 +39,7 @@ public interface NodeRepository {
    *
    * @param userId is a {@link String} representing the user for which we'll limit the visibility of
    * the nodes
-   * @param sort is an {@link Optional< NodeSort >} used for ordering the nodes
+   * @param sort is an {@link Optional<NodeSort>} used for ordering the nodes
    * @param flagged is an {@link Optional<Boolean>} to search only nodes with or without flag
    * @param folderId is an {@link Optional<String>} to search only nodes on the subtree of that
    * folder

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -886,6 +886,25 @@ public class NodeDataFetcher {
                   }
                 });
             }
+
+            // check if node needs an alternative name
+            List<String> targetFolderChildrenFilesName = nodeRepository.getNodes(
+                  nodeRepository.getChildrenIds(
+                      node.getParentId().get(),
+                      Optional.empty(),
+                      Optional.empty(),
+                      false),
+                  Optional.empty()
+              )
+              .map(Node::getFullName)
+              .toList();
+
+            if(targetFolderChildrenFilesName.contains(node.getFullName())) {
+              String newName = searchAlternativeName(
+                  node.getFullName(), node.getParentId().get(), node.getOwnerId()
+              );
+              node.setName(newName);
+            }
             nodeRepository.restoreNode(node.getId());
             nodeRepository.updateNode(node);
             cascadeUpdateAncestors(node);

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -903,7 +903,7 @@ public class NodeDataFetcher {
               String newName = searchAlternativeName(
                   node.getFullName(), node.getParentId().get(), node.getOwnerId()
               );
-              node.setName(newName);
+              node.setFullName(newName);
             }
             nodeRepository.restoreNode(node.getId());
             nodeRepository.updateNode(node);

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -888,16 +888,25 @@ public class NodeDataFetcher {
             }
 
             // check if node needs an alternative name
-            List<String> targetFolderChildrenFilesName = nodeRepository.getNodes(
-                  nodeRepository.getChildrenIds(
-                      node.getParentId().get(),
-                      Optional.empty(),
-                      Optional.empty(),
-                      false),
-                  Optional.empty()
-              )
-              .map(Node::getFullName)
-              .toList();
+            List<String> targetFolderChildrenFilesName = nodeRepository.findNodes(
+                requesterId,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(node.getParentId().get()),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Optional.empty()
+            )
+            .getLeft()
+            .stream()
+            .map(Node::getFullName)
+            .toList();
 
             if(targetFolderChildrenFilesName.contains(node.getFullName())) {
               String newName = searchAlternativeName(

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -20,11 +20,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TestUtils {
@@ -46,7 +42,13 @@ public class TestUtils {
         final Map<String, Object> data = (Map<String, Object>) result.get("data");
 
         if (data.get(operation) != null) {
-          return (Map<String, Object>) data.get(operation);
+          Object dataOperation = data.get(operation);
+          if(dataOperation instanceof ArrayList<?>) {
+            Map<String, Object> listResult = new HashMap<>();
+            listResult.put("listResult", dataOperation);
+            return listResult;
+          }
+          return (Map<String, Object>) dataOperation;
         }
       }
       return Collections.emptyMap();

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -45,7 +45,7 @@ public class TestUtils {
           Object dataOperation = data.get(operation);
           if(dataOperation instanceof ArrayList<?>) {
             Map<String, Object> listResult = new HashMap<>();
-            listResult.put("listResult", dataOperation);
+            listResult.put("data", dataOperation);
             return listResult;
           }
           return (Map<String, Object>) dataOperation;

--- a/core/src/test/java/com/zextras/carbonio/files/api/NodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/NodeApiIT.java
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.api;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.Node;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class NodeApiIT {
+
+  static Simulator simulator;
+  static NodeRepository nodeRepository;
+  static FileVersionRepository fileVersionRepository;
+  static LinkRepository linkRepository;
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement( // create a fake token to use in cookie for auth
+                Map.of(
+                    "fake-token",
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            .build()
+            .start();
+
+    final Injector injector = simulator.getInjector();
+    nodeRepository = injector.getInstance(NodeRepository.class);
+    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    linkRepository = injector.getInstance(LinkRepository.class);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  private void trashNode(String nodeId){
+    Optional<Node> trashedNodeOpt = nodeRepository.getNode(nodeId);
+    trashedNodeOpt.ifPresent(trashedNode -> {
+      String nodeParentId = trashedNode.getParentId().get();
+      trashedNode.setAncestorIds(Files.Db.RootId.TRASH_ROOT);
+      trashedNode.setParentId(Files.Db.RootId.TRASH_ROOT);
+      nodeRepository.trashNode(trashedNode.getId(), nodeParentId);
+      nodeRepository.updateNode(trashedNode);
+    });
+  }
+
+  @Test
+  void givenATrashedNodeRestoreNodesShouldRestoreThatNode() {
+    // Given
+    DatabasePopulator.aNodePopulator(simulator.getInjector())
+        .addNode(
+            new SimplePopulatorTextFile(
+                "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+
+    trashNode("00000000-0000-0000-0000-000000000002");
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("restoreNodes")
+            .withListOfStrings("node_ids", new String[]{"00000000-0000-0000-0000-000000000002"})
+            .withWantedResultFormat("{ id name }")
+            .build();
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "restoreNodes");
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("listResult");
+
+    Assertions.assertThat(nodes).hasSize(1);
+    // folders always on top
+    Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+        .containsEntry("name", "fake");
+  }
+
+  @Test
+  void givenTwoFilesOnWithTheSameNameAndOneIsTrashedBothWithSameParentDirectoryRestoreNodeShouldRestoreFileWithDifferentNameFromAlreadyExisting() {
+    // Given
+    DatabasePopulator.aNodePopulator(simulator.getInjector())
+        .addNode(
+            new SimplePopulatorTextFile(
+                "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+
+    trashNode("00000000-0000-0000-0000-000000000000");
+
+    DatabasePopulator.aNodePopulator(simulator.getInjector())
+        .addNode(
+            new SimplePopulatorTextFile(
+                "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("restoreNodes")
+            .withListOfStrings("node_ids", new String[]{"00000000-0000-0000-0000-000000000000"})
+            .withWantedResultFormat("{ id name }")
+            .build();
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "restoreNodes");
+
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("listResult");
+
+    Assertions.assertThat(nodes).hasSize(1);
+    // folders always on top
+    Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000000")
+        .containsEntry("name", "fake (1)");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/api/RestoreNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/RestoreNodesApiIT.java
@@ -11,11 +11,8 @@ import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
 import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
-import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
@@ -31,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-class NodeApiIT {
+class RestoreNodesApiIT {
 
   static Simulator simulator;
   static NodeRepository nodeRepository;
@@ -108,7 +105,7 @@ class NodeApiIT {
     final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "restoreNodes");
 
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("listResult");
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("data");
 
     Assertions.assertThat(nodes).hasSize(1);
     // folders always on top
@@ -151,7 +148,7 @@ class NodeApiIT {
     final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "restoreNodes");
 
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("listResult");
+    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("data");
 
     Assertions.assertThat(nodes).hasSize(1);
     // folders always on top


### PR DESCRIPTION
- Add a check that renames node when restoring if duplicate on same parent directory using same convention as copy (name + pharentesis with progressive integer)
- Add relative ITs

Refs: FILES-619