### PR TITLE
fix: filter out current file version in the deleteVersions operation

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -108,6 +108,14 @@ public final class Files {
       private Hikari() {}
     }
 
+    public static final class PurgeService {
+
+      public static final long RETENTION_TRASHED_ITEMS_IN_DAYS = 30L;
+      public static final long RETENTION_TOMBSTONE_ITEMS_IN_MINUTES = 120L;
+      public static final long JOB_EXECUTION_INTERVAL_IN_MINUTES = 120L;
+
+      private PurgeService() {}
+    }
   }
 
   public static final class Db {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/TombstoneRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/TombstoneRepositoryEbean.java
@@ -6,11 +6,13 @@ package com.zextras.carbonio.files.dal.repositories.impl.ebean;
 
 import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
+import com.zextras.carbonio.files.Files.Db;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.FileVersion;
 import com.zextras.carbonio.files.dal.dao.ebean.Tombstone;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
 import io.ebean.Transaction;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,10 +25,13 @@ public class TombstoneRepositoryEbean implements TombstoneRepository {
     dbManager = EbeanDatabaseManager;
   }
 
-  @Override
-  public void deleteTombstones() {
+  public void deleteTombstones(long itemsRetentionInMinutes) {
     dbManager.getEbeanDatabase()
       .find(Tombstone.class)
+      .where()
+      .lt(
+        Db.Tombstone.TIMESTAMP,
+        System.currentTimeMillis() - Duration.ofMinutes(itemsRetentionInMinutes).toMillis())
       .delete();
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/TombstoneRepository.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/interfaces/TombstoneRepository.java
@@ -19,7 +19,7 @@ public interface TombstoneRepository {
   /**
    * <p>Deletes all Tombstones from the database.</p>
    */
-  void deleteTombstones();
+  void deleteTombstones(long itemsRetentionInMinutes);
 
   /**
    * <p>Gets all Tombstones from the database.</p>

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -1898,13 +1898,12 @@ public class NodeDataFetcher {
           .orElseGet(() -> fileVersionRepository.getFileVersions(nodeId, List.of(FileVersionSort.VERSION_DESC)))
           .stream()
           .filter(fileVersion -> !fileVersion.isKeptForever())
+          .filter(fileVersion -> !node.getCurrentVersion().equals(fileVersion.getVersion()))
           .collect(Collectors.toList());
 
         List<Integer> versionsToDelete = fileVersionsToDelete
           .stream()
           .map(FileVersion::getVersion)
-          .filter(version -> !node.getCurrentVersion()
-            .equals(version))
           .collect(Collectors.toList());
 
         fileVersionRepository.deleteFileVersions(nodeId, versionsToDelete);

--- a/core/src/main/java/com/zextras/carbonio/files/tasks/PurgeService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/tasks/PurgeService.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files.tasks;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.zextras.carbonio.files.Files.Config;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.FileVersionSort;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
@@ -41,7 +42,7 @@ public class PurgeService implements Runnable {
     this.fileVersionRepository = fileVersionRepository;
   }
 
-  private void purgeTombstones() {
+  private void purgeTombstones(long tombstoneRetentionInMinutes) {
     tombstoneRepository.getTombstones().forEach(tombstone -> {
       try {
         StoragesClient
@@ -58,11 +59,11 @@ public class PurgeService implements Runnable {
       }
     });
 
-    tombstoneRepository.deleteTombstones();
+    tombstoneRepository.deleteTombstones(tombstoneRetentionInMinutes);
     logger.info("Deleted nodes");
   }
 
-  private void purgeTrashedNodes(Long retentionDays) {
+  private void purgeTrashedNodes(long retentionDays) {
 
     /*
      * Compute retentionTimestamp: everything older must be deleted
@@ -96,13 +97,18 @@ public class PurgeService implements Runnable {
 
   @Override
   public void run() {
-    purgeTombstones();
-    purgeTrashedNodes(30L);
+    purgeTombstones(Config.PurgeService.RETENTION_TOMBSTONE_ITEMS_IN_MINUTES);
+    purgeTrashedNodes(Config.PurgeService.RETENTION_TRASHED_ITEMS_IN_DAYS);
   }
 
   public void start() {
     scheduledExecutor = Executors.newScheduledThreadPool(1);
-    scheduledExecutor.scheduleAtFixedRate(this, 1, 120, TimeUnit.MINUTES);
+    scheduledExecutor.scheduleAtFixedRate(
+      this,
+      1,
+      Config.PurgeService.JOB_EXECUTION_INTERVAL_IN_MINUTES,
+      TimeUnit.MINUTES);
+
     logger.info("Purge Service started");
   }
 


### PR DESCRIPTION
- Fixed the `deleteVersions` datafetcher filtering out the current version from the versions to move in the tombstone table
- Updated the `PurgeService` to delete only items in tombstone that are older than 120 minutes

Refs: FILES-871