### PR TITLE
chore: carbonio.target should restart the services not covered by zmcontrol

### DIFF
--- a/package/carbonio-files-sidecar.service
+++ b/package/carbonio-files-sidecar.service
@@ -6,6 +6,7 @@
 Description=Carbonio Files sidecar proxy
 Documentation=https://docs.zextras.com/zextras-suite-documentation/latest/
 Requires=network-online.target
+After=network-online.target
 PartOf=carbonio.target
 
 [Service]

--- a/package/carbonio-files-sidecar.service
+++ b/package/carbonio-files-sidecar.service
@@ -6,7 +6,7 @@
 Description=Carbonio Files sidecar proxy
 Documentation=https://docs.zextras.com/zextras-suite-documentation/latest/
 Requires=network-online.target
-After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -24,4 +24,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target

--- a/package/carbonio-files.service
+++ b/package/carbonio-files.service
@@ -7,6 +7,7 @@ Description=Carbonio Files daemon
 Wants=network.target
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -20,4 +21,4 @@ TimeoutStopSec=120
 
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target

--- a/package/watches/carbonio-files-watches.service
+++ b/package/watches/carbonio-files-watches.service
@@ -7,6 +7,7 @@ Description=Carbonio Files Watches daemon
 Wants=network.target
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -20,4 +21,4 @@ TimeoutStopSec=120
 
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target


### PR DESCRIPTION
Refs: [IN-881](https://zextras.atlassian.net/browse/IN-881)

[IN-881]: https://zextras.atlassian.net/browse/IN-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