### PR TITLE
fix: initialize GraphQL instrumentations in a ChainedInstrumentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v2.13.0
     hooks:
       - id: pretty-format-java
-        args: [--autofix]
+        args: []
 
   - repo: https://github.com/ejba/pre-commit-maven
     rev: v0.3.4

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -17,12 +17,11 @@ import com.zextras.carbonio.files.graphql.datafetchers.ShareDataFetcher;
 import com.zextras.carbonio.files.graphql.datafetchers.UserDataFetcher;
 import com.zextras.carbonio.files.graphql.validators.InputFieldsController;
 import graphql.GraphQL;
+import graphql.analysis.MaxQueryDepthInstrumentation;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ResultPath;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
-import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
-import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationOptions;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
@@ -34,9 +33,7 @@ import graphql.schema.idl.SchemaParser;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.ArrayList;
 import java.util.List;
-import org.dataloader.BatchLoader;
 
 /**
  * <p>Setups the GraphQL instance with all the necessary properties. A GraphQL instance is
@@ -96,7 +93,7 @@ public class GraphQLProvider {
   private GraphQL setup() {
     List<Instrumentation> chainedInstrumentations = List.of(
       buildValidationInstrumentation(),
-      buildDataLoaderDispatcherInstrumentation()
+      new MaxQueryDepthInstrumentation(10)
     );
 
     return GraphQL.newGraphQL(buildSchema(buildWiring()))
@@ -201,18 +198,6 @@ public class GraphQLProvider {
       );
 
     return new FieldValidationInstrumentation(fieldValidation);
-  }
-
-  /**
-   * @return a {@link DataLoaderDispatcherInstrumentation} that allows to enable the registration of
-   * {@link BatchLoader}s. By default, the statistics are disabled.
-   */
-  private DataLoaderDispatcherInstrumentation buildDataLoaderDispatcherInstrumentation() {
-    return new DataLoaderDispatcherInstrumentation(
-      DataLoaderDispatcherInstrumentationOptions
-        .newOptions()
-        .includeStatistics(false)
-    );
   }
 
   /**

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/GraphQLProvider.java
@@ -19,6 +19,8 @@ import com.zextras.carbonio.files.graphql.validators.InputFieldsController;
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ResultPath;
+import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationOptions;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
@@ -32,6 +34,8 @@ import graphql.schema.idl.SchemaParser;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 import org.dataloader.BatchLoader;
 
 /**
@@ -83,16 +87,21 @@ public class GraphQLProvider {
    *   <li>{@link RuntimeWiring}: it links each interface, query and mutation with the related {@link DataFetcher}</li>
    *   <li>{@link GraphQLSchema}: the schema definition file is imported from the resources</li>
    *   <li>Execution strategy: how the execution of a request is performed (async or not)</li>
-   *   <li>Instrumentation: it is useful to check the input values of a request</li>
+   *   <li>Instrumentations: it is useful to check the input values of a request and to enable a
+   *   batching mechanism using {@link org.dataloader.DataLoader}s</li>
    * </ul>
    *
    * @return {@link GraphQL}
    */
   private GraphQL setup() {
+    List<Instrumentation> chainedInstrumentations = List.of(
+      buildValidationInstrumentation(),
+      buildDataLoaderDispatcherInstrumentation()
+    );
+
     return GraphQL.newGraphQL(buildSchema(buildWiring()))
       .queryExecutionStrategy(new AsyncExecutionStrategy())
-      .instrumentation(buildValidationInstrumentation())
-      .instrumentation(buildDataLoaderDispatcherInstrumentation())
+      .instrumentation(new ChainedInstrumentation(chainedInstrumentations))
       .build();
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -21,11 +21,16 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CreatePublicLinkApiIT {
 
@@ -33,6 +38,14 @@ class CreatePublicLinkApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static ShareRepository shareRepository;
+
+  // It is needed since strings cannot be generated as constants in the @ValueSource definition
+  static Stream<Arguments> invalidAccessCodesProvider() {
+    return Stream.of(
+      Arguments.of(RandomStringUtils.secure().nextAlphanumeric(9)),
+      Arguments.of(RandomStringUtils.secure().nextAlphanumeric(255))
+    );
+  }
 
   @BeforeAll
   static void init() {
@@ -218,6 +231,40 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
 
     Assertions.assertThat(createdLink).containsEntry("expires_at", null);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidAccessCodesProvider")
+  void givenAFileIdAndAnInvalidAccessCodeLengthTheCreateLinkShouldReturn200CodeWithAnErrorMessage(
+    String invalidAccessCode
+  ) {
+    // Given
+    createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    final String bodyPayload =
+      GraphqlCommandBuilder.aMutationBuilder("createLink")
+        .withString("node_id", "00000000-0000-0000-0000-000000000000")
+        .withInteger("expires_at", 5)
+        .withString("description", "super-description")
+        .withString("access_code", invalidAccessCode)
+        .withWantedResultFormat("{ id url expires_at created_at description access_code node { id } }")
+        .build();
+
+    final HttpRequest httpRequest =
+      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    final HttpResponse httpResponse =
+      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errorResponse =
+      TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errorResponse)
+      .hasSize(1)
+      .containsExactly(
+        "Invalid link access code. The access code must be between 10 and 255 characters long");
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -296,6 +296,7 @@ public class PublicDownloadApiIT {
             "00000000-0000-0000-0000-000000000000",
             "abcd1234abcd1234abcd1234abcd1234",
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
@@ -576,6 +576,7 @@ public class PublicFindNodesApiIT {
             "00000000-0000-0000-0000-000000000000",
             "abcd1234abcd1234abcd1234abcd1234",
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     String bodyPayload =

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-validator.version>1.9.0</commons-validator.version>
     <ebean.version>13.26.1</ebean.version>
-    <graphql-java.version>21.5</graphql-java.version>
+    <graphql-java.version>22.3</graphql-java.version>
     <guice.version>6.0.0</guice.version>
     <hikaricp.version>5.1.0</hikaricp.version>
     <hsqldb.version>2.7.3</hsqldb.version>


### PR DESCRIPTION
- Chained multiple instrumentations together and load them during the GraphQL initialization object
- Added an IT to test the FieldValidationInstrumentation
- Fixed some tests to make them build again
- Updated graphql-java version
- Removed DataLoaderDispatcherInstrumentation, now it is initialized at runtime by the library itself
- Add MaxQueryDepthInstrumentation with a depth of 10

Refs: FILES-867