### PR TITLE
feat: links public id from 32 to 50 characters

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.14.4-1</version>
+    <version>0.14.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-files-ce</artifactId>
     <groupId>com.zextras.carbonio.files</groupId>
-    <version>0.14.4-1</version>
+    <version>0.14.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -123,7 +123,7 @@ public final class Files {
 
     private Db() {}
 
-    public static final short DB_VERSION = 5;
+    public static final short DB_VERSION = 6;
 
     /**
      * Names of Files tables
@@ -780,9 +780,9 @@ public final class Files {
       public static final Pattern DOWNLOAD_FILE       = Pattern.compile(
         SERVICE + "download/([a-f\\d\\-]*)/?([\\d]+)?/?$");
       public static final Pattern PUBLIC_LINK =
-          Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32})/?$");
+          Pattern.compile(SERVICE + "link/([\\w]{8}|[\\w]{32}|[\\w]{50})/?$");
       public static final Pattern DOWNLOAD_VIA_PUBLIC_LINK =
-        Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32})/?$");
+        Pattern.compile(SERVICE + "public/link/download/([\\w]{8}|[\\w]{32}|[\\w]{50})/?$");
       public static final Pattern DOWNLOAD_PUBLIC_FILE = Pattern.compile(
           SERVICE + "public/download/([a-f\\d\\-]*)/?\\?node_link_id=([a-zA-Z\\d\\-]*)/?");
       public static final Pattern COLLABORATION_LINK  = Pattern.compile(

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
@@ -138,7 +138,7 @@ public class LinkDataFetcher {
         .has(SharePermission.READ_AND_SHARE)
         && optNode.isPresent() && optNode.get().getNodeType() != NodeType.ROOT
       ) {
-        String publicId = RandomStringUtils.randomAlphanumeric(50);
+        String publicId = RandomStringUtils.secure().nextAlphanumeric(50);
 
         Link createdLink = linkRepository.createLink(
           UUID.randomUUID().toString(),

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/LinkDataFetcher.java
@@ -138,7 +138,7 @@ public class LinkDataFetcher {
         .has(SharePermission.READ_AND_SHARE)
         && optNode.isPresent() && optNode.get().getNodeType() != NodeType.ROOT
       ) {
-        String publicId = RandomStringUtils.randomAlphanumeric(32);
+        String publicId = RandomStringUtils.randomAlphanumeric(50);
 
         Link createdLink = linkRepository.createLink(
           UUID.randomUUID().toString(),

--- a/core/src/main/resources/sql/postgresql_6.sql
+++ b/core/src/main/resources/sql/postgresql_6.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-ALTER TABLE link ALTER COLUMN public_id TYPE VARCHAR(50);
+ALTER TABLE link ALTER COLUMN public_id TYPE VARCHAR(255);
 
 UPDATE db_info SET version = 6;
 

--- a/core/src/main/resources/sql/postgresql_6.sql
+++ b/core/src/main/resources/sql/postgresql_6.sql
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+BEGIN;
+
+ALTER TABLE link ALTER COLUMN public_id TYPE VARCHAR(50);
+
+UPDATE db_info SET version = 6;
+
+COMMIT;

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -121,7 +121,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/public/link/download/")
-        .hasSize("example.com/services/files/public/link/download/".length() + 32);
+        .hasSize("example.com/services/files/public/link/download/".length() + 50);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", 5)
@@ -157,7 +157,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/services/files/public/link/download/")
-        .hasSize("example.com/services/files/public/link/download/".length() + 32);
+        .hasSize("example.com/services/files/public/link/download/".length() + 50);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", null)
@@ -194,7 +194,7 @@ class CreatePublicLinkApiIT {
     Assertions.assertThat((String) createdLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) createdLink.get("url"))
         .startsWith("example.com/files/public/link/access/")
-        .hasSize("example.com/files/public/link/access/".length() + 32);
+        .hasSize("example.com/files/public/link/access/".length() + 50);
 
     Assertions.assertThat(createdLink)
         .containsEntry("expires_at", null)

--- a/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
@@ -70,10 +70,12 @@ public class DownloadByPublicLinkApiIT {
   @CsvSource({
     "abcd1234,/public/link/download/,",
     "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/public/link/download/,",
     "abcd1234,/link/,",
     "abcd1234abcd1234abcd1234abcd1234,/link/,",
-    "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,fake-token",
-    "abcd1234abcd1234abcd1234abcd1234,/link/,fake-token",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/public/link/download/,fake-token",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/link/,fake-token",
   })
   void
       givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedTheDownloadByPublicLinkShouldReturnTheBlob(
@@ -129,8 +131,10 @@ public class DownloadByPublicLinkApiIT {
   @CsvSource({
     "abcd1234,/public/link/download/,",
     "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/public/link/download/,",
     "abcd1234,/link/,",
     "abcd1234abcd1234abcd1234abcd1234,/link/,",
+    "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab,/link/,",
     "abcd1234abcd1234abcd1234abcd1234,/public/link/download/,fake-token",
     "abcd1234abcd1234abcd1234abcd1234,/link/,fake-token",
   })
@@ -203,12 +207,12 @@ public class DownloadByPublicLinkApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "1234abcd1234abcd1234abcd1234abcd",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(1L),
             Optional.empty(),
             Optional.empty());
 
-    final String publicDownloadUrl = "/public/link/download/1234abcd1234abcd1234abcd1234abcd";
+    final String publicDownloadUrl = "/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -315,7 +319,7 @@ public class DownloadByPublicLinkApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "1234abcd1234abcd1234abcd1234abcd",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -329,7 +333,7 @@ public class DownloadByPublicLinkApiIT {
         .error(HttpError.error().withDropConnection(true));
 
     final HttpRequest httpRequest =
-        HttpRequest.of("GET", "/public/link/download/1234abcd1234abcd1234abcd1234abcd", null, null);
+        HttpRequest.of("GET", "/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab", null, null);
 
     // When
     final HttpResponse httpResponse =

--- a/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/GetPublicLinksApiIT.java
@@ -95,7 +95,7 @@ class GetPublicLinksApiIT {
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());
@@ -145,7 +145,7 @@ class GetPublicLinksApiIT {
         .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
         .containsEntry(
             "url",
-            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234")
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description");
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
@@ -161,7 +161,7 @@ class GetPublicLinksApiIT {
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());
@@ -190,7 +190,7 @@ class GetPublicLinksApiIT {
     Assertions.assertThat(publicLinks.get(0))
         .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
         .containsEntry(
-            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
+            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description");
     Assertions.assertThat((Map<String, Object>) publicLinks.get(0).get("node"))
@@ -206,7 +206,7 @@ class GetPublicLinksApiIT {
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.of("fake-access-code"));
@@ -235,7 +235,7 @@ class GetPublicLinksApiIT {
     Assertions.assertThat(publicLinks.get(0))
         .containsEntry("id", "06e0f2ae-b128-4d25-9b3b-df84eb7948a9")
         .containsEntry(
-            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234")
+            "url", "example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
         .containsEntry("expires_at", 5)
         .containsEntry("description", "super-description")
         .containsEntry("access_code", "fake-access-code");
@@ -341,7 +341,7 @@ class GetPublicLinksApiIT {
         .addLink(
             "0c04783b-bdfb-446f-870c-625f5ae02a0a",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -380,7 +380,7 @@ class GetPublicLinksApiIT {
         .addLink(
             "0c04783b-bdfb-446f-870c-625f5ae02a0a",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -91,14 +91,14 @@ public class PublicDownloadApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
     simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
 
     // When
@@ -140,12 +140,12 @@ public class PublicDownloadApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(1L),
             Optional.empty(),
             Optional.empty());
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -182,7 +182,7 @@ public class PublicDownloadApiIT {
                 1L,
                 "text/plain"));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -204,7 +204,7 @@ public class PublicDownloadApiIT {
 
   @Test
   void givenANotExistingNodeThePublicDownloadByNodeIdShouldReturnA404StatusCode() {
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -244,7 +244,7 @@ public class PublicDownloadApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "1234abcd1234abcd1234abcd1234abcd",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -257,7 +257,7 @@ public class PublicDownloadApiIT {
                 .withPath("/download"))
         .error(HttpError.error().withDropConnection(true));
 
-    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=1234abcd1234abcd1234abcd1234abcd";
+    final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
@@ -294,7 +294,7 @@ public class PublicDownloadApiIT {
         .addLink(
             "94103c01-e701-4f3d-9dc9-54b79064ad76",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/UpdatePublicLinkApiIT.java
@@ -92,7 +92,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.of("fake-access-code"));
@@ -120,7 +120,7 @@ class UpdatePublicLinkApiIT {
 
     Assertions.assertThat((String) updatedLink.get("url"))
         .isEqualTo(
-            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234");
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -141,7 +141,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.of("fake-access-code"));
@@ -169,7 +169,7 @@ class UpdatePublicLinkApiIT {
 
     Assertions.assertThat((String) updatedLink.get("url"))
         .isEqualTo(
-            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234");
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -190,7 +190,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());
@@ -216,7 +216,7 @@ class UpdatePublicLinkApiIT {
     Assertions.assertThat((String) updatedLink.get("id")).isNotNull().hasSize(36);
     Assertions.assertThat((String) updatedLink.get("url"))
         .isEqualTo(
-            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234");
+            "example.com/services/files/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -237,7 +237,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -263,7 +263,7 @@ class UpdatePublicLinkApiIT {
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateLink");
 
     Assertions.assertThat((String) updatedLink.get("url"))
-        .isEqualTo("example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234");
+        .isEqualTo("example.com/files/public/link/access/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab");
 
     Assertions.assertThat(updatedLink)
         .containsEntry("id", "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b")
@@ -313,7 +313,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());
@@ -353,7 +353,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.empty(),
             Optional.empty());
@@ -396,7 +396,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());
@@ -434,7 +434,7 @@ class UpdatePublicLinkApiIT {
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(5L),
             Optional.of("super-description"),
             Optional.empty());

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/PublicFindNodesApiIT.java
@@ -133,7 +133,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -142,7 +142,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -187,7 +187,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -197,7 +197,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -217,7 +217,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 3)
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withString("page_token", pageToken)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
@@ -258,7 +258,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -267,7 +267,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 6)
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -328,7 +328,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -336,7 +336,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -383,7 +383,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.of(1L),
             Optional.empty(),
             Optional.empty());
@@ -391,7 +391,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -424,7 +424,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -450,7 +450,7 @@ public class PublicFindNodesApiIT {
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
@@ -484,7 +484,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty())
@@ -560,7 +560,7 @@ public class PublicFindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 1)
-            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234")
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
             .withString(
                 "page_token", Base64.getEncoder().encodeToString(pageTokenHacked.getBytes()))
             .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -593,7 +593,7 @@ public class PublicFindNodesApiIT {
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
-            "abcd1234abcd1234abcd1234abcd1234",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/core/src/test/resources/sql/postgresql.sql
+++ b/core/src/test/resources/sql/postgresql.sql
@@ -123,3 +123,15 @@ UPDATE db_info SET version = 3;
 ALTER TABLE node ADD COLUMN hidden BOOLEAN DEFAULT FALSE NOT NULL;
 
 UPDATE db_info SET version = 4;
+
+-- postgresql_5
+
+ALTER TABLE link ADD COLUMN access_code VARCHAR(255) DEFAULT NULL;
+
+UPDATE db_info SET version = 5;
+
+-- postgresql_6
+
+ALTER TABLE link ALTER COLUMN public_id VARCHAR(50);
+
+UPDATE db_info SET version = 6;

--- a/core/src/test/resources/sql/postgresql.sql
+++ b/core/src/test/resources/sql/postgresql.sql
@@ -132,6 +132,6 @@ UPDATE db_info SET version = 5;
 
 -- postgresql_6
 
-ALTER TABLE link ALTER COLUMN public_id VARCHAR(50);
+ALTER TABLE link ALTER COLUMN public_id VARCHAR(255);
 
 UPDATE db_info SET version = 6;

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-files-ce"
-pkgver="0.14.4"
-pkgrel="1"
+pkgver="0.14.5"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.files</groupId>
   <artifactId>carbonio-files-ce</artifactId>
-  <version>0.14.4-1</version>
+  <version>0.14.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-files-ce</name>


### PR DESCRIPTION
- Add support for 50 chars public link id
- Adapted tests to work with 50 chars, keeping the tests for the 32 char public id to make this backwards compatible

Refs: FILES-852