### PR TITLE
chore: [CO-2850] add service discover properties

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/files/Constants.java
@@ -1149,6 +1149,10 @@ public final class Constants {
 
     public static final String SERVICE_NAME = "carbonio-files";
     public static final String MESSAGE_BROKER_SERVICE_NAME = "carbonio-message-broker";
+    public static final String HOST_PROPERTY = "carbonio.service-discover.host";
+    public static final String PORT_PROPERTY = "carbonio.service-discover.port";
+    public static final String DEFAULT_HOST = "localhost";
+    public static final Integer DEFAULT_PORT = 8500;
 
     public static final class Config {
 

--- a/core/src/main/java/com/zextras/carbonio/files/clients/ServiceDiscoverHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/ServiceDiscoverHttpClient.java
@@ -36,10 +36,6 @@ public class ServiceDiscoverHttpClient {
     return new ServiceDiscoverHttpClient(url + "/v1/kv/" + serviceName + "/");
   }
 
-  public static ServiceDiscoverHttpClient defaultURL(String serviceName) {
-    return new ServiceDiscoverHttpClient("http://localhost:8500/v1/kv/" + serviceName + "/");
-  }
-
   public Try<String> getConfig(String configKey) {
     try (CloseableHttpClient httpClient = HttpClients.createMinimal()) {
       HttpGet request = new HttpGet(serviceDiscoverURL + configKey);

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesConfig.java
@@ -71,7 +71,7 @@ public class FilesConfig {
     try {
       logger.debug("Creating secret key");
       // Create secret key if not exists
-      ServiceDiscoverHttpClient client = ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME);
+      ServiceDiscoverHttpClient client = getServiceDiscoverFilesClient();
       final String configKey = ServiceDiscover.Config.PAGE_TOKEN_SECRET_KEY;
 
       // Get existing key
@@ -108,19 +108,19 @@ public class FilesConfig {
   }
 
   public String getDatabaseName() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.Key.DB_NAME)
         .getOrElse(Constants.Config.Database.DEFAULT_NAME);
   }
 
   public String getDatabaseUsername() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.Key.DB_USERNAME)
         .getOrElse(Constants.Config.Database.DEFAULT_USERNAME);
   }
 
   public String getDatabasePassword() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.Key.DB_PASSWORD)
         .getOrElse("");
   }
@@ -209,19 +209,19 @@ public class FilesConfig {
   }
 
   public String getMessageBrokerPassword() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.MESSAGE_BROKER_SERVICE_NAME)
+    return getServiceDiscoverBrokerClient()
         .getConfig("default/password")
         .getOrElse(Constants.MessageBroker.Config.DEFAULT_PASSWORD);
   }
 
   public String getMessageBrokerUsername() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.MESSAGE_BROKER_SERVICE_NAME)
+    return getServiceDiscoverBrokerClient()
         .getConfig("default/username")
         .getOrElse(Constants.MessageBroker.Config.DEFAULT_USERNAME);
   }
 
   public int getHikariMaxPoolSize() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.Key.HIKARI_MAX_POOL_SIZE)
         .map(Integer::parseInt)
         .getOrElse(Constants.Config.Hikari.MAX_POOL_SIZE);
@@ -229,7 +229,7 @@ public class FilesConfig {
 
   public int getHikariMinIdleConnections() {
     int maxPoolSize = getHikariMaxPoolSize();
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.Key.HIKARI_MIN_IDLE_CONNECTIONS)
         .map(Integer::parseInt)
         .map(minIdleConnections -> Math.min(minIdleConnections, maxPoolSize))
@@ -237,24 +237,31 @@ public class FilesConfig {
   }
 
   public int getHikariIdleTimeout() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
       .getConfig(ServiceDiscover.Config.Key.HIKARI_IDLE_TIMEOUT)
       .map(Integer::parseInt)
       .getOrElse(Constants.Config.Hikari.IDLE_TIMEOUT);
   }
 
   public int getHikariLeakDetectionThreshold() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
       .getConfig(ServiceDiscover.Config.Key.HIKARI_LEAK_DETECTION_THRESHOLD)
       .map(Integer::parseInt)
       .getOrElse(Constants.Config.Hikari.LEAK_DETECTION_THRESHOLD);
   }
 
   public int getHikariMaxLifetime() {
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
       .getConfig(ServiceDiscover.Config.Key.HIKARI_MAX_LIFETIME)
       .map(Integer::parseInt)
       .getOrElse(Constants.Config.Hikari.MAX_LIFETIME);
+  }
+
+  public String getServiceDiscoverEndpoint() {
+    return "http://" + properties.getProperty(
+        ServiceDiscover.HOST_PROPERTY,
+        ServiceDiscover.DEFAULT_HOST) + ":" + properties.getProperty(ServiceDiscover.PORT_PROPERTY,
+        String.valueOf(ServiceDiscover.DEFAULT_PORT));
   }
 
   // ================================================================================
