### PR TITLE
CO-2474: normalize hikari configuration 

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Constants.java
@@ -144,6 +144,9 @@ public final class Constants {
 
       public static final int MAX_POOL_SIZE = 10;
       public static final int MIN_IDLE_CONNECTIONS = 2;
+      public static final int IDLE_TIMEOUT = 10_000;
+      public static final int LEAK_DETECTION_THRESHOLD = 5_000;
+      public static final int MAX_LIFETIME = 600_000;
 
       private Hikari() {
       }
@@ -1175,6 +1178,9 @@ public final class Constants {
         public static final String DB_PASSWORD = "db-password";
         public static final String HIKARI_MAX_POOL_SIZE = "hikari-max-pool-size";
         public static final String HIKARI_MIN_IDLE_CONNECTIONS = "hikari-min-idle-connections";
+        public static final String HIKARI_IDLE_TIMEOUT = "hikari-idle-timeout";
+        public static final String HIKARI_LEAK_DETECTION_THRESHOLD = "hikari-leak-detection-threshold";
+        public static final String HIKARI_MAX_LIFETIME = "hikari-max-lifetime";
       }
     }
   }

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -231,8 +231,8 @@ public class FilesConfig {
     int maxPoolSize = getHikariMaxPoolSize();
     return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
         .getConfig(ServiceDiscover.Config.Key.HIKARI_MIN_IDLE_CONNECTIONS)
-        .map(minIdleConnections ->
-            Math.min(Integer.parseInt(minIdleConnections), maxPoolSize))
+        .map(Integer::parseInt)
+        .map(minIdleConnections -> Math.min(minIdleConnections, maxPoolSize))
         .getOrElse(Constants.Config.Hikari.MIN_IDLE_CONNECTIONS);
   }
 

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -236,6 +236,27 @@ public class FilesConfig {
         .getOrElse(Constants.Config.Hikari.MIN_IDLE_CONNECTIONS);
   }
 
+  public int getHikariIdleTimeout() {
+    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(ServiceDiscover.Config.Key.HIKARI_IDLE_TIMEOUT)
+      .map(Integer::parseInt)
+      .getOrElse(Constants.Config.Hikari.IDLE_TIMEOUT);
+  }
+
+  public int getHikariLeakDetectionThreshold() {
+    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(ServiceDiscover.Config.Key.HIKARI_LEAK_DETECTION_THRESHOLD)
+      .map(Integer::parseInt)
+      .getOrElse(Constants.Config.Hikari.LEAK_DETECTION_THRESHOLD);
+  }
+
+  public int getHikariMaxLifetime() {
+    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+      .getConfig(ServiceDiscover.Config.Key.HIKARI_MAX_LIFETIME)
+      .map(Integer::parseInt)
+      .getOrElse(Constants.Config.Hikari.MAX_LIFETIME);
+  }
+
   // ================================================================================
   // Application Configuration Methods (non-connectivity related)
   // ================================================================================

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -99,20 +99,32 @@ public class FilesModule extends AbstractModule {
 
     int maximumPoolSize = config.getHikariMaxPoolSize();
     int minimumIdleConnections = config.getHikariMinIdleConnections();
+    int idleTimeout = config.getHikariIdleTimeout();
+    int leakDetectionThreshold = config.getHikariLeakDetectionThreshold();
+    int maxLifetime = config.getHikariMaxLifetime();
 
     logger.info("Hikari: maximum pool size: {}", maximumPoolSize);
     logger.info("Hikari: minimum idle connections: {}", minimumIdleConnections);
+    logger.info("Hikari: idle timeout: {}", idleTimeout);
+    logger.info("Hikari: leak detection threshold: {}", leakDetectionThreshold);
+    logger.info("Hikari: max lifetime: {}", maxLifetime);
 
     Properties dataSourceProperties = new Properties();
     dataSourceProperties.setProperty("sslmode", "disable");
+    dataSourceProperties.setProperty("ApplicationName", "files");
 
     HikariDataSource dataSource = new HikariDataSource();
     dataSource.setJdbcUrl(jdbcPostgresUrl);
+    dataSource.setPoolName("files-db-pool");
     dataSource.setUsername(config.getDatabaseUsername());
     dataSource.setPassword(config.getDatabasePassword());
     dataSource.setMaximumPoolSize(maximumPoolSize);
     dataSource.setMinimumIdle(minimumIdleConnections);
+    dataSource.setIdleTimeout(idleTimeout);
+    dataSource.setLeakDetectionThreshold(leakDetectionThreshold);
+    dataSource.setMaxLifetime(maxLifetime);
     dataSource.setDataSourceProperties(dataSourceProperties);
+
     return dataSource;
   }
 


### PR DESCRIPTION
Each Carbonio component uses a different HikariCP configuration, which could lead to inconsistent behavior, especially under pressure.

This PR adds the missing properties and a few small refactoring touches.