### PR TITLE
Revert WantedBy for compatibility with older systems

### DIFF
--- a/package/carbonio-files-sidecar.service
+++ b/package/carbonio-files-sidecar.service
@@ -23,4 +23,4 @@ KillSignal=SIGINT
 LimitNOFILE=65536
 
 [Install]
-WantedBy=carbonio.target
+WantedBy=multi-user.target

--- a/package/carbonio-files.service
+++ b/package/carbonio-files.service
@@ -21,4 +21,4 @@ TimeoutStopSec=120
 
 
 [Install]
-WantedBy=carbonio.target
+WantedBy=multi-user.target

--- a/package/watches/carbonio-files-watches.service
+++ b/package/watches/carbonio-files-watches.service
@@ -21,4 +21,4 @@ TimeoutStopSec=120
 
 
 [Install]
-WantedBy=carbonio.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Some changes introduced by IN-881 (#177) are not compatible with older systems.
Centos8 and ubuntu22 still use init.d, therefore some units were not activated at startup.

Solution: revert the `WantedBy=` to `multi-user.target` where modified.

Refs: IN-919 IN-881