### PR TITLE
build: upgrade JDK from 17 to 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
                     if (env.TAG_NAME) {
                         profile = '-P prod'
                     }
-                    container('jdk-17') {
+                    container('jdk-21') {
                         sh """
                             mvn ${MVN_OPTS} clean package ${profile}
                             cp -a boot/target/carbonio-files-*-jar-with-dependencies.jar package/carbonio-files.jar
@@ -97,7 +97,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh "mvn ${MVN_OPTS} verify -P run-unit-tests"
                 }
             }
@@ -108,7 +108,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh "mvn ${MVN_OPTS} verify -P run-integration-tests"
                 }
             }
@@ -119,7 +119,7 @@ pipeline {
                 expression { params.SKIP_CHECKS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh "mvn ${MVN_OPTS} verify -P generate-jacoco-full-report"
                     recordCoverage(
                         tools: [[parser: 'JACOCO']],
@@ -140,7 +140,7 @@ pipeline {
                }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
                         sh "mvn ${MVN_OPTS} sonar:sonar"
                     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -251,9 +251,12 @@ SPDX-License-Identifier: AGPL-3.0-only
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surfire.version}</version>
+        <version>${maven-surefire.version}</version>
         <configuration>
-          <skipTests>${skip.unit.tests}</skipTests>
+            <skipTests>${skip.unit.tests}</skipTests>
+            <argLine>
+                -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            </argLine>
         </configuration>
       </plugin>
 

--- a/docker/minimal/carbonio-files/Dockerfile
+++ b/docker/minimal/carbonio-files/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,10 @@ SPDX-License-Identifier: AGPL-3.0-only
     <mock-server.version>5.15.0</mock-server.version>
     <netty.version>4.1.113.Final</netty.version>
     <postgresql.version>42.7.4</postgresql.version>
-    <testcontainers.version>1.20.1</testcontainers.version>
+    <testcontainers.version>2.0.2</testcontainers.version>
+    <testcontainers.junit.jupiter.version>1.21.3</testcontainers.junit.jupiter.version>
+    <testcontainers.postgresql.version>1.21.3</testcontainers.postgresql.version>
+    <testcontainers.rabbitmq.version>1.21.3</testcontainers.rabbitmq.version>
 
     <!-- Plugins -->
     <maven-assembly.version>3.6.0</maven-assembly.version>
@@ -273,21 +276,21 @@ SPDX-License-Identifier: AGPL-3.0-only
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>${testcontainers.version}</version>
+        <version>${testcontainers.junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
-        <version>${testcontainers.version}</version>
+        <version>${testcontainers.postgresql.version}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>rabbitmq</artifactId>
-        <version>${testcontainers.version}</version>
+        <version>${testcontainers.rabbitmq.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>
     <micrometer.version>1.11.12</micrometer.version>
-    <mockito.version>5.13.0</mockito.version>
+    <mockito.version>5.20.0</mockito.version>
     <mock-server.version>5.15.0</mock-server.version>
     <netty.version>4.1.113.Final</netty.version>
     <postgresql.version>42.7.4</postgresql.version>
@@ -64,13 +64,13 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven-compiler.version>3.13.0</maven-compiler.version>
     <maven-failsafe.version>3.5.0</maven-failsafe.version>
     <maven-jacoco.version>0.8.12</maven-jacoco.version>
-    <maven-surfire.version>3.3.1</maven-surfire.version>
+    <maven-surefire.version>3.5.4</maven-surefire.version>
     <tiles-maven.version>2.40</tiles-maven.version>
 
     <!-- Other properties -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <java-compiler.version>17</java-compiler.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <java-compiler.version>21</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.coverage.jacoco.xmlReportPaths>
       ../core/target/jacoco-full-report/jacoco.xml


### PR DESCRIPTION
- Upgrade mockito version from 5.13.0 to 5.20.0
- Upgrade maven-surefire-plugin version from 3.3.1 to 3.5.4
- Update Java version to 21 in pom.xml files
- Configure Mockito agent for JDK 21 compatibility
- Update maven-surefire-plugin configuration

ref: CO-2825