### PR TITLE
fix: block access to files after public link is revoked

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -765,8 +765,9 @@ public final class Files {
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
         Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
-      public static final Pattern DOWNLOAD_PUBLIC_FILE  = Pattern.compile(
-        SERVICE + "public/download/([a-f\\d\\-]*)/?$");
+      public static final Pattern DOWNLOAD_PUBLIC_FILE =
+          Pattern.compile(SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-f\\d\\-]*)/?$");
+
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -448,6 +448,7 @@ public final class Files {
         public static final String KEYWORDS       = "keywords";
         public static final String NODE_TYPE      = "type";
         public static final String OWNER_ID       = "owner_id";
+        public static final String NODE_LINK_ID   = "node_link_id";
       }
 
       public static final class GetVersions {

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -767,8 +767,7 @@ public final class Files {
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
         Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern DOWNLOAD_PUBLIC_FILE =
-          Pattern.compile(SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-f\\d\\-]*)/?$");
-
+        Pattern.compile(SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-f\\d\\-]*)/?");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -766,8 +766,8 @@ public final class Files {
           Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
         Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
-      public static final Pattern DOWNLOAD_PUBLIC_FILE =
-        Pattern.compile(SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-f\\d\\-]*)/?");
+      public static final Pattern DOWNLOAD_PUBLIC_FILE = Pattern.compile(
+          SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-zA-Z\\d\\-]*)/?");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(
         SERVICE + "invite/([\\w]{8})/?$");
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -132,12 +132,12 @@ public class LinkRepositoryEbean implements LinkRepository {
       .exists();
   }
 
-  public boolean isLinkValidForNode(String linkId, Node node) {
+  public boolean isLinkValidForNode(String publicLinkId, Node node) {
     Optional<Link> linkOptional = ebeanDatabaseManager
         .getEbeanDatabase()
         .find(Link.class)
         .where()
-        .eq(Db.Link.ID, linkId)
+        .eq(Db.Link.PUBLIC_ID, publicLinkId)
         .eq(Db.Link.NODE_ID, node.getId())
         .or()
         .isNull(Db.Link.EXPIRES_AT)

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -131,4 +131,19 @@ public class LinkRepositoryEbean implements LinkRepository {
       .endOr()
       .exists();
   }
+
+  public boolean isLinkValidForNode(String linkId, Node node) {
+    Optional<Link> linkOptional = ebeanDatabaseManager
+        .getEbeanDatabase()
+        .find(Link.class)
+        .where()
+        .eq(Db.Link.ID, linkId)
+        .eq(Db.Link.NODE_ID, node.getId())
+        .or()
+        .isNull(Db.Link.EXPIRES_AT)
+        .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())
+        .endOr()
+        .findOneOrEmpty();
+    return linkOptional.isPresent();
+  }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -115,24 +115,8 @@ public class LinkRepositoryEbean implements LinkRepository {
     }
   }
 
