### PR TITLE
chore(deps): update carbonio-message-broker-sdk to 0.1.3, carbonio-preview-sdk to 1.0.5  and user management SDK versions to 0.5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 
 # Reuse license
 LICENSES
+
+# VS Code
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Dependencies -->
     <assertj.version>3.27.3</assertj.version>
     <caffeine.version>3.2.0</caffeine.version>
-    <carbonio-message-broker-sdk.version>0.1.2</carbonio-message-broker-sdk.version>
+    <carbonio-message-broker-sdk.version>0.1.3</carbonio-message-broker-sdk.version>
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-sdk.version>0.5.5</carbonio-user-management-sdk.version>
-    <carbonio-preview-sdk.version>1.0.4</carbonio-preview-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.7</carbonio-user-management-sdk.version>
+    <carbonio-preview-sdk.version>1.0.5</carbonio-preview-sdk.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-validator.version>1.9.0</commons-validator.version>
     <ebean.version>13.26.1</ebean.version>


### PR DESCRIPTION
update carbonio-message-broker-sdk to 0.1.3, carbonio-preview-sdk to 1.0.5  and user management SDK versions to 0.5.7

ref: CO-2394