@@ -264,7 +271,7 @@ public class FilesConfig {
   public int getMaxNumberOfFileVersion() {
     try {
       return Integer.parseInt(
-          ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+          getServiceDiscoverFilesClient()
               .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
               .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
     } catch (NumberFormatException e) {
@@ -272,10 +279,18 @@ public class FilesConfig {
     }
   }
 
+  private ServiceDiscoverHttpClient getServiceDiscoverFilesClient() {
+    return ServiceDiscoverHttpClient.atURL(this.getServiceDiscoverEndpoint(), ServiceDiscover.SERVICE_NAME);
+  }
+
+  private ServiceDiscoverHttpClient getServiceDiscoverBrokerClient() {
+    return ServiceDiscoverHttpClient.atURL(this.getServiceDiscoverEndpoint(), ServiceDiscover.MESSAGE_BROKER_SERVICE_NAME);
+  }
+
   public String getPageTokenSecretKey() {
     // The default secret key is obviously useless since it's public, but since the security implications are minimal
     // (only used for page token and already protected against attacks) I prefer to let the application run.
-    return ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+    return getServiceDiscoverFilesClient()
         .getConfig(ServiceDiscover.Config.PAGE_TOKEN_SECRET_KEY)
         .getOrElse(ServiceDiscover.Config.DEFAULT_PAGE_TOKEN_SECRET_KEY);
   }
@@ -293,7 +308,7 @@ public class FilesConfig {
   // Returns the maximum uploadable file size in MB or optional.empty if not found or malformed
   public Optional<Integer> getMaxUploadableFileSizeInMb() {
     return Optional.ofNullable(
-        ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+        getServiceDiscoverFilesClient()
             .getConfig(ServiceDiscover.Config.MAX_UPLOADABLE_SIZE_IN_MB)
             .getOrElse((String) null)
     )
@@ -316,7 +331,7 @@ public class FilesConfig {
 
   public Optional<Integer> getMaxDownloadableFileSizeInMb() {
     return Optional.ofNullable(
-        ServiceDiscoverHttpClient.defaultURL(ServiceDiscover.SERVICE_NAME)
+        getServiceDiscoverFilesClient()
             .getConfig(ServiceDiscover.Config.MAX_DOWNLOADABLE_SIZE_IN_MB)
             .getOrElse((String) null)
     )

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/ConfigDataFetcher.java
@@ -10,6 +10,7 @@ import com.zextras.carbonio.files.Constants.ServiceDiscover;
 import com.zextras.carbonio.files.Constants.ServiceDiscover.Config;
 import com.zextras.carbonio.files.Constants.GraphQL;
 import com.zextras.carbonio.files.clients.ServiceDiscoverHttpClient;
+import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.graphql.GraphQLProvider;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 public class ConfigDataFetcher {
 
   private final Map<String, String> configMap;
+  private final FilesConfig filesConfig;
   private       String              maxKeepVersionsValue;
 
   /**
@@ -38,7 +40,8 @@ public class ConfigDataFetcher {
    * configuration</p>
    */
   @Inject
-  public ConfigDataFetcher() {
+  public ConfigDataFetcher(FilesConfig filesConfig) {
+    this.filesConfig = filesConfig;
     configMap = new HashMap<>();
     configMap.put(Config.MAX_VERSIONS, String.valueOf(Config.DEFAULT_MAX_VERSIONS));
     configMap.put(Config.MAX_DOWNLOADABLE_SIZE_IN_MB, null);
@@ -62,7 +65,7 @@ public class ConfigDataFetcher {
       List<DataFetcherResult<Map<String, String>>> result = new ArrayList<>();
       configMap.forEach((key, value) -> {
         String currValue = ServiceDiscoverHttpClient
-          .defaultURL(ServiceDiscover.SERVICE_NAME)
+            .atURL(filesConfig.getServiceDiscoverEndpoint(), ServiceDiscover.SERVICE_NAME)
           .getConfig(key)
           .getOrElse(value);
 

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/datafetchers/NodeDataFetcher.java
@@ -137,7 +137,7 @@ public class NodeDataFetcher {
     this.fileStore = fileStore;
 
     this.maxNumberOfVersions = Integer.parseInt(ServiceDiscoverHttpClient
-      .defaultURL(ServiceDiscover.SERVICE_NAME)
+      .atURL(filesConfig.getServiceDiscoverEndpoint(), ServiceDiscover.SERVICE_NAME)
       .getConfig(ServiceDiscover.Config.MAX_VERSIONS)
       .getOrElse(String.valueOf(ServiceDiscover.Config.DEFAULT_MAX_VERSIONS)));
 

--- a/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/config/FilesConfigTest.java
@@ -4,6 +4,8 @@
 
 package com.zextras.carbonio.files.config;
 
+import com.zextras.carbonio.files.Constants.ServiceDiscover;
+import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -12,19 +14,23 @@ import org.junit.jupiter.api.Test;
 class FilesConfigTest {
 
   @BeforeEach
-  void setUp() {}
+  void setUp() {
+    System.clearProperty(ServiceDiscover.HOST_PROPERTY);
+    System.clearProperty(ServiceDiscover.PORT_PROPERTY);
+  }
 
   // This test will pass when the config.ini is removed or when the FilesConfig
   // uses also the System.getEnv() to retrieve the configuration values.
   @Disabled("Disabled until a refactor on the FilesConfig is done")
   @Test
   void
-      givenAMailboxUrlAndAPortSetInPropertiesTheGetMailboxUrlShouldReturnTheFullMailboxUrlString() {
+      givenAMailboxUrlAndAPortSetInPropertiesTheGetMailboxUrlShouldReturnTheFullMailboxUrlString()
+			throws IOException {
     // Given
     System.setProperty("carbonio.mailbox.url", "1.2.3.4");
     System.setProperty("carbonio.mailbox.port", "9999");
 
-    FilesConfig filesConfig = new FilesConfig();
+    FilesConfig filesConfig = getLoadedConfig();
 
     // When
     String mailboxUrl = filesConfig.getMailboxHost();
@@ -34,14 +40,40 @@ class FilesConfigTest {
   }
 
   @Test
-  void givenEmptyPropertiesTheGetMailboxUrlShouldReturnTheDefaultFullMailboxUrlString() {
+  void givenEmptyPropertiesTheGetMailboxUrlShouldReturnTheDefaultFullMailboxUrlString()
+			throws IOException {
     // Given
-    FilesConfig filesConfig = new FilesConfig();
+    FilesConfig filesConfig = getLoadedConfig();
 
     // When
     String mailboxUrl = "http://" + filesConfig.getMailboxHost() + ":" + filesConfig.getMailboxPort() + "/";
 
     // Then
     Assertions.assertThat(mailboxUrl).isEqualTo("http://127.78.0.2:20004/");
+  }
+
+  @Test
+  void givenEmptyPropertiesTheServiceDiscoverEndpointShouldReturnTheDefault() throws IOException {
+    FilesConfig filesConfig = getLoadedConfig();
+
+    Assertions.assertThat(filesConfig.getServiceDiscoverEndpoint()).isEqualTo("http://localhost:8500");
+  }
+  @Test
+  void givenServiceDiscoverPropertiesTheServiceDiscoverEndpointShouldReturnProvidedValues()
+			throws IOException {
+    System.setProperty(ServiceDiscover.HOST_PROPERTY, "service-discover-endpoint");
+    System.setProperty(ServiceDiscover.PORT_PROPERTY, "19000");
+    final FilesConfig filesConfig = getLoadedConfig();
+
+    Assertions.assertThat(filesConfig.getServiceDiscoverEndpoint()).isEqualTo("http://service-discover-endpoint:19000");
+  }
+
+  private static FilesConfig getLoadedConfig() throws IOException {
+    // It would be best to avoid side effect caused by loadConfig, however
+    // files depends on ServiceDiscover at startup of config, unlike Tasks,
+    // so for now I kept the loadConfig() method
+    FilesConfig filesConfig = new FilesConfig();
+    filesConfig.loadConfig();
+    return filesConfig;
   }
 }

--- a/docker/minimal/carbonio-files/Dockerfile
+++ b/docker/minimal/carbonio-files/Dockerfile
@@ -6,42 +6,6 @@ RUN mkdir -p /etc/carbonio/files
 
 COPY ../../boot/target/carbonio-files-*-jar-with-dependencies.jar .
 
-CMD sh -c 'echo "\n\
-# Files Service\n\
-carbonio.files.host=${CARBONIO_FILES_HOST}\n\
-carbonio.files.port=${CARBONIO_FILES_PORT}\n\
-\n\
-# Docs Connector Service\n\
-carbonio.docs-connector.host=${CARBONIO_DOCS_CONNECTOR_HOST}\n\
-carbonio.docs-connector.port=${CARBONIO_DOCS_CONNECTOR_PORT}\n\
-\n\
-# Mailbox Service\n\
-carbonio.mailbox.host=${CARBONIO_MAILBOX_HOST}\n\
-carbonio.mailbox.port=${CARBONIO_MAILBOX_PORT}\n\
-\n\
-# Message Broker Service\n\
-carbonio.message-broker.host=${CARBONIO_MESSAGE_BROKER_HOST}\n\
-carbonio.message-broker.port=${CARBONIO_MESSAGE_BROKER_PORT}\n\
-\n\
-# PostgreSQL Database Service\n\
-carbonio.postgresql.host=${CARBONIO_POSTGRESQL_HOST}\n\
-carbonio.postgresql.port=${CARBONIO_POSTGRESQL_PORT}\n\
-\n\
-# Preview Service\n\
-carbonio.preview.host=${CARBONIO_PREVIEW_HOST}\n\
-carbonio.preview.port=${CARBONIO_PREVIEW_PORT}\n\
-\n\
-# Storages Service\n\
-carbonio.storages.host=${CARBONIO_STORAGES_HOST}\n\
-carbonio.storages.port=${CARBONIO_STORAGES_PORT}\n\
-\n\
-# User Management Service\n\
-carbonio.user-management.host=${CARBONIO_USER_MANAGEMENT_HOST}\n\
-carbonio.user-management.port=${CARBONIO_USER_MANAGEMENT_PORT}" > /etc/carbonio/files/config.properties && \
-JAR=$(ls carbonio-files-*-jar-with-dependencies.jar | head -n 1) && \
-java -Djava.net.preferIPv4Stack=true \
-     -Xms4096m \
-     -Xmx4096m \
-     -DFILES_LOG_LEVEL=info \
-     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5050 \
-     -jar "$JAR"'
+COPY docker/minimal/carbonio-files/entrypoint.sh entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/minimal/carbonio-files/entrypoint.sh
+++ b/docker/minimal/carbonio-files/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+echo "" > /etc/carbonio/files/config.properties
+
+addEnvToProperties() {
+  if [ -n "$2" ];
+  then echo "$1=$2" >> /etc/carbonio/files/config.properties;
+  else echo "$1 is not set. Skipping it.";
+  fi
+}
+
+addEnvToProperties "carbonio.files.host" "${CARBONIO_FILES_HOST}"
+addEnvToProperties "carbonio.files.port" "${CARBONIO_FILES_PORT}"
+
+# Docs Connector Service
+addEnvToProperties "carbonio.docs-connector.host" "${CARBONIO_DOCS_CONNECTOR_HOST}"
+addEnvToProperties "carbonio.docs-connector.port" "${CARBONIO_DOCS_CONNECTOR_PORT}"
+
+# Mailbox Service
+addEnvToProperties "carbonio.mailbox.host" "${CARBONIO_MAILBOX_HOST}"
+addEnvToProperties "carbonio.mailbox.port" "${CARBONIO_MAILBOX_PORT}"
+
+# Message Broker Service
+addEnvToProperties "carbonio.message-broker.host" "${CARBONIO_MESSAGE_BROKER_HOST}"
+addEnvToProperties "carbonio.message-broker.port" "${CARBONIO_MESSAGE_BROKER_PORT}"
+
+# PostgreSQL Database Service
+addEnvToProperties "carbonio.postgresql.host" "${CARBONIO_POSTGRESQL_HOST}"
+addEnvToProperties "carbonio.postgresql.port" "${CARBONIO_POSTGRESQL_PORT}"
+
+# Preview Service
+addEnvToProperties "carbonio.preview.host" "${CARBONIO_PREVIEW_HOST}"
+addEnvToProperties "carbonio.preview.port" "${CARBONIO_PREVIEW_PORT}"
+
+# Storages Service
+addEnvToProperties "carbonio.storages.host" "${CARBONIO_STORAGES_HOST}"
+addEnvToProperties "carbonio.storages.port" "${CARBONIO_STORAGES_PORT}"
+
+# Service Discover
+addEnvToProperties "carbonio.service-discover.host" "${CARBONIO_SERVICE_DISCOVER_HOST}"
+addEnvToProperties "carbonio.service-discover.port" "${CARBONIO_SERVICE_DISCOVER_PORT}"
+
+# User Management Service
+addEnvToProperties "carbonio.user-management.host" "${CARBONIO_USER_MANAGEMENT_HOST}"
+addEnvToProperties "carbonio.user-management.port" "${CARBONIO_USER_MANAGEMENT_PORT}"
+
+
+JAR=$(ls carbonio-files-*-jar-with-dependencies.jar | head -n 1)
+
+exec java -Djava.net.preferIPv4Stack=true \
+          -Xms4096m \
+          -Xmx4096m \
+          -DFILES_LOG_LEVEL=info \
+          -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5050 \
+          -jar "$JAR"


### PR DESCRIPTION
Changes are similar to: https://github.com/zextras/carbonio-tasks/pull/63
With the exceptions that FilesConfig depends on ServiceDiscover at startup, so I kept the loadConfig() method.
It must noted though that having a loadConfig could cause creating a configuration without loading properties.
I experienced this first in the test, and only after calling "loadConfig" the test was passing. 
I think it is not ideal, but maybe it can be improved in another PR.

Tested the container against a custom service discover endpoint.