-  public boolean hasNodeANotExpiredPublicLink(Node node) {
-    List<String> nodeIds = new ArrayList<>();
-    nodeIds.add(node.getId());
-    nodeIds.addAll(node.getAncestorsList());
-
-    return ebeanDatabaseManager
-      .getEbeanDatabase()
-      .find(Link.class)
-      .where()
-      .in(Db.Link.NODE_ID, nodeIds)
-      .or()
-      .isNull(Db.Link.EXPIRES_AT)
-      .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())
-      .endOr()
-      .exists();
-  }
-
   public boolean isLinkValidForNode(String publicLinkId, Node node) {
+    publicLinkId = publicLinkId == null ? "" : publicLinkId;
     Optional<Link> linkOptional = ebeanDatabaseManager
         .getEbeanDatabase()
         .find(Link.class)

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/LinkRepositoryEbean.java
@@ -117,12 +117,17 @@ public class LinkRepositoryEbean implements LinkRepository {
 
   public boolean isLinkValidForNode(String publicLinkId, Node node) {
     publicLinkId = publicLinkId == null ? "" : publicLinkId;
+
+    List<String> nodeIds = new ArrayList<>();
+    nodeIds.add(node.getId());
+    nodeIds.addAll(node.getAncestorsList());
+
     Optional<Link> linkOptional = ebeanDatabaseManager
         .getEbeanDatabase()
         .find(Link.class)
         .where()
         .eq(Db.Link.PUBLIC_ID, publicLinkId)
-        .eq(Db.Link.NODE_ID, node.getId())
+        .in(Db.Link.NODE_ID, nodeIds)
         .or()
         .isNull(Db.Link.EXPIRES_AT)
         .gt(Db.Link.EXPIRES_AT, System.currentTimeMillis())

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -54,9 +54,9 @@ public interface LinkRepository {
    * Checks whether a {@link Link} obtained from linkId is a valid link (node is the correct node
    * and link is not expired) for the provided node, which allows access to the node without requiring permissions.
   *
-   * @param linkId is the {@link Link} id to check for correctness of node and expiration.
+   * @param publicLinkId is the {@link Link} public id to check for correctness of node and expiration.
    * @param node is the {@link Node} to check the correctness of node id inside link.
    * @return true if the {@link Link} obtained by linkId has nodeId associated and is not expired, false otherwise.
    */
-  boolean isLinkValidForNode(String linkId, Node node);
+  boolean isLinkValidForNode(String publicLinkId, Node node);
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -49,4 +49,14 @@ public interface LinkRepository {
    * @return true if the {@link Node} has at least one public link associated, false otherwise.
    */
   boolean hasNodeANotExpiredPublicLink(Node node);
+
+  /**
+   * Checks whether a {@link Link} obtained from linkId is a valid link (node is the correct node
+   * and link is not expired) for the provided node, which allows access to the node without requiring permissions.
+  *
+   * @param linkId is the {@link Link} id to check for correctness of node and expiration.
+   * @param node is the {@link Node} to check the correctness of node id inside link.
+   * @return true if the {@link Link} obtained by linkId has nodeId associated and is not expired, false otherwise.
+   */
+  boolean isLinkValidForNode(String linkId, Node node);
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/LinkRepository.java
@@ -42,15 +42,6 @@ public interface LinkRepository {
   void deleteLinksBulk(Collection<String> linkIds);
 
   /**
-   * Checks whether a given {@link Node} has at least one unexpired public link associated with it,
-   * which allows access to the node without requiring permissions.
-  *
-   * @param node is a given {@link Node} to check.
-   * @return true if the {@link Node} has at least one public link associated, false otherwise.
-   */
-  boolean hasNodeANotExpiredPublicLink(Node node);
-
-  /**
    * Checks whether a {@link Link} obtained from linkId is a valid link (node is the correct node
    * and link is not expired) for the provided node, which allows access to the node without requiring permissions.
   *

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -93,6 +93,7 @@ public class PublicNodeDataFetchers {
   }
 
   public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, String>>>> findNodes() {
+    //TODO api to update
     return environment ->
         CompletableFuture.supplyAsync(
             () -> {
@@ -100,11 +101,12 @@ public class PublicNodeDataFetchers {
               String folderId = environment.getArgument(FindNodes.FOLDER_ID);
               Integer limit = environment.getArgument(FindNodes.LIMIT);
               String pageToken = environment.getArgument(FindNodes.PAGE_TOKEN);
+              String nodeLinkId = environment.getArgument(FindNodes.NODE_LINK_ID);
 
               Optional<Node> optFolder = nodeRepository.getNode(folderId);
 
               if (optFolder.isPresent()
-                  && linkRepository.hasNodeANotExpiredPublicLink(optFolder.get())) {
+                  && linkRepository.isLinkValidForNode(nodeLinkId, optFolder.get())) {
                 ImmutablePair<List<Node>, String> findResult =
                     nodeRepository.publicFindNodes(folderId, limit, pageToken);
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/PublicNodeDataFetchers.java
@@ -93,7 +93,6 @@ public class PublicNodeDataFetchers {
   }
 
   public DataFetcher<CompletableFuture<DataFetcherResult<Map<String, String>>>> findNodes() {
-    //TODO api to update
     return environment ->
         CompletableFuture.supplyAsync(
             () -> {

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
@@ -90,7 +90,8 @@ public class PublicBlobController extends SimpleChannelInboundHandler<HttpReques
       ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched) {
 
     final String nodeId = uriMatched.group(1);
-    final Optional<BlobResponse> blobResponse = blobService.downloadPublicFileById(nodeId);
+    final String nodeLinkId = uriMatched.group(2);
+    final Optional<BlobResponse> blobResponse = blobService.downloadPublicFileById(nodeId, nodeLinkId);
 
     if (blobResponse.isPresent()) {
       context.write(HttpResponseBuilder.createSuccessDownloadHttpResponse(blobResponse.get()));

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -125,7 +125,7 @@ public class BlobService {
    * Downloads from the {@link Filestore} a blob related to an identifier of a public node.
    *
    * @param nodeId    is a {@link String} representing the node identifier
-   * @param nodeLinkId    is a {@link String} representing the link identifier
+   * @param nodeLinkId    is a {@link String} representing the link public id
    * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
    * itself) and all its metadata if the {@link Node} exists, and it is contained on a public folder with a valid link.
    * Otherwise, it returns an {@link Optional#empty()}.

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -125,17 +125,21 @@ public class BlobService {
    * Downloads from the {@link Filestore} a blob related to an identifier of a public node.
    *
    * @param nodeId    is a {@link String} representing the node identifier
+   * @param nodeLinkId    is a {@link String} representing the link identifier
    * @return an {@link Optional} of {@link BlobResponse} containing the stream of bytes (the blob
-   * itself) and all its metadata if the {@link Node} exists, and it is contained on a public folder.
+   * itself) and all its metadata if the {@link Node} exists, and it is contained on a public folder with a valid link.
    * Otherwise, it returns an {@link Optional#empty()}.
    *
    * @throws DependencyException if the {@link Filestore} failed to download the blob
    */
-  public Optional<BlobResponse> downloadPublicFileById(String nodeId) {
-    return nodeRepository
-      .getNode(nodeId)
-      .filter(linkRepository::hasNodeANotExpiredPublicLink)
-      .flatMap(node -> downloadFile(nodeId, null));
+  public Optional<BlobResponse> downloadPublicFileById(String nodeId, String nodeLinkId) {
+    Optional<Node> nodeOptional = nodeRepository.getNode(nodeId);
+
+    if (nodeOptional.isPresent() && linkRepository.isLinkValidForNode(nodeLinkId, nodeOptional.get())) {
+        return nodeOptional.flatMap(node -> downloadFile(nodeId, null));
+    }
+
+    return Optional.empty();
   }
 
   /**

--- a/core/src/main/resources/api/public-rest.yaml
+++ b/core/src/main/resources/api/public-rest.yaml
@@ -29,7 +29,6 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         200:
           $ref: '#/components/responses/200DownloadNode'

--- a/core/src/main/resources/api/public-rest.yaml
+++ b/core/src/main/resources/api/public-rest.yaml
@@ -23,6 +23,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - in: query
+          name: node_link_id
+          description: The id of the node link
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           $ref: '#/components/responses/200DownloadNode'

--- a/core/src/main/resources/api/public-schema.graphql
+++ b/core/src/main/resources/api/public-schema.graphql
@@ -106,6 +106,8 @@ type Query {
         folder_id: ID!
         # If valued it limits the number of nodes to return per page
         limit: Int
+        # If valued it makes sure that the link obtained from this public id is valid (not expired and with correct node)
+        node_link_id: String
         # If valued it will return the next page of nodes based on the given page_token,
         # if this param is passed all other params will be ignored
         page_token: String

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -97,7 +97,7 @@ public class PublicDownloadApiIT {
 
     simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
 
     // When
@@ -143,7 +143,7 @@ public class PublicDownloadApiIT {
             Optional.of(1L),
             Optional.empty());
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -180,7 +180,7 @@ public class PublicDownloadApiIT {
                 1L,
                 "text/plain"));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -202,8 +202,7 @@ public class PublicDownloadApiIT {
 
   @Test
   void givenANotExistingNodeThePublicDownloadByNodeIdShouldReturnA404StatusCode() {
-    // Given
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=ab000000-0000-0000-0000-000000000000";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -255,7 +254,7 @@ public class PublicDownloadApiIT {
                 .withPath("/download"))
         .error(HttpError.error().withDropConnection(true));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -265,4 +265,46 @@ public class PublicDownloadApiIT {
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
   }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "fake-token",
+      })
+  void
+      givenAUserWithOrWithoutCookieAnExistingFileAndAValidPublicLinkAssociatedButNotPassedInUrlThePublicDownloadByNodeIdShouldReturnA404StatusCode(
+          String userToken) {
+    // Given
+    DatabasePopulator.aNodePopulator(simulator.getInjector())
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000000",
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "LOCAL_ROOT",
+                "test.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad76",
+            "00000000-0000-0000-0000-000000000000",
+            "abcd1234abcd1234abcd1234abcd1234",
+            Optional.empty(),
+            Optional.empty());
+
+    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
+    final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
+
+    // When
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -97,7 +97,7 @@ public class PublicDownloadApiIT {
 
     simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
 
     // When
@@ -143,7 +143,7 @@ public class PublicDownloadApiIT {
             Optional.of(1L),
             Optional.empty());
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -180,7 +180,7 @@ public class PublicDownloadApiIT {
                 1L,
                 "text/plain"));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -202,7 +202,7 @@ public class PublicDownloadApiIT {
 
   @Test
   void givenANotExistingNodeThePublicDownloadByNodeIdShouldReturnA404StatusCode() {
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=ab000000-0000-0000-0000-000000000000";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -254,7 +254,7 @@ public class PublicDownloadApiIT {
                 .withPath("/download"))
         .error(HttpError.error().withDropConnection(true));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=94103c01-e701-4f3d-9dc9-54b79064ad76";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=1234abcd1234abcd1234abcd1234abcd";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
@@ -136,6 +136,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -189,6 +190,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -208,6 +210,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withString("page_token", pageToken)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
@@ -256,6 +259,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 6)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -323,6 +327,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -376,6 +381,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -408,6 +414,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -433,6 +440,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -527,6 +535,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 1)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
             .withString(
                 "page_token", Base64.getEncoder().encodeToString(pageTokenHacked.getBytes()))
             .withWantedResultFormat("{ nodes { id name }, page_token }")

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -224,8 +224,8 @@ class HttpRoutingHandlerTest {
         "/public/link/download/abcd1234/",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234/",
-        "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=00000000-0000-0000-0000-000000000001",
-        "/public/download/00000000-0000-0000-0000-000000000000/?node_link_id=00000000-0000-0000-0000-000000000001"
+        "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234",
+        "/public/download/00000000-0000-0000-0000-000000000000/?node_link_id=abcd1234abcd1234abcd1234abcd1234"
       })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
       String uri) {

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -224,8 +224,8 @@ class HttpRoutingHandlerTest {
         "/public/link/download/abcd1234/",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234",
         "/public/link/download/abcd1234abcd1234abcd1234abcd1234/",
-        "/public/download/00000000-0000-0000-0000-000000000000",
-        "/public/download/00000000-0000-0000-0000-000000000000/"
+        "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=00000000-0000-0000-0000-000000000001",
+        "/public/download/00000000-0000-0000-0000-000000000000/?node_link_id=00000000-0000-0000-0000-000000000001"
       })
   void givenAPublicLinkRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
       String uri) {


### PR DESCRIPTION
- Add node_link_id to public findNodes query and to download public file endpoint in schema
- Add check validation of passed link
- Add relevant ITs and adapted existing ITs and UTs

Refs: FILES-850