### PR TITLE
fix: change how the key set of the page token is generated

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files;
 
 
 import com.zextras.carbonio.files.Files.Config.Pagination;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -165,6 +166,10 @@ public final class Files {
       public static final String INDEX_STATUS    = "index_status";
       public static final String SIZE            = "size";
       public static final String HIDDEN            = "hidden";
+
+      public static final List<String> ALLOWED_CONDITIONAL_COLUMN_NAMES = List.of(
+        ID, EDITOR_ID, NAME, OWNER_ID, CATEGORY, UPDATED_AT, CREATED_AT, SIZE
+      );
     }
 
     public static final class Trashed {

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbean.java
@@ -17,6 +17,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.TrashedNode;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.FindNodeKeySetBuilder;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.PageQuery;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SQLExpression;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SearchBuilder;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import io.ebean.Query;
@@ -82,11 +83,10 @@ public class NodeRepositoryEbean implements NodeRepository {
 
     List<NodeSort> realSortsToApply = getRealSortingsToApply(sort);
     nextPage.setKeySet(
-        FindNodeKeySetBuilder.aSearchKeySetBuilder()
-            .withNodeSorts(realSortsToApply)
-            .fromNode(node)
-            .build());
-
+      FindNodeKeySetBuilder.aSearchKeySetBuilder()
+        .withNodeSorts(realSortsToApply)
+        .fromNode(node)
+        .build());
     return nextPage.toToken();
   }
 
