### PR TITLE
feat: allow domain admin to define the maximum size of uploadable items in files

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -861,6 +861,7 @@ public final class Files {
       private Config() {}
 
       public static final String COLLATION                             = "collation";
+      public static final String MAX_UPLOADABLE_SIZE_IN_MB             = "max-uploadable-size-in-mb";
       public static final String PAGE_TOKEN_SECRET_KEY                 = "page-token-secret-key";
       public static final String DEFAULT_PAGE_TOKEN_SECRET_KEY         = "carbonio-files-page-token-sign";
       public static final String FALLBACK_COLLATE                      = "en_US.utf8";

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -8,6 +8,7 @@ import com.zextras.carbonio.preview.PreviewClient;
 import com.zextras.carbonio.usermanagement.UserManagementClient;
 import com.zextras.filestore.api.Filestore;
 
+import java.util.Optional;
 import java.util.Properties;
 
 public interface FilesConfig {
@@ -24,4 +25,5 @@ public interface FilesConfig {
   String getMessageBrokerPassword();
   String getMessageBrokerUsername();
   String getPageTokenSecretKey();
+  Optional<Integer> getMaxUploadableFileSizeInMb();
 }

--- a/core/src/main/java/com/zextras/carbonio/files/config/impl/FilesConfigImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/impl/FilesConfigImpl.java
@@ -126,10 +126,14 @@ public class FilesConfigImpl implements FilesConfig {
   }
 
   public int getMaxNumberOfFileVersion() {
-    return Integer.parseInt(
-        ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
-            .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
-            .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
+    try {
+      return Integer.parseInt(
+          ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+              .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
+              .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
+    } catch (NumberFormatException e) {
+      return ServiceDiscover.Config.DEFAULT_MAX_VERSIONS;
+    }
   }
 
   public String getDatabaseUrl() {
@@ -181,6 +185,22 @@ public class FilesConfigImpl implements FilesConfig {
     return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
         .getConfig(ServiceDiscover.Config.PAGE_TOKEN_SECRET_KEY)
         .getOrElse(ServiceDiscover.Config.DEFAULT_PAGE_TOKEN_SECRET_KEY);
+  }
+
+  // Returns the maximum uploadable file size in MB or optional.empty if not found or malformed
+  public Optional<Integer> getMaxUploadableFileSizeInMb() {
+    return Optional.ofNullable(
+        ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+            .getConfig(ServiceDiscover.Config.MAX_UPLOADABLE_SIZE_IN_MB)
+            .getOrElse((String) null)
+    )
+    .flatMap(s -> {
+      try {
+        return Optional.of(Integer.parseInt(s));
+      } catch (NumberFormatException e) {
+        return Optional.empty();
+      }
+    });
   }
 
   private String generateHmacSha256Key() {

--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/FileSizeException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/FileSizeException.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class FileSizeException extends Exception {
+
+  public FileSizeException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
@@ -79,6 +79,10 @@ public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
       responseStatus = HttpResponseStatus.UNAUTHORIZED;
       payload = cause.getMessage();
     }
+    else if (cause instanceof FileSizeException) {
+      responseStatus = HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+      payload = HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE.toString();
+    }
     else {
       responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
       payload = HttpResponseStatus.INTERNAL_SERVER_ERROR.toString();

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -151,8 +151,8 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     // Check if the file size is within the limit (empty optional limit means no limit)
     double blobLengthInMB = blobLength / (1024.0 * 1024.0);
     Optional<Integer> maxFileSize = filesConfig.getMaxUploadableFileSizeInMb();
-    logger.warn("File size: {}", blobLengthInMB);
-    logger.warn("Max file size: {}", maxFileSize);
+    logger.info("File size: {}", blobLengthInMB);
+    logger.info("Max file size: {}", maxFileSize);
     if (maxFileSize.isPresent() && blobLengthInMB > maxFileSize.get()) {
       context.fireExceptionCaught(new FileSizeException("File size exceeds the maximum allowed of " + maxFileSize.get() + "MB"));
       return;
@@ -223,6 +223,8 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     // Check if the file size is within the limit (empty optional limit means no limit)
     double blobLengthInMB = blobLength / (1024.0 * 1024.0);
     Optional<Integer> maxFileSize = filesConfig.getMaxUploadableFileSizeInMb();
+    logger.info("File size: {}", blobLengthInMB);
+    logger.info("Max file size: {}", maxFileSize);
     if (maxFileSize.isPresent() && blobLengthInMB > maxFileSize.get()) {
       context.fireExceptionCaught(new FileSizeException("File size exceeds the maximum allowed of " + maxFileSize.get() + "MB"));
       return;

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -11,7 +11,9 @@ import com.google.inject.Inject;
 import com.zextras.carbonio.files.Files;
 import com.zextras.carbonio.files.Files.API.Endpoints;
 import com.zextras.carbonio.files.Files.API.Headers;
+import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.User;
+import com.zextras.carbonio.files.exceptions.FileSizeException;
 import com.zextras.carbonio.files.netty.utilities.BufferInputStream;
 import com.zextras.carbonio.files.netty.utilities.HttpResponseBuilder;
 import com.zextras.carbonio.files.netty.utilities.NettyBufferWriter;
@@ -51,12 +53,14 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
   private static final AttributeKey<BufferInputStream> fileStreamReader =
       AttributeKey.valueOf("FileStreamReader");
 
+  private final FilesConfig filesConfig;
   private final BlobService blobService;
   private final PrometheusService prometheusService;
 
   @Inject
-  public BlobController(BlobService blobService, PrometheusService prometheusService) {
+  public BlobController(FilesConfig filesConfig, BlobService blobService, PrometheusService prometheusService) {
     super(true);
+    this.filesConfig = filesConfig;
     this.blobService = blobService;
     this.prometheusService = prometheusService;
   }
@@ -143,6 +147,17 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
         Optional.ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_DESCRIPTION))
             .orElse("");
     long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+
+    // Check if the file size is within the limit (empty optional limit means no limit)
+    double blobLengthInMB = blobLength / (1024.0 * 1024.0);
+    Optional<Integer> maxFileSize = filesConfig.getMaxUploadableFileSizeInMb();
+    logger.warn("File size: {}", blobLengthInMB);
+    logger.warn("Max file size: {}", maxFileSize);
+    if (maxFileSize.isPresent() && blobLengthInMB > maxFileSize.get()) {
+      context.fireExceptionCaught(new FileSizeException("File size exceeds the maximum allowed of " + maxFileSize.get() + "MB"));
+      return;
+    }
+
     String encodedFilename = httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_FILENAME);
     String decodedFilename =
         encodedFilename == null || !Base64.isBase64(encodedFilename)
@@ -204,6 +219,14 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     boolean overwrite =
         Boolean.parseBoolean(httpRequest.headers().getAsString(Headers.UPLOAD_OVERWRITE_VERSION));
     long blobLength = Long.parseLong(httpRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+
+    // Check if the file size is within the limit (empty optional limit means no limit)
+    double blobLengthInMB = blobLength / (1024.0 * 1024.0);
+    Optional<Integer> maxFileSize = filesConfig.getMaxUploadableFileSizeInMb();
+    if (maxFileSize.isPresent() && blobLengthInMB > maxFileSize.get()) {
+      context.fireExceptionCaught(new FileSizeException("File size exceeds the maximum allowed of " + maxFileSize.get() + "MB"));
+      return;
+    }
 
     logger.debug("Uploading new version of node with id: {}, overwrite: {}", nodeId, overwrite);
 

--- a/core/src/test/java/com/zextras/carbonio/files/rest/controllers/BlobControllerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/rest/controllers/BlobControllerTest.java
@@ -8,6 +8,7 @@ import com.zextras.carbonio.files.dal.dao.User;
 import com.zextras.carbonio.files.rest.services.BlobService;
 import com.zextras.carbonio.files.rest.types.BlobResponse;
 import com.zextras.carbonio.files.tasks.PrometheusService;
+import com.zextras.carbonio.files.utilities.TestFilesConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -87,7 +88,7 @@ public class BlobControllerTest {
       ))
       .thenReturn(Optional.of(blobResponseMock));
 
-    BlobController blobController = new BlobController(blobServiceMock, prometheusServiceMock);
+    BlobController blobController = new BlobController(new TestFilesConfig(), blobServiceMock, prometheusServiceMock);
 
     // When
     blobController.channelRead0(contextMock, httpRequestMock);


### PR DESCRIPTION
- Add a consul KV that lets admin specify maximum size of uploadable file on Files (max-uploadable-size-in-mb)
- Returns payload-too-big HTTP code if trying to upload bigger file

Refs: FILES-877