### PR TITLE
feat: make node version as a query param in Preview APIs

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -798,22 +798,22 @@ public final class Files {
       public static final Pattern PREVIEW            = Pattern.compile(SERVICE + "preview/(.*)");
       public static final Pattern PREVIEW_IMAGE      = Pattern.compile(
         SERVICE
-          + "preview/image/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+          + "preview/image/([a-f\\d\\-]*)/([\\d]*x[\\d]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_IMAGE    = Pattern.compile(
-        SERVICE + "preview/image/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/image/([a-f\\d\\-]*)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
       public static final Pattern PREVIEW_PDF        = Pattern.compile(
-        SERVICE + "preview/pdf/([a-f\\d\\-]*)/([\\d]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+        SERVICE + "preview/pdf/([a-f\\d\\-]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_PDF      = Pattern.compile(
-        SERVICE + "preview/pdf/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/pdf/([a-f\\d\\-]*)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
       public static final Pattern PREVIEW_DOCUMENT   = Pattern.compile(
-        SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
+        SERVICE + "preview/document/([a-f\\d\\-]*)/?((?=(?!thumbnail))(?=([^/\\n ]*)))"
       );
       public static final Pattern THUMBNAIL_DOCUMENT = Pattern.compile(
-        SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]+)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
+        SERVICE + "preview/document/([a-f\\d\\-]*)/([\\d]*x[\\d]*)/thumbnail/?\\??(.*)"
       );
       public static final Pattern PUBLIC_GRAPHQL             = Pattern.compile(SERVICE + "public/graphql/?$");
     }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
@@ -176,16 +176,15 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched, User requester) {
 
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
-    String previewArea = uriMatched.group(3);
+    String previewArea = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(5));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
             requester.getId(),
             nodeId,
-            Integer.parseInt(nodeVersion),
+            queryParameters.getNodeVersion().orElse(null),
             Collections.singleton("image/"));
 
     if (tryCheckNode.isSuccess()) {
@@ -220,16 +219,15 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
   private void thumbnailImage(
       ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched, User requester) {
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
-    String previewArea = uriMatched.group(3);
+    String previewArea = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(3));
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
             requester.getId(),
             nodeId,
-            Integer.parseInt(nodeVersion),
+            queryParameters.getNodeVersion().orElse(null),
             Collections.singleton("image/"));
 
     if (tryCheckNode.isSuccess()) {
@@ -265,15 +263,14 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched, User requester) {
 
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(3));
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
             requester.getId(),
             nodeId,
-            Integer.parseInt(nodeVersion),
+            queryParameters.getNodeVersion().orElse(null),
             Collections.singleton("application/pdf"));
 
     if (tryCheckNode.isSuccess()) {
@@ -308,16 +305,15 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       ChannelHandlerContext context, HttpRequest httpRequest, Matcher uriMatched, User requester) {
 
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
-    String area = uriMatched.group(3);
+    String area = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(3));
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
             requester.getId(),
             nodeId,
-            Integer.parseInt(nodeVersion),
+            queryParameters.getNodeVersion().orElse(null),
             Collections.singleton("application/pdf"));
 
     if (tryCheckNode.isSuccess()) {
@@ -356,14 +352,16 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       UserMyself requester) {
 
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(3));
     queryParameters.setLocale(requester.getLocale().toLanguageTag());
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
-            requester.getId(), nodeId, Integer.parseInt(nodeVersion), documentAllowedTypes);
+            requester.getId(),
+            nodeId,
+            queryParameters.getNodeVersion().orElse(null),
+            documentAllowedTypes);
 
     if (tryCheckNode.isSuccess()) {
       String fileDigestWithLanguage = tryCheckNode.get().getRight().getDigest() + requester.getLocale().toLanguageTag();
@@ -400,15 +398,17 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       UserMyself requester) {
 
     String nodeId = uriMatched.group(1);
-    String nodeVersion = uriMatched.group(2);
-    String area = uriMatched.group(3);
+    String area = uriMatched.group(2);
 
-    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(4));
+    PreviewQueryParameters queryParameters = parseQueryParameters(uriMatched.group(3));
     queryParameters.setLocale(requester.getLocale().toLanguageTag());
 
     Try<Pair<Node, FileVersion>> tryCheckNode =
         checkNodePermissionAndExistence(
-            requester.getId(), nodeId, Integer.parseInt(nodeVersion), documentAllowedTypes);
+            requester.getId(),
+            nodeId,
+            queryParameters.getNodeVersion().orElse(null),
+            documentAllowedTypes);
 
     if (tryCheckNode.isSuccess()) {
       String fileDigestWithLanguage = tryCheckNode.get().getRight().getDigest() + requester.getLocale().toLanguageTag();
@@ -571,8 +571,11 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
    * {@link FileVersion} or, a {@link Try#failure} containing the specific error.
    */
   private Try<Pair<Node, FileVersion>> checkNodePermissionAndExistence(
-      String requesterId, String nodeId, int version, Set<String> supportedMimeTypeList) {
-    Optional<FileVersion> optFileVersion = fileVersionRepository.getFileVersion(nodeId, version);
+      String requesterId, String nodeId, Integer version, Set<String> supportedMimeTypeList) {
+    Optional<FileVersion> optFileVersion = (version == null)
+        ? fileVersionRepository.getLastFileVersion(nodeId)
+        : fileVersionRepository.getFileVersion(nodeId, version);
+
     if (permissionsChecker.getPermissions(nodeId, requesterId).has(SharePermission.READ_ONLY)
         && optFileVersion.isPresent()) {
       return (mimeTypeUtils.isMimeTypeAllowed(

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
@@ -196,7 +196,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getPreviewOfImage(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 previewArea,
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigest, blob))
@@ -240,7 +240,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getThumbnailOfImage(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 previewArea,
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigest, blob))
@@ -284,7 +284,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getPreviewOfPdf(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigest, blob))
             .onFailure(failure -> failureResponse(context, httpRequest, failure));
@@ -328,7 +328,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getThumbnailOfPdf(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 area,
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigest, blob))
@@ -373,7 +373,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getPreviewOfDocument(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigestWithLanguage, blob))
             .onFailure(failure -> failureResponse(context, httpRequest, failure));
@@ -418,7 +418,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
             .getThumbnailOfDocument(
                 tryCheckNode.get().getLeft().getOwnerId(),
                 nodeId,
-                Integer.parseInt(nodeVersion),
+                tryCheckNode.get().getRight().getVersion(),
                 area,
                 queryParameters)
             .onSuccess(blob -> successResponse(context, httpRequest, fileDigestWithLanguage, blob))

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PreviewController.java
@@ -100,8 +100,7 @@ public class PreviewController extends SimpleChannelInboundHandler<HttpRequest> 
       /*
        get the user with updated locale for every preview request.
        if this was cached so would be the locale resulting in incorrect preview if user changes
-       language and then
-       requests a preview. all cookie checks here are already passed so we know there is one and
+       language and then requests a preview. All cookie checks here are already passed so we know there is one and
        if user management is not down an usermyself should always be returned given the cookie.
       */
       HttpHeaders headersRequest = httpRequest.headers();

--- a/core/src/main/java/com/zextras/carbonio/files/rest/types/PreviewQueryParameters.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/types/PreviewQueryParameters.java
@@ -30,13 +30,9 @@ public class PreviewQueryParameters {
   @JsonProperty("locale")
   private String locale;
 
-  public Optional<String> getLocale() {
-    return Optional.ofNullable(locale);
-  }
+  @JsonProperty("version")
+  private Integer nodeVersion;
 
-  public void setLocale(String locale) {
-    this.locale = locale;
-  }
 
   public Optional<String> getQuality() {
     return Optional.ofNullable(quality == null ? null : quality.name());
@@ -60,6 +56,22 @@ public class PreviewQueryParameters {
 
   public Optional<Integer> getLastPage() {
     return Optional.ofNullable(lastPage);
+  }
+
+  public Optional<String> getLocale() {
+    return Optional.ofNullable(locale);
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  public Optional<Integer> getNodeVersion() {
+    return Optional.ofNullable(nodeVersion);
+  }
+
+  public void setNodeVersion(Integer nodeVersion) {
+    this.nodeVersion = nodeVersion;
   }
 
   private enum Quality {

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -415,7 +415,7 @@ public class Simulator implements AutoCloseable {
   }
 
   public void clearFileVersionCache() {
-    injector.getInstance(CacheHandler.class).getFileVersionCache().flushAll();;
+    injector.getInstance(CacheHandler.class).getFileVersionCache().flushAll();
   }
 
   public void getBlob(String nodeId, int version) {

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -12,6 +12,7 @@ import com.zextras.carbonio.files.Files.Config.Preview;
 import com.zextras.carbonio.files.Files.Config.Storages;
 import com.zextras.carbonio.files.Files.Config.UserManagement;
 import com.zextras.carbonio.files.Files.ServiceDiscover.Config.Db;
+import com.zextras.carbonio.files.cache.CacheHandler;
 import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.config.FilesModule;
 import com.zextras.carbonio.files.dal.EbeanDatabaseManager;
@@ -411,6 +412,10 @@ public class Simulator implements AutoCloseable {
 
   public void resetDatabase() {
     ebeanDatabaseManager.getEbeanDatabase().find(Node.class).delete();
+  }
+
+  public void clearFileVersionCache() {
+    injector.getInstance(CacheHandler.class).getFileVersionCache().flushAll();;
   }
 
   public void getBlob(String nodeId, int version) {

--- a/core/src/test/java/com/zextras/carbonio/files/api/PreviewApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PreviewApiIT.java
@@ -112,7 +112,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1",
+            "/preview/document/00000000-0000-0000-0000-000000000000",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -130,7 +130,7 @@ class PreviewApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"2", "?version=2"})
+  @ValueSource(strings = {"", "?version=2"})
   void givenTwoVersionsOfAnExistingDocumentTheGetPreviewApiShouldReturnThePdfOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -157,7 +157,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/2",// + versionQueryParam,
+            "/preview/document/00000000-0000-0000-0000-000000000000" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -194,7 +194,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1",//?version=1",
+            "/preview/document/00000000-0000-0000-0000-000000000000?version=1",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -207,7 +207,7 @@ class PreviewApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"3", "?version=3"})
+  @ValueSource(strings = {"", "?version=3"})
   void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnThePdfOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -235,7 +235,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/3",// + versionQueryParam,
+            "/preview/pdf/00000000-0000-0000-0000-000000000000/" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -273,7 +273,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/2/",//?version=2",
+            "/preview/pdf/00000000-0000-0000-0000-000000000000?version=2",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -286,7 +286,7 @@ class PreviewApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"2", "?version=2"})
+  @ValueSource(strings = {"", "?version=2"})
   void givenTwoVersionsOfAnExistingPngImageTheGetPreviewApiShouldReturnThePngOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -313,7 +313,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",// + versionQueryParam,
+            "/preview/image/00000000-0000-0000-0000-000000000000/0x0" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -350,7 +350,7 @@ class PreviewApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0",//?version=2",
+            "/preview/image/00000000-0000-0000-0000-000000000000/0x0?version=2",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
@@ -112,7 +112,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail",
+            "/preview/document/00000000-0000-0000-0000-000000000000/5x5/thumbnail",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -129,7 +129,7 @@ class ThumbnailApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"2", "?version=2"})
+  @ValueSource(strings = {"", "?version=2"})
   void givenTwoVersionsOfAnExistingDocumentTheGetThumbnailApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -155,7 +155,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail",// + versionQueryParam,
+            "/preview/document/00000000-0000-0000-0000-000000000000/5x5/thumbnail" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -191,7 +191,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail",//?version=1",
+            "/preview/document/00000000-0000-0000-0000-000000000000/5x5/thumbnail?version=1",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -204,7 +204,7 @@ class ThumbnailApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"3", "?version=3"})
+  @ValueSource(strings = {"", "?version=3"})
   void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -231,7 +231,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/3/5x5/thumbnail",// + versionQueryParam,