@@ -128,7 +128,7 @@ public class NodeRepositoryEbean implements NodeRepository {
       Optional<Boolean> sharedByMe,
       Optional<Boolean> directShare,
       List<String> keywords,
-      Optional<String> keyset,
+      Optional<SQLExpression> keySet,
       Optional<NodeType> optNodeType,
       Optional<String> optOwnerId) {
 
@@ -148,7 +148,7 @@ public class NodeRepositoryEbean implements NodeRepository {
     optOwnerId.ifPresent(search::setOwner);
 
     search.setLimit(limit);
-    keyset.ifPresent(search::setKeyset);
+    keySet.ifPresent(ks -> search.setKeySet(ks.toExpression(), ks.getParameters().toArray()));
 
     sorts.forEach(search::setSort);
 
@@ -165,7 +165,7 @@ public class NodeRepositoryEbean implements NodeRepository {
   /**
    * This is the single method that decides what sortings to apply and in what order. This is
    * responsible for default sorting, additional sorting not explicitly requested by user, and
-   * keyset generation for pagination.
+   * keySet generation for pagination.
    */
   public static List<NodeSort> getRealSortingsToApply(Optional<NodeSort> inputSort) {
     List<NodeSort> result = new ArrayList<>();
@@ -320,7 +320,8 @@ public class NodeRepositoryEbean implements NodeRepository {
             .query();
 
     if (pageQuery.getKeySet().isPresent()) {
-      findNodeQuery.where().and().raw(pageQuery.getKeySet().get());
+      SQLExpression keySet = pageQuery.getKeySet().get();
+      findNodeQuery.where().and().raw(keySet.toExpression(), keySet.getParameters().toArray());
     }
 
     List<Node> nodes =

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/FindNodeKeySetBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/FindNodeKeySetBuilder.java
@@ -6,7 +6,7 @@ package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
 
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
-import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 public class FindNodeKeySetBuilder {
@@ -19,8 +19,9 @@ public class FindNodeKeySetBuilder {
   }
 
   public FindNodeKeySetBuilder withNodeSorts(List<NodeSort> sorts) {
-    if (sorts.isEmpty())
+    if (sorts.isEmpty()) {
       throw new IllegalArgumentException("A default sort option should always be present");
+    }
     this.sorts = sorts;
     return this;
   }
@@ -30,59 +31,47 @@ public class FindNodeKeySetBuilder {
     return this;
   }
 
-  private String formatObjectSql(Object obj) {
-    return obj instanceof String ? "'" + obj.toString() + "'" : String.valueOf(obj);
-  }
+  private NodeSQLCondition createSQLCondition(NodeSort sort, SortOrder order) {
+    String columnNameToCompare = sort.getName();
+    // Special case: if sorting by name -> compare the lowercase of the fullName
+    Object parameterToCompare = Files.Db.Node.NAME.equals(columnNameToCompare)
+      ? node.getFullName().toLowerCase()
+      : node.getSortingValueFromColumn(columnNameToCompare);
 
-  private CompareExpression buildSortingExpression(NodeSort sort, SortOrder order) {
-    String nameToCompare = sort.getName();
-    String compareSymbol = order.getSymbol();
-    Object objToCompare;
-
-    if (Files.Db.Node.NAME.equals(nameToCompare)) {
-      // Special case: if sorting by name we actually want to compare lowercase names, so
-      // get name and adapt query composition
-      nameToCompare = MessageFormat.format("LOWER({0})", Files.Db.Node.NAME);
-      objToCompare = node.getFullName().toLowerCase();
-    } else if (Files.Db.Node.ID.equals(nameToCompare)) {
-      nameToCompare = "t0.node_id"; // since findnodes makes a join node_id would be ambiguous
-      objToCompare = node.getId();
-    } else {
-      objToCompare = node.getSortingValueFromColumn(nameToCompare);
-    }
-    String valueToCompare = formatObjectSql(objToCompare);
-    return CompareExpression.aCompareExpression(nameToCompare, compareSymbol, valueToCompare);
+    return new NodeSQLCondition(columnNameToCompare, order, parameterToCompare);
   }
 
   /**
-   * This essentially concatenates conditions to put in the WHERE of the find nodes query. The
-   * keyset is constructed following the order of the sortings to apply while querying. For example,
-   * given the last page's node and using sort by category and then by size, the keyset returned
+   * This essentially concatenates conditions to put in the WHERE of the find nodes query. The key
+   * set is constructed following the order of the sorting to apply while querying. For example,
+   * given the last page's node and using sort by category and then by size, the key set returned
    * will be CATEGORY > lastNodeCategory OR (CATEGORY = lastNodeCategory AND SIZE > lastNodeSize).
    * This builder works with N sorts, following the pattern A>B OR (A=B AND B>C) OR (A=B AND B=C AND
    * C>D) and so on.
    */
-  public String build() {
+  public SQLExpression build() {
 
-    if (this.sorts == null || this.sorts.isEmpty())
+    if (this.sorts == null || this.sorts.isEmpty()) {
       throw new IllegalArgumentException("Set sorting first");
-    if (this.node == null) throw new IllegalArgumentException("Set node first");
-
-    NodeSort firstSort = sorts.get(0); // there always is a first sort
-    CompareExpression keysetExpression = buildSortingExpression(firstSort, firstSort.getOrder());
-
-    for (NodeSort s : sorts.subList(1, sorts.size())) {
-      NodeSort temp = sorts.get(0);
-      CompareExpression tempEx = buildSortingExpression(temp, SortOrder.EQUAL);
-      for (NodeSort t : sorts.subList(1, sorts.indexOf(s))) {
-        tempEx.and(buildSortingExpression(t, SortOrder.EQUAL));
-      }
-      tempEx.and(
-          buildSortingExpression(
-              sorts.get(sorts.indexOf(s)), sorts.get(sorts.indexOf(s)).getOrder()));
-      keysetExpression.or(tempEx.encapsulate());
     }
 
-    return keysetExpression.toExpression();
+    if (this.node == null) {
+      throw new IllegalArgumentException("Set node first");
+    }
+
+    List<SQLPart> orConditions = new ArrayList<>();
+
+    for (NodeSort s : sorts) {
+      List<SQLPart> andConditions = new ArrayList<>();
+
+      for (NodeSort t : sorts.subList(0, sorts.indexOf(s))) {
+        andConditions.add(createSQLCondition(t, SortOrder.EQUAL));
+      }
+
+      andConditions.add(createSQLCondition(s, s.getOrder()));
+      orConditions.add(SQLExpression.and(andConditions));
+    }
+
+    return SQLExpression.or(orConditions);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/LogicalOperator.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/LogicalOperator.java
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+public enum LogicalOperator {
+  AND,
+  OR
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSQLCondition.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSQLCondition.java
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import com.zextras.carbonio.files.Files.Db.Node;
+
+public class NodeSQLCondition extends SQLCondition {
+
+  public NodeSQLCondition(String field, SortOrder operator, Object parameter) {
+    super(field, operator, parameter);
+    setField(field);
+ }
+
+  @Override
+  public void setField(String field) {
+    if (!Node.ALLOWED_CONDITIONAL_COLUMN_NAMES.contains(field)) {
+      throw new IllegalArgumentException("The " + field + " field is invalid");
+    }
+
+    if (Node.ID.equals(field)) {
+      super.setField("t0." + field);
+      return;
+    }
+
+    if (Node.NAME.equals(field)) {
+      super.setField("LOWER(" + field + ")");
+      return;
+    }
+
+    super.setField(field);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/PageQuery.java
@@ -23,7 +23,7 @@ public class PageQuery {
 
   private Integer limit;
   private List<String> keywords;
-  private Optional<String> keySet;
+  private Optional<SQLExpression> keySet;
   private Optional<NodeSort> sort;
   private Optional<Boolean> flagged;
   private Optional<String> folderId;
@@ -50,7 +50,7 @@ public class PageQuery {
   }
 
   public PageQuery(
-      String keySet,
+      SQLExpression keySet,
       Integer limit,
       String sort,
       Boolean flagged,
@@ -72,11 +72,11 @@ public class PageQuery {
     setKeywords(keywords);
   }
 
-  public Optional<String> getKeySet() {
+  public Optional<SQLExpression> getKeySet() {
     return keySet;
   }
 
-  public PageQuery setKeySet(String keySet) {
+  public PageQuery setKeySet(SQLExpression keySet) {
     this.keySet = Optional.of(keySet);
     return this;
   }

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLCondition.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLCondition.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.stream.Stream;
+
+@JsonTypeName("condition")
+class SQLCondition implements SQLPart {
+
+  private String field;
+  private final SortOrder operator;
+  private final Object parameter;
+
+  protected SQLCondition(
+    @JsonProperty("field") String field,
+    @JsonProperty("operator") SortOrder operator,
+    @JsonProperty("parameter") Object parameter) {
+
+    this.field = field;
+    this.operator = operator;
+    this.parameter = parameter;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public void setField(String field) {
+    this.field = field;
+  }
+
+  public SortOrder getOperator() {
+    return operator;
+  }
+
+  public Object getParameter() {
+    return parameter;
+  }
+
+  @JsonIgnore
+  public String toExpression() {
+    return String.format("%s %s ?", field, operator.getSymbol());
+  }
+
+  @JsonIgnore
+  public Stream<Object> getParameters() {
+    return Stream.of(getParameter());
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLExpression.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLExpression.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@JsonTypeName("expression")
+public class SQLExpression implements SQLPart {
+
+  private final LogicalOperator logicalOperator;
+  @JsonProperty("parts")
+  private final List<SQLPart> sqlParts;
+
+  @JsonCreator
+  public SQLExpression(
+    @JsonProperty("logicalOperator") LogicalOperator logicalOperator,
+    @JsonProperty("parts") List<SQLPart> sqlParts) {
+
+    this.logicalOperator = logicalOperator;
+    this.sqlParts = sqlParts;
+  }
+
+  public LogicalOperator getLogicalOperator() {
+    return logicalOperator;
+  }
+
+  public List<SQLPart> getSqlParts() {
+    return sqlParts;
+  }
+
+  public static SQLExpression and(List<SQLPart> sqlParts) {
+    return new SQLExpression(LogicalOperator.AND, sqlParts);
+  }
+
+  public static SQLExpression or(List<SQLPart> sqlParts) {
+    return new SQLExpression(LogicalOperator.OR, sqlParts);
+  }
+
+  @JsonIgnore
+  public String toExpression() {
+    String logicalOperatorName = " " + logicalOperator.name() + " ";
+    return sqlParts
+      .stream()
+      .map(SQLPart::toExpression)
+      .collect(Collectors.joining(logicalOperatorName, "(", ")"));
+  }
+
+  @JsonIgnore
+  public Stream<Object> getParameters() {
+    return sqlParts.stream().flatMap(SQLPart::getParameters);
+  }
+
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLPart.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLPart.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.stream.Stream;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @Type(value = SQLExpression.class, name = "expression"),
+  @Type(value = SQLCondition.class, name = "condition")
+})
+public interface SQLPart {
+
+  String toExpression();
+
+  Stream<Object> getParameters();
+}

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SearchBuilder.java
@@ -209,8 +209,8 @@ public class SearchBuilder {
     return this;
   }
 
-  public SearchBuilder setKeyset(String keyset) {
-    this.query.where().and().raw(keyset).endAnd();
+  public SearchBuilder setKeySet(String expression, Object[] parameters) {
+    this.query.where().and().raw(expression, parameters).endAnd();
     return this;
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
@@ -4,6 +4,8 @@
 
 package com.zextras.carbonio.files.api.search;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
 import com.zextras.carbonio.files.Simulator;
 import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
@@ -12,6 +14,9 @@ import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSQLCondition;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SQLExpression;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SortOrder;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
@@ -471,7 +476,7 @@ public class PublicFindNodesApiIT {
     not public and an hacked page token that is formed to try access a private node: the findNodes
     should return an empty page""")
   @Test
-  void givenAnHackedPageTokenTheFindNodesShouldReturnAnEmptyList() {
+  void givenAnHackedPageTokenTheFindNodesShouldReturnAnEmptyList() throws JsonProcessingException {
     // Given
     createFolderTree();
 
@@ -520,12 +525,26 @@ public class PublicFindNodesApiIT {
                 0L,
                 null));
 
-    String pageTokenHacked =
+    SQLExpression keySet = SQLExpression.or(List.of(
+      new NodeSQLCondition("node_category", SortOrder.ASCENDING, 1),
+      SQLExpression.and(List.of(
+        new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
+        new NodeSQLCondition("name", SortOrder.ASCENDING, "folder child")
+      )),
+        SQLExpression.and(List.of(
+          new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
+          new NodeSQLCondition("name", SortOrder.EQUAL, "folder child"),
+          new NodeSQLCondition("node_id", SortOrder.ASCENDING, "88888888-8888-8888-8888-888888888888")
+        ))
+      ));
+    String jsonKeySet = new ObjectMapper().writeValueAsString(keySet);
+
+      String pageTokenHacked = String.format(
         """
     {
       "limit": 1,
       "keywords": [],
-      "keySet": "(node_category > 1) OR (node_category = 1 AND LOWER(name)>'folder child') OR (node_category = 1 AND LOWER(name) = 'folder child' AND t0.node_id > '88888888-8888-8888-8888-888888888888')",
+      "keySet": %s,
       "sort": "NAME_ASC",
       "flagged": null,
       "folderId": "77777777-7777-7777-7777-777777777777",
@@ -535,7 +554,7 @@ public class PublicFindNodesApiIT {
       "directShare": null,
       "nodeType": null,
       "ownerId": null
-    }""";
+    }""", jsonKeySet);
 
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")

--- a/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSQLConditionTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/NodeSQLConditionTest.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NodeSQLConditionTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"node_id", "owner_id", "editor_id", "node_category", "name",
+    "updated_timestamp", "creation_timestamp", "size"})
+  void givenAValidFieldTheConstructorShouldUpdateTheFieldCorrectly(String field) {
+    // Given & When & Then
+    Assertions
+      .assertThatNoException()
+      .isThrownBy(() -> new NodeSQLCondition(field, SortOrder.EQUAL, 2));
+  }
+
+  @Test
+  void givenAnInvalidFieldTheSetFieldShouldThrownAnIllegalArgumentException() {
+    // Given & When & Then
+    Assertions
+      .assertThatIllegalArgumentException()
+      .isThrownBy(() -> new NodeSQLCondition("invalid-field", SortOrder.EQUAL, 2))
+      .withMessage("The invalid-field field is invalid");
+  }
+
+  @Test
+  void givenTheNodeIdFieldTheGetFieldShouldReturnTheFieldWithTheT0TableSuffix() {
+    // Given
+    SQLCondition sqlCondition = new NodeSQLCondition("node_id", SortOrder.EQUAL, "test");
+
+    // When
+    String field = sqlCondition.getField();
+
+    // Then
+    Assertions.assertThat(field).isEqualTo("t0.node_id");
+  }
+
+  @Test
+  void givenTheNameFieldTheGetFieldShouldReturnTheFieldWithTheSqlLowerSyntaxSuffix() {
+    // Given
+    SQLCondition sqlCondition = new NodeSQLCondition("name", SortOrder.EQUAL, "test");
+
+    // When
+    String field = sqlCondition.getField();
+
+    // Then
+    Assertions.assertThat(field).isEqualTo("LOWER(name)");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLConditionTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLConditionTest.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class SQLConditionTest {
+
+  @Test
+  void givenAFieldAnOperatorAndAParameterTheConstructorShouldCreateASQLCondition() {
+    // Given
+    final String field = "field";
+    final SortOrder operator = SortOrder.EQUAL;
+    final int parameter = 2;
+
+    // When
+    SQLCondition sqlCondition = new SQLCondition(field, operator, parameter);
+
+    // Then
+    Assertions.assertThat(sqlCondition.getField()).isEqualTo("field");
+    Assertions.assertThat(sqlCondition.getOperator()).isEqualTo(SortOrder.EQUAL);
+    Assertions.assertThat(sqlCondition.getParameter()).isEqualTo(2);
+  }
+
+  @ParameterizedTest()
+  @EnumSource(SortOrder.class)
+  void givenASQLConditionTheToExpressionShouldReturnTheConditionWithQuestionMarkParameter(
+    SortOrder operator) {
+    // Given
+    final String field = "field";
+    final int parameter = 2;
+
+    SQLCondition sqlCondition = new SQLCondition(field, operator, parameter);
+
+    // When
+    String sqlExpression = sqlCondition.toExpression();
+
+    // Then
+    Assertions.assertThat(sqlExpression).isEqualTo("field " + operator.getSymbol() + " ?");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLExpressionTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/utilities/SQLExpressionTest.java
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.Files.Db.Node;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SQLExpressionTest {
+
+  private SQLExpression createAComplexSQLExpression() {
+    return SQLExpression.or(
+      List.of(
+        new NodeSQLCondition(Node.CATEGORY, SortOrder.ASCENDING, 1),
+        SQLExpression.and(
+          List.of(
+            new NodeSQLCondition(Node.CATEGORY, SortOrder.EQUAL, 1),
+            new NodeSQLCondition(Node.NAME, SortOrder.ASCENDING, "f.txt"))
+        ),
+        SQLExpression.and(
+          List.of(
+            new NodeSQLCondition(Node.CATEGORY, SortOrder.EQUAL, 1),
+            new NodeSQLCondition(Node.NAME, SortOrder.EQUAL, "f.txt"),
+            new NodeSQLCondition(Node.ID, SortOrder.ASCENDING, "00000000"))
+        )
+      )
+    );
+  }
+
+  @Test
+  void givenALogicalOperatorAndAListOfSqlPartsTheConstructorShouldCreateASqlExpression() {
+    // Given
+    final LogicalOperator logicalOperator = LogicalOperator.AND;
+    final List<SQLPart> sqlParts = List.of(
+      new SQLCondition("field", SortOrder.ASCENDING, "test"),
+      new SQLCondition("field2", SortOrder.EQUAL, "test2")
+    );
+
+    // When
+    SQLExpression sqlExpression = new SQLExpression(logicalOperator, sqlParts);
+
+    // Then
+    Assertions.assertThat(sqlExpression.getLogicalOperator()).isEqualTo(LogicalOperator.AND);
+    Assertions.assertThat(sqlExpression.getSqlParts()).hasSize(2);
+
+    SQLCondition sqlCondition1 = (SQLCondition) sqlExpression.getSqlParts().get(0);
+    Assertions.assertThat(sqlCondition1.getField()).isEqualTo("field");
+    Assertions.assertThat(sqlCondition1.getOperator()).isEqualTo(SortOrder.ASCENDING);
+    Assertions.assertThat(sqlCondition1.getParameter()).isEqualTo("test");
+
+    SQLCondition sqlCondition2 = (SQLCondition) sqlExpression.getSqlParts().get(1);
+    Assertions.assertThat(sqlCondition2.getField()).isEqualTo("field2");
+    Assertions.assertThat(sqlCondition2.getOperator()).isEqualTo(SortOrder.EQUAL);
+    Assertions.assertThat(sqlCondition2.getParameter()).isEqualTo("test2");
+  }
+
+  @Test
+  void givenAListOfSqlPartsTheOrMethodShouldCreateASqlExpressionWithTheOrOperator() {
+    // Given
+    final List<SQLPart> sqlParts = List.of(new SQLCondition("field", SortOrder.ASCENDING, "test"));
+
+    // When
+    SQLExpression sqlExpression = SQLExpression.or(sqlParts);
+
+    // Then
+    Assertions.assertThat(sqlExpression.getLogicalOperator()).isEqualTo(LogicalOperator.OR);
+    Assertions.assertThat(sqlExpression.getSqlParts()).hasSize(1);
+  }
+
+  @Test
+  void givenAListOfSqlPartsTheAndMethodShouldCreateASqlExpressionWithTheAndOperator() {
+    // Given
+    final List<SQLPart> sqlParts = List.of(new SQLCondition("field", SortOrder.ASCENDING, "test"));
+
+    // When
+    SQLExpression sqlExpression = SQLExpression.and(sqlParts);
+
+    // Then
+    Assertions.assertThat(sqlExpression.getLogicalOperator()).isEqualTo(LogicalOperator.AND);
+    Assertions.assertThat(sqlExpression.getSqlParts()).hasSize(1);
+  }
+
+  @Test
+  void givenAnSqlExpressionTheJsonSerializationAndDeserializationWorksCorrectly() throws Throwable {
+    // Given & When
+    ObjectMapper mapper = new ObjectMapper();
+
+    SQLExpression sqlExpression = SQLExpression.or(
+      List.of(
+        new SQLCondition("field1", SortOrder.ASCENDING, 1),
+        SQLExpression.and(
+          List.of(
+            new SQLCondition("field3", SortOrder.DESCENDING, "test"),
+            new SQLCondition("field4", SortOrder.EQUAL, (short) 2)
+          )
+        )
+      )
+    );
+
+    // Then
+    Assertions.assertThatNoException().isThrownBy(() -> {
+        // Serialize
+        String serializedExpression = mapper.writeValueAsString(sqlExpression);
+        // Deserialize
+        mapper.readValue(serializedExpression, SQLExpression.class);
+      }
+    );
+  }
+
+  @Test
+  void givenAComplexSqlExpressionTheToExpressionShouldReturnAStringRepresentingTheExpression() {
+    // Given
+    SQLExpression sqlExpression = createAComplexSQLExpression();
+
+    // When
+    String sqlExpressionAsString = sqlExpression.toExpression();
+
+    // Then
+    Assertions
+      .assertThat(sqlExpressionAsString)
+      .isEqualTo("(node_category > ? OR (node_category = ? AND LOWER(name) > ?) OR (node_category"
+        + " = ? AND LOWER(name) = ? AND t0.node_id > ?))");
+  }
+
+  @Test
+  void givenAComplexSqlExpressionTheGetParametersShouldReturnAStreamOfAllTheConditionParameters() {
+    // Given
+    SQLExpression sqlExpression = createAComplexSQLExpression();
+
+    // When
+    Stream<Object> sqlParameters = sqlExpression.getParameters();
+
+    // Then
+    Assertions.assertThat(sqlParameters).containsExactly(1, 1, "f.txt", 1, "f.txt", "00000000");
+  }
+}


### PR DESCRIPTION
- The key set is represented by a SQLExpression object that is compoesed
  by a LogicalOperator and a list of SQLPart. An SQLPart could be
  another SQLExpression or an SQLCondition. The combination of this two
  type allows to create an object representing a where expression of an
  SQL query.
- Updated how the eBean raw method is called: now it is always passed
  the where expression as a String containing question marks and an
  array of parameters to be sanitized and to replace the question marks.
- Added UTs and ITs to test the new classes

Refs: FILES-843
