### PR TITLE
feat: create internal upload file endpoint 

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Files.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Files.java
@@ -791,6 +791,7 @@ public final class Files {
         SERVICE + "health/ready/?$");
       public static final Pattern GRAPHQL             = Pattern.compile(SERVICE + "graphql/?$");
       public static final Pattern UPLOAD_FILE         = Pattern.compile(SERVICE + "upload/?$");
+      public static final Pattern UPLOAD_FILE_INTERNAL= Pattern.compile(SERVICE + "internal/upload/?$");
       public static final Pattern UPLOAD_FILE_VERSION = Pattern.compile(
         SERVICE + "upload-version/?$");
       public static final Pattern UPLOAD_FILE_TO      = Pattern.compile(SERVICE + "upload-to/?$");
@@ -835,6 +836,7 @@ public final class Files {
       public static final String UPLOAD_FILENAME          = "Filename";
       public static final String UPLOAD_DESCRIPTION       = "Description";
       public static final String UPLOAD_PARENT_ID         = "ParentId";
+      public static final String UPLOAD_ACCOUNT_ID        = "AccountId";
       public static final String UPLOAD_NODE_ID           = "NodeId";
       public static final String UPLOAD_OVERWRITE_VERSION = "OverwriteVersion";
       public static final String COOKIE_ZM_AUTH_TOKEN     = "ZM_AUTH_TOKEN";

--- a/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/HttpRoutingHandler.java
@@ -118,6 +118,15 @@ public class HttpRoutingHandler extends SimpleChannelInboundHandler<HttpRequest>
       return;
     }
 