+            "/preview/pdf/00000000-0000-0000-0000-000000000000/5x5/thumbnail/" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -268,7 +268,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail",//?version=2",
+            "/preview/pdf/00000000-0000-0000-0000-000000000000/5x5/thumbnail?version=2",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -281,7 +281,7 @@ class ThumbnailApiIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"2", "?version=2"})
+  @ValueSource(strings = {"", "?version=2"})
   void givenTwoVersionsOfAnExistingPngImageTheGetThumbnailApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
@@ -307,7 +307,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail", //+ versionQueryParam,
+            "/preview/image/00000000-0000-0000-0000-000000000000/5x5/thumbnail" + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -343,7 +343,7 @@ class ThumbnailApiIT {
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail", //?version=1",
+            "/preview/image/00000000-0000-0000-0000-000000000000/5x5/thumbnail/?version=1",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+// SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -29,7 +29,7 @@ import org.mockserver.model.Parameter;
 
 import java.util.Map;
 
-class PreviewApiIT {
+class ThumbnailApiIT {
 
   static Simulator simulator;
   static NodeRepository nodeRepository;
@@ -42,7 +42,7 @@ class PreviewApiIT {
             .withDatabase()
             .withServiceDiscover()
             .withPreview()
-            .withUserManagement( // create a fake token to use in cookie for auth
+            .withUserManagement(
                 Map.of(
                     "fake-token",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
@@ -64,14 +64,15 @@ class PreviewApiIT {
     simulator.stopAll();
   }
 
-  static String mockSuccessPreviewResponse(String previewPathEndpoint, MediaType previewTypeResponse) {
+  static String mockSuccessThumbnailResponse(String thumbnailPathEndpoint) {
+
     org.mockserver.model.HttpRequest request = org.mockserver.model.HttpRequest.request()
         .withMethod(HttpMethod.GET.toString())
-        .withPath(previewPathEndpoint)
+        .withPath(thumbnailPathEndpoint)
         .withQueryStringParameter(new Parameter("service_type", "files"))
         .withHeader("FileOwnerId", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    if (previewPathEndpoint.contains("document")) {
+    if (thumbnailPathEndpoint.contains("document")) {
       request.withQueryStringParameter(new Parameter("locale", "en"));
     }
 
@@ -79,16 +80,16 @@ class PreviewApiIT {
         .when(request)
         .respond(org.mockserver.model.HttpResponse.response()
             .withStatusCode(200)
-            .withBody(new BinaryBody("0".getBytes())).withContentType(previewTypeResponse))[0].getId();
+            .withBody(new BinaryBody("0".getBytes())).withContentType(MediaType.JPEG))[0].getId();
   }
 
-  static void verifyAndClearExpectationInPreviewMockService(String expectationId) {
+  static void verifyAndClearExpectationInThumbnailMockService(String expectationId) {
     MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
     previewServiceMock.verify(expectationId).clear(expectationId);
   }
 
   @Test
-  void givenAnExistingDocumentTheGetPreviewApiShouldGetAndReturnThePreviewWithLocale() {
+  void givenAnExistingDocumentTheGetThumbnailApiShouldGetAndReturnTheThumbnailWithLocale() {
     // Given
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addNode(
@@ -105,33 +106,31 @@ class PreviewApiIT {
                 "application/vnd.ms-excel")
         );
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/1/",
-        MediaType.PDF
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1",
+            "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
     Assertions.assertThat(httpResponse.getHeaders())
         .extracting(header -> header.getKey().equals("content-type") ? header.getValue() : null)
-        .contains("application/pdf");
+        .contains("image/jpeg");
 
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"2", "?version=2"})
-  void givenTwoVersionsOfAnExistingDocumentTheGetPreviewApiShouldReturnThePdfOfTheLatestVersion(
+  void givenTwoVersionsOfAnExistingDocumentTheGetThumbnailApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
     // Given
@@ -150,14 +149,13 @@ class PreviewApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/2/",
-        MediaType.PDF
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/document/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/2",// + versionQueryParam,
+            "/preview/document/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail",// + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -166,11 +164,11 @@ class PreviewApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @Test
-  void givenTwoVersionsOfAnExistingDocumentTheGetPreviewApiShouldReturnThePdfOfTheFirstVersion() {
+  void givenTwoVersionsOfAnExistingDocumentTheGetThumbnailApiShouldReturnTheJpegOfTheFirstVersion() {
     // Given
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addNode(
@@ -187,14 +185,13 @@ class PreviewApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/1/",
-        MediaType.PDF
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/document/00000000-0000-0000-0000-000000000000/1",//?version=1",
+            "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail",//?version=1",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -203,12 +200,12 @@ class PreviewApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"3", "?version=3"})
-  void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnThePdfOfTheLatestVersion(
+  void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
     // Given
@@ -228,14 +225,13 @@ class PreviewApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/pdf/00000000-0000-0000-0000-000000000000/3/",
-        MediaType.PDF
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/pdf/00000000-0000-0000-0000-000000000000/3/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/3",// + versionQueryParam,
+            "/preview/pdf/00000000-0000-0000-0000-000000000000/3/5x5/thumbnail",// + versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -244,11 +240,11 @@ class PreviewApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @Test
-  void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnThePdfOfTheSecondVersion() {
+  void givenThreeVersionsOfAnExistingPdfTheGetThumbnailApiShouldReturnTheJpegOfTheSecondVersion() {
     // Given
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addNode(
@@ -266,14 +262,13 @@ class PreviewApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/pdf/00000000-0000-0000-0000-000000000000/2/",
-        MediaType.PDF
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/pdf/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/pdf/00000000-0000-0000-0000-000000000000/2/",//?version=2",
+            "/preview/pdf/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail",//?version=2",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -282,12 +277,12 @@ class PreviewApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"2", "?version=2"})
-  void givenTwoVersionsOfAnExistingPngImageTheGetPreviewApiShouldReturnThePngOfTheLatestVersion(
+  void givenTwoVersionsOfAnExistingPngImageTheGetThumbnailApiShouldReturnTheJpegOfTheLatestVersion(
       String versionQueryParam
   ) {
     // Given
@@ -306,14 +301,13 @@ class PreviewApiIT {
                 "image/png")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",
-        MediaType.PNG
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/image/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",// + versionQueryParam,
+            "/preview/image/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail", //+ versionQueryParam,
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
@@ -322,11 +316,11 @@ class PreviewApiIT {
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 
   @Test
-  void givenTwoVersionsOfAnExistingJpegImageTheGetPreviewApiShouldReturnTheJpegOfTheSecondVersion() {
+  void givenTwoVersionsOfAnExistingJpegImageTheGetThumbnailApiShouldReturnTheJpegOfTheFirstVersion() {
     // Given
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addNode(
@@ -343,22 +337,22 @@ class PreviewApiIT {
                 "image/jpeg")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
-        "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",
-        MediaType.JPEG
+    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
+        "/preview/image/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
     );
 
     final HttpRequest httpRequest =
         HttpRequest.of("GET",
-            "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0",//?version=2",
+            "/preview/image/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail", //?version=1",
             "ZM_AUTH_TOKEN=fake-token",
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse =
+        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/HttpRoutingHandlerTest.java
@@ -268,18 +268,18 @@ class HttpRoutingHandlerTest {
   // However I listed all the acceptable url even if the pattern accepts everything
   @ValueSource(
       strings = {
-        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10",
-        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/",
-        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1",
-        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/",
-        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1",
-        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/",
-        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail",
-        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/1/10x10/thumbnail/"
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/10x10",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/10x10/",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail",
+        "/preview/image/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail",
+        "/preview/pdf/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail",
+        "/preview/document/8caeef71-6f72-439c-847a-38e90efd0965/10x10/thumbnail/"
       })
   void givenAPreviewRequestHttpRoutingHandlerShouldAddTheRightHandlersInTheChannelPipeline(
       String uri) {


### PR DESCRIPTION
This technical improvement allows the client to call the preview and thumbnail APIs without being forced to specify the file version. It is useful when the client want the preview of the latest file version without knowing which is. Now the version of the file is optional and can be passed as a query param `?version=1` or `&version=1`

- Added PreviewIT to cover all the success cases
- Added ThumbnailIT to cover all the success cases
- Improved the PreviewController to automatically fetch the latest version of the file to preview if the node version is not passed

Refs: FILES-227