+    // No auth for internal calls
+    if (Endpoints.UPLOAD_FILE_INTERNAL.matcher(request.uri()).matches()) {
+      context.pipeline()
+        .addLast("rest-handler", blobController)
+        .addLast("exceptions-handler", exceptionsHandler);
+      context.fireChannelRead(request);
+      return;
+    }
+
     if (Endpoints.DOWNLOAD_VIA_PUBLIC_LINK.matcher(request.uri()).matches()
       || Endpoints.PUBLIC_LINK.matcher(request.uri()).matches()
       || Endpoints.DOWNLOAD_PUBLIC_FILE.matcher(request.uri()).matches()) {

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -74,13 +74,16 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
 
         Matcher downloadMatcher = Endpoints.DOWNLOAD_FILE.matcher(uriRequest);
         Matcher uploadMatcher = Endpoints.UPLOAD_FILE.matcher(uriRequest);
+        Matcher uploadInternalMatcher = Endpoints.UPLOAD_FILE_INTERNAL.matcher(uriRequest);
         Matcher uploadVersionMatcher = Endpoints.UPLOAD_FILE_VERSION.matcher(uriRequest);
 
         if (downloadMatcher.find()) {
           download(context, httpRequest, downloadMatcher);
         }
 
-        if (uploadMatcher.find()) {
+        if (uploadInternalMatcher.find()) {
+          uploadFileInternal(context, httpRequest);
+        } else if (uploadMatcher.find()) {
           uploadFile(context, httpRequest);
         }
 
@@ -137,9 +140,17 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     context.channel().attr(fileStreamReader).set(new BufferInputStream(context.channel().config()));
   }
 
+  private void uploadFileInternal(ChannelHandlerContext context, HttpRequest httpRequest) {
+    String accountId = httpRequest.headers().get(Files.API.Headers.UPLOAD_ACCOUNT_ID);
+    doUploadFile(context, httpRequest, accountId);
+  }
+
   private void uploadFile(ChannelHandlerContext context, HttpRequest httpRequest) {
     User requester = (User) context.channel().attr(AttributeKey.valueOf("requester")).get();
+    doUploadFile(context, httpRequest, requester.getId());
+  }
 
+  private void doUploadFile(ChannelHandlerContext context, HttpRequest httpRequest, String requestedId) {
     String parentId =
         Optional.ofNullable(httpRequest.headers().getAsString(Files.API.Headers.UPLOAD_PARENT_ID))
             .orElse(Files.Db.RootId.LOCAL_ROOT);
@@ -178,7 +189,7 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
               String nodeId =
                   blobService
                       .uploadFile(
-                          requester,
+                          requestedId,
                           context.channel().attr(fileStreamReader).get(),
                           blobLength,
                           parentId,

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/BlobService.java
@@ -184,7 +184,7 @@ public class BlobService {
    *   <li>creates the shares for the new node if the destination folder has shares associated</li>
    * </ul>
    *
-   * @param requester         is a {@link User} making the upload request
+   * @param requesterId         is a {@link String} id of user making the upload request
    * @param bufferInputStream is a {@link BufferInputStream} of the blob to upload
    * @param blobLength        is a <code>long</code> representing the length of the blob
    * @param folderId          is a {@link String} representing the folder identifier where the node
@@ -199,7 +199,7 @@ public class BlobService {
    * @throws DependencyException if the {@link Filestore} failed to upload the blob
    */
   public Optional<String> uploadFile(
-    User requester,
+    String requesterId,
     BufferInputStream bufferInputStream,
     long blobLength,
     String folderId,
@@ -207,14 +207,14 @@ public class BlobService {
     String description
   ) {
     if (permissionsChecker
-      .getPermissions(folderId, requester.getId())
+      .getPermissions(folderId, requesterId)
       .has(SharePermission.READ_AND_WRITE)
     ) {
       // Here we are sure that the node exists otherwise the permission checker would be failed
       Node destinationFolder = nodeRepository.getNode(folderId).get();
       String nodeId = UUID.randomUUID().toString();
       String nodeOwner = folderId.equals(RootId.LOCAL_ROOT)
-        ? requester.getId()
+        ? requesterId
         : destinationFolder.getOwnerId();
 
       MediaType mediaType = mimeTypeUtils.detectMimeTypeFromFilename(
@@ -226,7 +226,7 @@ public class BlobService {
 
       Node newNode = nodeRepository.createNewNode(
         nodeId,
-        requester.getId(),
+        requesterId,
         nodeOwner,
         folderId,
         searchAlternativeName(nodeRepository, filename.trim(), folderId, nodeOwner),
@@ -241,7 +241,7 @@ public class BlobService {
       UploadResponse uploadResponse = Try.of(() ->
         fileStore
           .uploadPost(
-            FilesIdentifier.of(nodeId, 1, requester.getId()),
+            FilesIdentifier.of(nodeId, 1, requesterId),
             bufferInputStream,
             blobLength
           )
@@ -263,7 +263,7 @@ public class BlobService {
       try (Transaction t = ebeanDatabaseManager.getEbeanDatabase().beginTransaction()) {
         fileVersionRepository.createNewFileVersion(
           nodeId,
-          requester.getId(),
+          requesterId,
           1,
           mediaType.toString(),
           uploadResponse.getSize(),
@@ -295,7 +295,7 @@ public class BlobService {
 
     logger.warn(
       "User {} does not have the necessary permission to upload the node {} on the folder {}",
-      requester.getId(),
+      requesterId,
       filename,
       folderId
     );

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -108,6 +108,52 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
+  /internal/upload:
+    post:
+      description: Uploads a new node (internal call without token verification)
+      operationId: uploadNodeInternal
+      parameters:
+        - in: header
+          name: Filename
+          description: The fullname of the file to upload encoded in Base64
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+        - in: header
+          name: Description
+          description: The description of the file to upload
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            format: byte
+        - in: header
+          name: ParentId
+          description: The id of the folder where to upload the file, if omitted it will be uploaded on user Home
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            format: UUID
+        - in: header
+          name: AccountId
+          description: The id of the account where to upload the file
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+      requestBody:
+        $ref: '#/components/requestBodies/UploadNodeBody'
+      responses:
+        200:
+          $ref: '#/components/responses/200UploadNode'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
   /upload-version:
     post:
       description: Uploads a new version of an existing node

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -19,6 +19,12 @@
           }
         },
         {
+          "Action": "deny",
+          "HTTP": {
+            "PathPrefix": "/internal"
+          }
+        },
+        {
           "Action": "allow",
           "HTTP": {
             "PathPrefix": "/"


### PR DESCRIPTION
- Created /internal/upload to be called from other backend services to let them upload a file without a valid user's cookie

Refs: FILES-936