### PR TITLE
It optimization

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/dal/impl/DatabaseManagerFlyway.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/impl/DatabaseManagerFlyway.java
@@ -97,5 +97,9 @@ public class DatabaseManagerFlyway implements DatabaseManager {
       logger.info("Shutting down database connection...");
       ebeanDatabase.shutdown(true, true);
     }
+    if (dataSource != null && !dataSource.isClosed()) {
+      logger.info("Closing HikariCP data source...");
+      dataSource.close();
+    }
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -4,8 +4,12 @@
 
 package com.zextras.carbonio.files;
 
-import com.google.inject.*;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
 import com.zextras.carbonio.files.Constants.Config.Database;
 import com.zextras.carbonio.files.Constants.ServiceDiscover.Config.Key;
@@ -16,44 +20,25 @@ import com.zextras.carbonio.files.dal.DatabaseManager;
 import com.zextras.carbonio.files.dal.dao.ebean.Node;
 import com.zextras.carbonio.files.netty.HttpRoutingHandler;
 import com.zextras.carbonio.files.utilities.MockFilesConfig;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserByEmailRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.GetUserMyselfRequest;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserInfoResponse;
+import com.zextras.carbonio.files.utilities.MockUserManagementService;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
-import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceImplBase;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
-import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfResponse;
-import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
-import com.zextras.storages.internal.pojo.Query;
-import com.zextras.storages.internal.pojo.StoragesBulkDeleteResponse;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
-import io.grpc.Status;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.stub.StreamObserver;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpMethod;
-
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
-import org.mockserver.model.JsonBody;
-import org.mockserver.model.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -299,14 +284,6 @@ public class Simulator implements AutoCloseable {
     return this;
   }
 
-  /**
-   * Registers a token-to-userId mapping so that subsequent gRPC {@code getUserMyself} calls
-   * with the given token will return a valid user with the "carbonioFeatureFilesEnabled" feature.
-   */
-  private void registerUser(String cookie, String userId) {
-    mockUmService.registerToken(cookie, userId);
-  }
-
   private Simulator startStorages() {
     startMockServer();
 
@@ -435,15 +412,11 @@ public class Simulator implements AutoCloseable {
     return injector;
   }
 
-  public MockServerClient getServiceDiscoverMock() {
-    return serviceDiscoverMock;
-  }
-
   /**
    * Returns the mock UM gRPC service, allowing tests to register additional users
    * (e.g. for getUserById lookups in transfer ownership scenarios).
    */
-  public MockUserManagementService getUserManagementService() {
+  public MockUserManagementService getUserManagementMock() {
     return mockUmService;
   }
 
@@ -473,11 +446,11 @@ public class Simulator implements AutoCloseable {
     return storagesMock;
   }
 
-  public MockServerClient getPreviewServiceMock() {
+  public MockServerClient getPreviewMock() {
     return previewServiceMock;
   }
 
-  public MockServerClient getDocsConnectorServiceMock() {
+  public MockServerClient getDocsConnectorMock() {
     return docsConnectorServiceMock;
   }
 
@@ -516,40 +489,6 @@ public class Simulator implements AutoCloseable {
     }
   }
 
-  public void getBlob(String nodeId, int version) {
-    storagesMock
-        .when(
-            HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download")
-                .withQueryStringParameter(Parameter.param("node", nodeId))
-                .withQueryStringParameter(Parameter.param("version", String.valueOf(version)))
-                .withQueryStringParameter(Parameter.param("type", "files")))
-        .respond(
-            HttpResponse.response()
-                .withStatusCode(200)
-                .withBody((nodeId + version).getBytes(StandardCharsets.UTF_8)));
-  }
-
-  public void bulkDelete(List<String> ids) {
-    final StoragesBulkDeleteResponse response = new StoragesBulkDeleteResponse();
-    Query queryList = new Query();
-    for (String id : ids) {
-      queryList.setNode(id);
-      queryList.setType("files");
-    }
-    response.setIds(List.of(queryList));
-    storagesMock
-        .when(
-            HttpRequest.request()
-                .withMethod(HttpMethod.POST.toString())
-                .withPath("/bulk-delete"))
-        .respond(
-            HttpResponse.response()
-                .withStatusCode(200)
-                .withBody(JsonBody.json(response)));
-  }
-
   /**
    * Guice module that overrides the ManagedChannel and BlockingStub bindings
    * to use the gRPC InProcess transport for testing.
@@ -572,117 +511,6 @@ public class Simulator implements AutoCloseable {
     @Singleton
     public UserManagementServiceBlockingStub provideUserManagementStub() {
       return UserManagementServiceGrpc.newBlockingStub(channel);
-    }
-  }
-
-  /**
-   * In-memory gRPC service implementation for UserManagement. Supports
-   * {@code getUserMyself} (token lookup), {@code getUserById} (userId lookup),
-   * and {@code getUserByEmail} (email lookup).
-   */
-  public static class MockUserManagementService extends UserManagementServiceImplBase {
-
-    private final Map<String, UserMyselfResponse> tokenToMyself = new ConcurrentHashMap<>();
-    private final Map<String, UserInfoProto> userIdToInfo = new ConcurrentHashMap<>();
-
-    /**
-     * Registers a minimal token-to-userId mapping. A full {@link UserMyselfResponse} is built
-     * with default values for email, name, domain, status, locale, and the
-     * "carbonioFeatureFilesEnabled" feature enabled.
-     */
-    void registerToken(String token, String userId) {
-      if (!tokenToMyself.containsKey(token)) {
-        UserInfoProto info = UserInfoProto.newBuilder()
-            .setUserId(userId)
-            .setEmail("fake-email@example.com")
-            .setFullName("Fake User")
-            .setDomain("example.com")
-            .setStatus("active")
-            .setType(UserTypeProto.INTERNAL)
-            .build();
-        UserMyselfProto myself = UserMyselfProto.newBuilder()
-            .setInfo(info)
-            .setLocale("en")
-            .addFeatures("carbonioFeatureFilesEnabled")
-            .build();
-        tokenToMyself.put(token, UserMyselfResponse.newBuilder().setUser(myself).build());
-        userIdToInfo.put(userId, info);
-      }
-    }
-
-    /**
-     * Removes a userId from the {@code getUserById} lookup map so that subsequent
-     * {@code getUserById} calls for this user will return NOT_FOUND.
-     */
-    public void unregisterUserById(String userId) {
-      userIdToInfo.remove(userId);
-    }
-
-    /**
-     * Registers a user profile for lookup by userId via {@code getUserById}.
-     * This is used by integration tests that need to look up users other than
-     * the requester (e.g. transfer ownership target user).
-     */
-    public void registerUserById(String userId, String email, String fullName,
-        String domain, String status) {
-      UserInfoProto info = UserInfoProto.newBuilder()
-          .setUserId(userId)
-          .setEmail(email)
-          .setFullName(fullName)
-          .setDomain(domain)
-          .setStatus(status)
-          .setType(UserTypeProto.INTERNAL)
-          .build();
-      userIdToInfo.put(userId, info);
-    }
-
-    void clearAll() {
-      tokenToMyself.clear();
-      userIdToInfo.clear();
-    }
-
-    @Override
-    public void getUserMyself(GetUserMyselfRequest request,
-        StreamObserver<UserMyselfResponse> responseObserver) {
-      String token = request.getToken();
-      UserMyselfResponse response = tokenToMyself.get(token);
-      if (response != null) {
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
-      } else {
-        responseObserver.onError(
-            Status.UNAUTHENTICATED.withDescription("Invalid token").asRuntimeException());
-      }
-    }
-
-    @Override
-    public void getUserById(GetUserByIdRequest request,
-        StreamObserver<UserInfoResponse> responseObserver) {
-      String userId = request.getUserId();
-      UserInfoProto info = userIdToInfo.get(userId);
-      if (info != null) {
-        responseObserver.onNext(UserInfoResponse.newBuilder().setUser(info).build());
-        responseObserver.onCompleted();
-      } else {
-        responseObserver.onError(
-            Status.NOT_FOUND.withDescription("User not found").asRuntimeException());
-      }
-    }
-
-    @Override
-    public void getUserByEmail(GetUserByEmailRequest request,
-        StreamObserver<UserInfoResponse> responseObserver) {
-      String email = request.getUserEmail();
-      // Search by email across registered users
-      for (UserInfoProto info : userIdToInfo.values()) {
-        if (info.getEmail().equals(email)) {
-          responseObserver.onNext(UserInfoResponse.newBuilder().setUser(info).build());
-          responseObserver.onCompleted();
-          return;
-        }
-      }
-      responseObserver.onError(
-          Status.NOT_FOUND.withDescription("User not found by email").asRuntimeException());
     }
   }
 
@@ -716,10 +544,7 @@ public class Simulator implements AutoCloseable {
 
     public SimulatorBuilder withUserManagement(Map<String, String> users) {
       simulator.startUserManagement();
-      users.forEach(
-          (cookie, userId) -> {
-            simulator.registerUser(cookie, userId);
-          });
+      users.forEach((cookie, userId) -> simulator.mockUmService.registerToken(cookie, userId));
       return this;
     }
 

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -29,12 +29,6 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpMethod;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
@@ -45,11 +39,19 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.shaded.com.trilead.ssh2.crypto.Base64;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class Simulator implements AutoCloseable {
 
   private static final Logger logger = LoggerFactory.getLogger(Simulator.class);
   private static final String UM_INPROCESS_BASE_NAME = "um-files-test";
-  private static final AtomicInteger UM_COUNTER = new AtomicInteger();
+  private static final AtomicInteger UM_COUNTER =
+      new AtomicInteger();
   private String umInProcessName;
 
   // Singleton containers: started once per JVM, reused across all test classes.
@@ -416,7 +418,7 @@ public class Simulator implements AutoCloseable {
    * Returns the mock UM gRPC service, allowing tests to register additional users
    * (e.g. for getUserById lookups in transfer ownership scenarios).
    */
-  public MockUserManagementService getUserManagementMock() {
+  public MockUserManagementService getUserManagementService() {
     return mockUmService;
   }
 
@@ -544,7 +546,10 @@ public class Simulator implements AutoCloseable {
 
     public SimulatorBuilder withUserManagement(Map<String, String> users) {
       simulator.startUserManagement();
-      users.forEach((cookie, userId) -> simulator.mockUmService.registerToken(cookie, userId));
+      users.forEach(
+          (cookie, userId) -> {
+            simulator.mockUmService.registerToken(cookie, userId);
+          });
       return this;
     }
 

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -40,9 +40,13 @@ import io.netty.handler.codec.http.HttpMethod;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
@@ -53,21 +57,33 @@ import org.mockserver.model.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.com.trilead.ssh2.crypto.Base64;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.shaded.com.trilead.ssh2.crypto.Base64;
 
-@Testcontainers
 public class Simulator implements AutoCloseable {
 
   private static final Logger logger = LoggerFactory.getLogger(Simulator.class);
-  private static final String UM_INPROCESS_NAME = "um-files-test";
+  private static final String UM_INPROCESS_BASE_NAME = "um-files-test";
+  private static final AtomicInteger UM_COUNTER = new AtomicInteger();
+  private String umInProcessName;
+
+  // Singleton containers: started once per JVM, reused across all test classes.
+  // Testcontainers' Ryuk will clean them up when the JVM exits.
+  private static final PostgreSQLContainer<?> SHARED_POSTGRES =
+      new PostgreSQLContainer<>("postgres:16.6");
+  private static final RabbitMQContainer SHARED_RABBITMQ =
+      new RabbitMQContainer("rabbitmq:3.13.4");
+
+  // Singleton MockServer: started once per JVM on fixed ports, reused across all test classes.
+  // Unlike the container fields (static final, never null, safe to lock on directly),
+  // sharedMockServer starts null — so we need a separate lock object to synchronize on.
+  private static volatile ClientAndServer sharedMockServer;
+  private static final Object MOCK_SERVER_LOCK = new Object();
+
+  private final Set<String> managedProperties = new HashSet<>();
 
   private Injector injector;
-  private PostgreSQLContainer<?> postgreSQLContainer;
-  private RabbitMQContainer messageBrokerContainer;
-  private DatabaseManager databaseManagerFlyway;
-  private ClientAndServer clientAndServer;
+  private DatabaseManager databaseManager;
   private MockServerClient serviceDiscoverMock;
   private MockServerClient storagesMock;
   private MockServerClient previewServiceMock;
@@ -82,12 +98,20 @@ public class Simulator implements AutoCloseable {
   // Private methods
   //
 
+  private void setManagedProperty(String key, String value) {
+    System.setProperty(key, value);
+    managedProperties.add(key);
+  }
+
   private Simulator createInjector() {
     // Always create the InProcess channel so Guice can inject ManagedChannel and BlockingStub.
     // The InProcess server is only started when withUserManagement() is called; without it,
     // the channel will be in TRANSIENT_FAILURE state (simulating UM being unreachable).
     if (umChannel == null) {
-      umChannel = InProcessChannelBuilder.forName(UM_INPROCESS_NAME).directExecutor().build();
+      if (umInProcessName == null) {
+        umInProcessName = UM_INPROCESS_BASE_NAME + "-" + UM_COUNTER.incrementAndGet();
+      }
+      umChannel = InProcessChannelBuilder.forName(umInProcessName).directExecutor().build();
     }
     if (mockUmService == null) {
       mockUmService = new MockUserManagementService();
@@ -113,36 +137,35 @@ public class Simulator implements AutoCloseable {
   }
 
   private Simulator startDatabase() {
-    if (postgreSQLContainer == null) {
-      postgreSQLContainer = new PostgreSQLContainer<>("postgres:16.6");
+    synchronized (SHARED_POSTGRES) {
+      if (!SHARED_POSTGRES.isRunning()) {
+        SHARED_POSTGRES.start();
+      }
     }
-
-    postgreSQLContainer.start();
-
     // Set the System.properties for the dynamic database url and port
-    System.setProperty(Database.HOST_PROPERTY, postgreSQLContainer.getHost());
-    System.setProperty(Database.PORT_PROPERTY, String.valueOf(postgreSQLContainer.getFirstMappedPort()));
+    setManagedProperty(Database.HOST_PROPERTY, SHARED_POSTGRES.getHost());
+    setManagedProperty(Database.PORT_PROPERTY, String.valueOf(SHARED_POSTGRES.getFirstMappedPort()));
 
     return this;
   }
 
   private Simulator startMessageBroker() {
-    if (messageBrokerContainer == null) {
-      messageBrokerContainer = new RabbitMQContainer("rabbitmq:3.13.4");
+    synchronized (SHARED_RABBITMQ) {
+      if (!SHARED_RABBITMQ.isRunning()) {
+        SHARED_RABBITMQ.start();
+      }
     }
-    messageBrokerContainer.start();
-
     // Set the System.properties for the dynamic rabbit url and port
-    System.setProperty(Constants.Config.MessageBroker.HOST_PROPERTY, messageBrokerContainer.getHost());
-    System.setProperty(Constants.Config.MessageBroker.PORT_PROPERTY, String.valueOf(messageBrokerContainer.getFirstMappedPort()));
+    setManagedProperty(Constants.Config.MessageBroker.HOST_PROPERTY, SHARED_RABBITMQ.getHost());
+    setManagedProperty(Constants.Config.MessageBroker.PORT_PROPERTY, String.valueOf(SHARED_RABBITMQ.getFirstMappedPort()));
 
     return this;
   }
 
   private Simulator startEbeanDatabaseManager() {
-    if (databaseManagerFlyway == null) {
-      databaseManagerFlyway = injector.getInstance(DatabaseManager.class);
-      databaseManagerFlyway.initialize();
+    if (databaseManager == null) {
+      databaseManager = injector.getInstance(DatabaseManager.class);
+      databaseManager.initialize();
     }
 
     return this;
@@ -159,10 +182,10 @@ public class Simulator implements AutoCloseable {
     String adminUsername;
     String adminPassword;
 
-    if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
-      dbName = postgreSQLContainer.getDatabaseName();
-      dbUsername = postgreSQLContainer.getUsername();
-      dbPassword = postgreSQLContainer.getPassword();
+    if (SHARED_POSTGRES.isRunning()) {
+      dbName = SHARED_POSTGRES.getDatabaseName();
+      dbUsername = SHARED_POSTGRES.getUsername();
+      dbPassword = SHARED_POSTGRES.getPassword();
     } else {
       logger.warn(
           "The ServiceDiscover will be mocked without a database container. The database "
@@ -173,9 +196,9 @@ public class Simulator implements AutoCloseable {
       dbPassword = Key.DB_PASSWORD;
     }
 
-    if (messageBrokerContainer != null && messageBrokerContainer.isRunning()) {
-      adminUsername = messageBrokerContainer.getAdminUsername();
-      adminPassword = messageBrokerContainer.getAdminPassword();
+    if (SHARED_RABBITMQ.isRunning()) {
+      adminUsername = SHARED_RABBITMQ.getAdminUsername();
+      adminPassword = SHARED_RABBITMQ.getAdminPassword();
     } else {
       logger.warn("The ServiceDiscover will be mocked without a rabbitMQ container");
 
@@ -259,11 +282,12 @@ public class Simulator implements AutoCloseable {
 
   private Simulator startUserManagement() {
     mockUmService = new MockUserManagementService();
-    umChannel = InProcessChannelBuilder.forName(UM_INPROCESS_NAME).directExecutor().build();
+    umInProcessName = UM_INPROCESS_BASE_NAME + "-" + UM_COUNTER.incrementAndGet();
+    umChannel = InProcessChannelBuilder.forName(umInProcessName).directExecutor().build();
 
     try {
       umGrpcServer =
-          InProcessServerBuilder.forName(UM_INPROCESS_NAME)
+          InProcessServerBuilder.forName(umInProcessName)
               .directExecutor()
               .addService(mockUmService)
               .build()
@@ -290,7 +314,7 @@ public class Simulator implements AutoCloseable {
         new MockServerClient(
             "localhost",
             Constants.Config.Storages.DEFAULT_PORT);
-    System.setProperty(Constants.Config.Storages.HOST_PROPERTY, "localhost");
+    setManagedProperty(Constants.Config.Storages.HOST_PROPERTY, "localhost");
 
     return this;
   }
@@ -302,7 +326,7 @@ public class Simulator implements AutoCloseable {
       "localhost",
       Constants.Config.Preview.DEFAULT_PORT
     );
-    System.setProperty(Constants.Config.Preview.HOST_PROPERTY, "localhost");
+    setManagedProperty(Constants.Config.Preview.HOST_PROPERTY, "localhost");
 
     return this;
   }
@@ -314,44 +338,35 @@ public class Simulator implements AutoCloseable {
       "localhost",
       Constants.Config.DocsConnector.DEFAULT_PORT
     );
-    System.setProperty(Constants.Config.DocsConnector.HOST_PROPERTY, "localhost");
+    setManagedProperty(Constants.Config.DocsConnector.HOST_PROPERTY, "localhost");
 
     return this;
   }
 
   private void startMockServer() {
-    if (clientAndServer == null) {
-      final int storagesPort = Constants.Config.Storages.DEFAULT_PORT;
-      final int previewServicePort = Constants.Config.Preview.DEFAULT_PORT;
-      final int docsConnectorServicePort = Constants.Config.DocsConnector.DEFAULT_PORT;
+    synchronized (MOCK_SERVER_LOCK) {
+      if (sharedMockServer == null || !sharedMockServer.isRunning()) {
+        final int storagesPort = Constants.Config.Storages.DEFAULT_PORT;
+        final int previewServicePort = Constants.Config.Preview.DEFAULT_PORT;
+        final int docsConnectorServicePort = Constants.Config.DocsConnector.DEFAULT_PORT;
 
-      clientAndServer =
-          ClientAndServer.startClientAndServer(8500, storagesPort, previewServicePort, docsConnectorServicePort);
-    }
-  }
-
-  private void stopDatabase() {
-    if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
-      postgreSQLContainer.stop();
-    }
-  }
-
-  private void stopRabbitMq() {
-    if (messageBrokerContainer != null && messageBrokerContainer.isRunning()) {
-      messageBrokerContainer.stop();
+        sharedMockServer =
+            ClientAndServer.startClientAndServer(8500, storagesPort, previewServicePort, docsConnectorServicePort);
+      }
     }
   }
 
   private void stopEbeanDatabaseManager() {
-    if (databaseManagerFlyway != null) {
-      databaseManagerFlyway.stop();
+    if (databaseManager != null) {
+      databaseManager.stop();
     }
   }
 
-  private void stopServiceDiscover() {
+  private void resetServiceDiscoverMock() {
     if (serviceDiscoverMock != null && serviceDiscoverMock.hasStarted()) {
-      serviceDiscoverMock.stop();
+      serviceDiscoverMock.reset();
     }
+    serviceDiscoverMock = null;
   }
 
   private void stopUserManagement() {
@@ -365,22 +380,25 @@ public class Simulator implements AutoCloseable {
     }
   }
 
-  private void stopStoragesService() {
-    if (previewServiceMock != null && previewServiceMock.hasStarted()) {
-      previewServiceMock.stop();
+  private void resetStoragesMock() {
+    if (storagesMock != null && storagesMock.hasStarted()) {
+      storagesMock.reset();
     }
+    storagesMock = null;
   }
 
-  private void stopPreviewService() {
+  private void resetPreviewMock() {
     if (previewServiceMock != null && previewServiceMock.hasStarted()) {
-      previewServiceMock.stop();
+      previewServiceMock.reset();
     }
+    previewServiceMock = null;
   }
 
-  private void stopDocsConnectorService() {
+  private void resetDocsConnectorMock() {
     if (docsConnectorServiceMock != null && docsConnectorServiceMock.hasStarted()) {
-      docsConnectorServiceMock.stop();
+      docsConnectorServiceMock.reset();
     }
+    docsConnectorServiceMock = null;
   }
 
   //
@@ -394,14 +412,18 @@ public class Simulator implements AutoCloseable {
   }
 
   public void stopAll() {
-    stopDocsConnectorService();
-    stopPreviewService();
-    stopStoragesService();
+    // Container lifecycle (PostgreSQL, RabbitMQ) and the shared MockServer are JVM-scoped
+    // singletons managed by Testcontainers' Ryuk — they are NOT stopped here.
+    // This method only tears down per-Simulator resources: Ebean/HikariCP, gRPC UM server,
+    // and MockServer expectations (reset, not stopped).
+    resetDocsConnectorMock();
+    resetPreviewMock();
+    resetStoragesMock();
     stopUserManagement();
-    stopServiceDiscover();
-    stopDatabase();
+    resetServiceDiscoverMock();
     stopEbeanDatabaseManager();
-    stopRabbitMq();
+    // Clear all System properties set by start methods to prevent leaking config to the next Simulator.
+    managedProperties.forEach(System::clearProperty);
   }
 
   @Override
@@ -434,7 +456,7 @@ public class Simulator implements AutoCloseable {
     if (umGrpcServer != null) {
       umGrpcServer.shutdownNow();
       try {
-        umGrpcServer.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+        umGrpcServer.awaitTermination(5, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
@@ -463,16 +485,35 @@ public class Simulator implements AutoCloseable {
     return new EmbeddedChannel(injector.getInstance(HttpRoutingHandler.class));
   }
 
-  public RabbitMQContainer getMessageBrokerContainer() {
-    return messageBrokerContainer;
-  }
-
   public void resetDatabase() {
-    databaseManagerFlyway.getEbeanDatabase().find(Node.class).delete();
+    var db = databaseManager.getEbeanDatabase();
+    // Delete test nodes but preserve ROOT nodes (LOCAL_ROOT, TRASH_ROOT) which have null owner_id.
+    db.find(Node.class)
+            .where()
+            .isNotNull("mOwnerId")
+            .delete();
+    // Wipe notification and snapshot tables (not FK-linked to node, so not cascade-deleted above).
+    db.sqlUpdate("TRUNCATE user_notification_interest, notification, snapshot_node, snapshot_user, user_notifications_info, tombstone CASCADE").execute();
   }
 
   public void clearFileVersionCache() {
     injector.getInstance(CacheHandler.class).getFileVersionCache().flushAll();
+  }
+
+  public void reinitializeMocks() {
+    if (serviceDiscoverMock != null && serviceDiscoverMock.hasStarted()) {
+      serviceDiscoverMock.reset();
+      startServiceDiscover();
+    }
+    if (storagesMock != null && storagesMock.hasStarted()) {
+      storagesMock.reset();
+    }
+    if (previewServiceMock != null && previewServiceMock.hasStarted()) {
+      previewServiceMock.reset();
+    }
+    if (docsConnectorServiceMock != null && docsConnectorServiceMock.hasStarted()) {
+      docsConnectorServiceMock.reset();
+    }
   }
 
   public void getBlob(String nodeId, int version) {

--- a/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/CreatePublicLinkApiIT.java
@@ -21,9 +21,6 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
@@ -94,17 +91,6 @@ class CreatePublicLinkApiIT {
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addShare(nodeId, targetUserId, permission);
-  }
-
-  void createLink(String nodeId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addLink(
-            UUID.randomUUID().toString(),
-            nodeId,
-            RandomStringUtils.secure().nextAlphanumeric(32),
-            Optional.of(5L),
-            Optional.of("super-description"),
-            Optional.empty());
   }
 
   @Test
@@ -404,7 +390,8 @@ class CreatePublicLinkApiIT {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    IntStream.range(0, 50).forEach(i -> createLink("00000000-0000-0000-0000-000000000000"));
+    DatabasePopulator.aNodePopulator(simulator.getInjector())
+        .addLinks("00000000-0000-0000-0000-000000000000", 50);
 
     final String bodyPayload =
         GraphqlCommandBuilder.aMutationBuilder("createLink")

--- a/core/src/test/java/com/zextras/carbonio/files/api/DeleteAllNodesAndBlobsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DeleteAllNodesAndBlobsApiIT.java
@@ -15,6 +15,7 @@ import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,6 +31,7 @@ import java.util.Optional;
 class DeleteAllNodesAndBlobsApiIT {
 
   static Simulator simulator;
+  static StoragesMockHelper storagesMockHelper;
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
@@ -53,6 +55,7 @@ class DeleteAllNodesAndBlobsApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
   }
 
   @AfterEach
@@ -123,7 +126,7 @@ class DeleteAllNodesAndBlobsApiIT {
             .withWantedResultFormat("")
             .build();
 
-    simulator.bulkDelete(List.of(new String[]{"00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003"}));
+    storagesMockHelper.bulkDelete(List.of(new String[]{"00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003"}));
 
     List<Map.Entry<String, String>> headers = List.of(Map.entry("Internal", ""));
     final HttpRequest httpRequest =

--- a/core/src/test/java/com/zextras/carbonio/files/api/DeleteAllNodesAndBlobsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DeleteAllNodesAndBlobsApiIT.java
@@ -20,7 +20,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,8 +34,8 @@ class DeleteAllNodesAndBlobsApiIT {
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -58,7 +58,7 @@ class DeleteAllNodesAndBlobsApiIT {
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DownloadByPublicLinkApiIT.java
@@ -14,6 +14,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
@@ -33,6 +34,7 @@ import org.mockserver.verify.VerificationTimes;
 public class DownloadByPublicLinkApiIT {
 
   static Simulator simulator;
+  static StoragesMockHelper storagesMockHelper;
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
@@ -53,6 +55,7 @@ public class DownloadByPublicLinkApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
   }
 
   @AfterEach
@@ -102,7 +105,7 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty(),
             Optional.empty());
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
@@ -163,7 +166,7 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty(),
             Optional.of("test"));
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
@@ -372,7 +375,7 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty())
         .addNodeToTrash("00000000-0000-0000-0000-000000000000", "LOCAL_ROOT");
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);

--- a/core/src/test/java/com/zextras/carbonio/files/api/DownloadMultipleApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/DownloadMultipleApiIT.java
@@ -17,6 +17,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
@@ -36,6 +37,7 @@ import java.util.Map;
 public class DownloadMultipleApiIT {
 
   static Simulator simulator;
+  static StoragesMockHelper storagesMockHelper;
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
@@ -57,6 +59,7 @@ public class DownloadMultipleApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
   }
 
   @AfterEach
@@ -128,9 +131,9 @@ public class DownloadMultipleApiIT {
                 "image/jpeg"));
 
     // Mock storages responses for each file
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
-    simulator.getBlob(fileId3, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId3, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2, fileId3);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -238,8 +241,8 @@ public class DownloadMultipleApiIT {
                 "text/plain"));
 
     // Mock storages responses
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, subFolderId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -311,8 +314,8 @@ public class DownloadMultipleApiIT {
                 null));
 
     // Mock storages responses
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(Constants.Db.RootId.LOCAL_ROOT);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -522,7 +525,7 @@ public class DownloadMultipleApiIT {
         .addShare(fileId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", ACL.SharePermission.READ_ONLY);
 
     // Mock storages response
-    simulator.getBlob(fileId, 1);
+    storagesMockHelper.getBlob(fileId, 1);
 
     List<String> nodeIds = List.of(fileId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);

--- a/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
@@ -72,7 +72,7 @@ class HealthApiIT {
           .respond(HttpResponse.response().withStatusCode(200));
 
       // Preview
-      MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+      MockServerClient previewServiceMock = simulator.getPreviewMock();
 
       previewServiceMock
           .when(
@@ -82,7 +82,7 @@ class HealthApiIT {
           .respond(HttpResponse.response().withStatusCode(200));
 
       // DocsConnector
-      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorServiceMock();
+      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorMock();
 
       docsConnectorServiceMock
           .when(
@@ -173,7 +173,7 @@ class HealthApiIT {
           .respond(HttpResponse.response().withStatusCode(200));
 
       // Preview
-      MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+      MockServerClient previewServiceMock = simulator.getPreviewMock();
 
       previewServiceMock
           .when(
@@ -183,7 +183,7 @@ class HealthApiIT {
           .respond(HttpResponse.response().withStatusCode(200));
 
       // DocsConnector
-      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorServiceMock();
+      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorMock();
 
       docsConnectorServiceMock
           .when(

--- a/core/src/test/java/com/zextras/carbonio/files/api/IntrospectionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/IntrospectionApiIT.java
@@ -16,7 +16,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,8 +29,8 @@ class IntrospectionApiIT {
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -52,7 +52,6 @@ class IntrospectionApiIT {
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/MoveNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/MoveNodesApiIT.java
@@ -32,8 +32,8 @@ class MoveNodesApiIT {
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,7 +55,6 @@ class MoveNodesApiIT {
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/PreviewApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PreviewApiIT.java
@@ -75,7 +75,7 @@ class PreviewApiIT {
       request.withQueryStringParameter(new Parameter("lang_tag", "en"));
     }
 
-    return simulator.getPreviewServiceMock()
+    return simulator.getPreviewMock()
         .when(request)
         .respond(org.mockserver.model.HttpResponse.response()
             .withStatusCode(200)
@@ -83,7 +83,7 @@ class PreviewApiIT {
   }
 
   static void verifyAndClearExpectationInPreviewMockService(String expectationId) {
-    MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+    MockServerClient previewServiceMock = simulator.getPreviewMock();
     previewServiceMock.verify(expectationId).clear(expectationId);
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadApiIT.java
@@ -14,6 +14,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
@@ -33,6 +34,7 @@ import org.mockserver.verify.VerificationTimes;
 public class PublicDownloadApiIT {
 
   static Simulator simulator;
+  static StoragesMockHelper storagesMockHelper;
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
@@ -53,6 +55,7 @@ public class PublicDownloadApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
   }
 
   @AfterEach
@@ -96,7 +99,7 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.empty());
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
@@ -299,7 +302,7 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.empty());
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
@@ -371,7 +374,7 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.of("accesscode"));
 
-    simulator.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab&access_code=accesscode";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);

--- a/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadMultipleApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/PublicDownloadMultipleApiIT.java
@@ -16,6 +16,7 @@ import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
@@ -36,6 +37,7 @@ import org.mockserver.verify.VerificationTimes;
 public class PublicDownloadMultipleApiIT {
 
   static Simulator simulator;
+  static StoragesMockHelper storagesMockHelper;
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
@@ -57,6 +59,7 @@ public class PublicDownloadMultipleApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
   }
 
   @AfterEach
@@ -137,9 +140,9 @@ public class PublicDownloadMultipleApiIT {
             Optional.of("Public folder link"),
             Optional.empty());
 
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
-    simulator.getBlob(fileId3, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId3, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2, fileId3);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -238,8 +241,8 @@ public class PublicDownloadMultipleApiIT {
             Optional.of("Protected link"),
             Optional.of(accessCode));
 
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -406,8 +409,8 @@ public class PublicDownloadMultipleApiIT {
         .addLink(
             linkId, parentFolderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
 
-    simulator.getBlob(fileId1, 1);
-    simulator.getBlob(fileId2, 1);
+    storagesMockHelper.getBlob(fileId1, 1);
+    storagesMockHelper.getBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, subFolderId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);

--- a/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/ThumbnailApiIT.java
@@ -76,7 +76,7 @@ class ThumbnailApiIT {
       request.withQueryStringParameter(new Parameter("lang_tag", "en"));
     }
 
-    return simulator.getPreviewServiceMock()
+    return simulator.getPreviewMock()
         .when(request)
         .respond(org.mockserver.model.HttpResponse.response()
             .withStatusCode(200)
@@ -84,7 +84,7 @@ class ThumbnailApiIT {
   }
 
   static void verifyAndClearExpectationInThumbnailMockService(String expectationId) {
-    MockServerClient previewServiceMock = simulator.getPreviewServiceMock();
+    MockServerClient previewServiceMock = simulator.getPreviewMock();
     previewServiceMock.verify(expectationId).clear(expectationId);
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedAndRemovedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedAndRemovedNodeNotificationMoveApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationCopyApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationCopyApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class AddedNodeNotificationCopyApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class AddedNodeNotificationCopyApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationCreateApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationCreateApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class AddedNodeNotificationCreateApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class AddedNodeNotificationCreateApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/AddedNodeNotificationMoveApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class AddedNodeNotificationMoveApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class AddedNodeNotificationMoveApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/NewShareNotificationApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/NewShareNotificationApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class NewShareNotificationApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class NewShareNotificationApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/RemovedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/RemovedNodeNotificationMoveApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class RemovedNodeNotificationMoveApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class RemovedNodeNotificationMoveApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/notifications/RemovedNodeNotificationTrashApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/notifications/RemovedNodeNotificationTrashApiIT.java
@@ -22,7 +22,7 @@ import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,9 +34,10 @@ class RemovedNodeNotificationTrashApiIT {
   static NodeRepository nodeRepository;
   static FileVersionRepository fileVersionRepository;
   static LinkRepository linkRepository;
+  static MockFilesConfig mockConfig;
 
-  @BeforeEach
-  void init() {
+  @BeforeAll
+  static void init() {
     simulator =
         SimulatorBuilder.aSimulator()
             .init()
@@ -55,12 +56,14 @@ class RemovedNodeNotificationTrashApiIT {
     nodeRepository = injector.getInstance(NodeRepository.class);
     fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     linkRepository = injector.getInstance(LinkRepository.class);
+    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
   }
 
   @AfterEach
   void cleanUp() {
     simulator.resetDatabase();
-    simulator.stopAll();
+    simulator.reinitializeMocks();
+    mockConfig.setAreNotificationsEnabled(true);
   }
 
   @AfterAll

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/FindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/FindNodesApiIT.java
@@ -25,7 +25,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 class FindNodesApiIT {
 
@@ -56,351 +58,379 @@ class FindNodesApiIT {
     linkRepository = injector.getInstance(LinkRepository.class);
   }
 
-  @AfterEach
-  void cleanUp() {
-    simulator.resetDatabase();
-  }
-
   @AfterAll
   static void cleanUpAll() {
     simulator.stopAll();
   }
 
-  void createNodesDifferentNames() {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000001",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "folderA"))
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000002",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "folderB"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000001",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaa.txt"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000002",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "bbb.txt"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000003",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "ccc.txt"));
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class SortByNameTests {
+
+    @BeforeAll
+    void setUp() {
+      DatabasePopulator.aNodePopulator(simulator.getInjector())
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000001",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "folderA"))
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000002",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "folderB"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000001",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "aaa.txt"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000002",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "bbb.txt"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000003",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "ccc.txt"));
+    }
+
+    @AfterAll
+    void tearDown() {
+      simulator.resetDatabase();
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortNameAscShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_ASC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folderA");
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folderB");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "bbb");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortNameDescShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_DESC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folderA");
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folderB");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "bbb");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortLastUpdateAscShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folderA");
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folderB");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "bbb");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortLastUpdateDescShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folderA");
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folderB");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "bbb");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void givenFilesOnRootSearchByKeywordsShouldReturnCorrectNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_ASC)
+              .withInteger("limit", 5)
+              .withListOfStrings("keywords", new String[] {"a"})
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(2);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folderA");
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+    }
   }
 
-  void createNodesDifferentSizes() { // files with same name, to really be sure it's the size that's
-    // being compared
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 0L))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1L))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000003",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                2L));
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class SortBySizeTests {
+
+    @BeforeAll
+    void setUp() {
+      DatabasePopulator.aNodePopulator(simulator.getInjector())
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 0L))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1L))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000003",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  2L));
+    }
+
+    @AfterAll
+    void tearDown() {
+      simulator.resetDatabase();
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortSizeAscShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folder");
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folder");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "fake");
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "fake");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "fake");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortSizeDescShouldReturnCorrectlySortedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withInteger("limit", 5)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(5);
+      Assertions.assertThat(nodes.get(3))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "folder");
+      Assertions.assertThat(nodes.get(4))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folder");
+      Assertions.assertThat(nodes.get(2))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "fake");
+      Assertions.assertThat(nodes.get(1))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "fake");
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "fake");
+    }
   }
 
-  @Test
-  void givenFilesOnRootSearchWithSortNameAscShouldReturnCorrectlySortedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
+  @Nested
+  class FilterTests {
 
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+    @AfterEach
+    void cleanUp() {
+      simulator.resetDatabase();
+    }
 
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders always on top
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folderA");
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folderB");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "bbb");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortNameDescShouldReturnCorrectlySortedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_DESC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders always on top
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folderA");
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folderB");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "bbb");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortSizeAscShouldReturnCorrectlySortedNodes() {
-    // Given
-    createNodesDifferentSizes();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_ASC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders have size 0 and are on top
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folder");
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folder");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "fake");
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "fake");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "fake");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortSizeDescShouldReturnCorrectlySortedNodes() {
-    // Given
-    createNodesDifferentSizes();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_DESC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders have size 0 so they are always on bottom with size desc sorting
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folder");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folder");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "fake");
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "fake");
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "fake");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortLastUpdateAscShouldReturnCorrectlySortedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_ASC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders always on top
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folderA");
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folderB");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "bbb");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortLastUpdateDescShouldReturnCorrectlySortedNodes() { // recents
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_DESC)
-            .withInteger("limit", 5)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(5);
-    // folders always on top
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folderA");
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folderB");
-    Assertions.assertThat(nodes.get(4))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-    Assertions.assertThat(nodes.get(3))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "bbb");
-    Assertions.assertThat(nodes.get(2))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithFlaggedShouldReturnFlaggedNodes() {
+    @Test
+    void givenFilesOnRootSearchWithFlaggedShouldReturnFlaggedNodes() {
     // Given
     DatabasePopulator.aNodePopulator(simulator.getInjector())
         .addNode(
@@ -639,43 +669,5 @@ class FindNodesApiIT {
         .containsEntry("id", "00000000-0000-0000-0000-000000000001")
         .containsEntry("name", "trashed");
   }
-
-  @Test
-  void givenFilesOnRootSearchByKeywordsShouldReturnCorrectNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
-            .withInteger("limit", 5)
-            .withListOfStrings("keywords", new String[] {"a"})
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(2);
-    // folders always on top
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "folderA");
-    Assertions.assertThat(nodes.get(1))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/search/PaginationFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/search/PaginationFindNodesApiIT.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 /*
  * This test class mimics findNodes tests but only checks if the pagination is correct and has been created
@@ -63,549 +65,544 @@ class PaginationFindNodesApiIT {
     linkRepository = injector.getInstance(LinkRepository.class);
   }
 
-  @AfterEach
-  void cleanUp() {
-    simulator.resetDatabase();
-  }
-
   @AfterAll
   static void cleanUpAll() {
     simulator.stopAll();
   }
 
-  void createNodesDifferentNames() {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000001",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "folderA"))
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000002",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "folderB"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000001",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaa.txt"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000002",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "bbb.txt"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000003",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "ccc.txt"));
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class PaginateByNameTests {
+
+    @BeforeAll
+    void setUp() {
+      DatabasePopulator.aNodePopulator(simulator.getInjector())
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000001",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "folderA"))
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000002",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "folderB"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000001",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "aaa.txt"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000002",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "bbb.txt"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000003",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "ccc.txt"));
+    }
+
+    @AfterAll
+    void tearDown() {
+      simulator.resetDatabase();
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortNameAscShouldReturnCorrectlyPaginatedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_ASC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_ASC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortNameDescShouldReturnCorrectlyPaginatedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_DESC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.NAME_DESC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortLastUpdateAscShouldReturnCorrectlyPaginatedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "ccc");
+    }
+
+    @Test
+    void
+        givenFilesOnRootSearchWithSortLastUpdateDescShouldReturnCorrectlyPaginatedNodes() { // recents
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000001")
+          .containsEntry("name", "aaa");
+    }
   }
 
-  void createNodesDifferentSizes() { // files with same name, to really be sure it's the size that's
-    // being compared
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-        .addNode(
-            new SimplePopulatorFolder(
-                "10000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 0L))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1L))
-        .addNode(
-            new SimplePopulatorTextFile(
-                "00000000-0000-0000-0000-000000000003",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                2L));
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class PaginateBySizeTests {
+
+    @BeforeAll
+    void setUp() {
+      DatabasePopulator.aNodePopulator(simulator.getInjector())
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+          .addNode(
+              new SimplePopulatorFolder(
+                  "10000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 0L))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1L))
+          .addNode(
+              new SimplePopulatorTextFile(
+                  "00000000-0000-0000-0000-000000000003",
+                  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  2L));
+    }
+
+    @AfterAll
+    void tearDown() {
+      simulator.resetDatabase();
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortSizeAscShouldReturnCorrectlyPaginatedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "00000000-0000-0000-0000-000000000003")
+          .containsEntry("name", "fake");
+    }
+
+    @Test
+    void givenFilesOnRootSearchWithSortSizeDescShouldReturnCorrectlyPaginatedNodes() {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withInteger("limit", 4)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequest =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+      final HttpResponse httpResponse =
+          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+
+      final Map<String, Object> page =
+          TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+      final String pageToken = (String) page.get("page_token");
+
+      String bodyPayloadPage =
+          GraphqlCommandBuilder.aQueryBuilder("findNodes")
+              .withString("folder_id", "LOCAL_ROOT")
+              .withBoolean("cascade", true)
+              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withInteger("limit", 1)
+              .withString("page_token", pageToken)
+              .withWantedResultFormat("{ nodes { id name }, page_token }")
+              .build();
+
+      final HttpRequest httpRequestPage =
+          HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
+
+      final HttpResponse httpResponsePage =
+          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+
+      final Map<String, Object> secondPage =
+          TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
+
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+          .containsEntry("id", "10000000-0000-0000-0000-000000000002")
+          .containsEntry("name", "folder");
+    }
   }
 
-  @Test
-  void givenFilesOnRootSearchWithSortNameAscShouldReturnCorrectlyPaginatedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
+  @Nested
+  class SQLInjectionTests {
+
+    @AfterEach
+    void cleanUp() {
+      simulator.resetDatabase();
+    }
+
+    @Test
+    @DisplayName("""
+      Given a LOCAL_ROOT with three nodes inside, a limit of two elements per page and the second
+      element is a file having a filename with a SQL injected: the findNodes should not be vulnerable
+      by the injection and should return the second page containing the third node and a null
+      page_token
+      """)
+    void givenFilesOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
+      DatabasePopulator
+        .aNodePopulator(simulator.getInjector())
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000001",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "folderA"))
+        .addNode(new SimplePopulatorTextFile(
+          "00000000-0000-0000-0000-000000000001",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "test\')) OR 1=1 --file.txt"))
+        .addNode(new SimplePopulatorTextFile(
+          "00000000-0000-0000-0000-000000000002",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "y file.txt"))
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000002",
+          "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "g folder"))
+        .addNode(new SimplePopulatorTextFile(
+          "00000000-0000-0000-0000-000000000003",
+          "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "z file.txt"));
+
+      String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
+          .withString("folder_id", "LOCAL_ROOT")
+          .withEnum("sort", NodeSort.NAME_ASC)
+          .withInteger("limit", 2)
+          .withWantedResultFormat("{ nodes { id name }, page_token }")
+          .build();
 
-    final HttpRequest httpRequest =
+      final HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    final HttpResponse httpResponse =
+      final HttpResponse httpResponse =
         TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
-    final Map<String, Object> page =
+      final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
+      final String pageToken = (String) page.get("page_token");
 
-    String bodyPayloadPage =
+      String bodyPayloadPage =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
+          .withString("folder_id", "LOCAL_ROOT")
+          .withEnum("sort", NodeSort.NAME_ASC)
+          .withInteger("limit", 2)
+          .withString("page_token", pageToken)
+          .withWantedResultFormat("{ nodes { id name }, page_token }")
+          .build();
 
-    final HttpRequest httpRequestPage =
+      final HttpRequest httpRequestPage =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-    // When
-    final HttpResponse httpResponsePage =
+      final HttpResponse httpResponsePage =
         TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
 
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
-    final Map<String, Object> secondPage =
+      final Map<String, Object> secondPage =
         TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
 
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
 
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "00000000-0000-0000-0000-000000000002")
+        .containsEntry("name", "y file");
+    }
 
-  @Test
-  void givenFilesOnRootSearchWithSortNameDescShouldReturnCorrectlyPaginatedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
+    @DisplayName("""
+      Given a LOCAL_ROOT with three nodes inside, a limit of two elements per page and the second
+      element is a folder having a filename with a SQL injected: the findNodes should not be
+      vulnerable by the injection and should return the second page containing the third node and a
+      null page_token
+      """)
+    @Test
+    void givenFoldersOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
+      DatabasePopulator
+        .aNodePopulator(simulator.getInjector())
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000001",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "folderA"))
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000002",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "folderB\')) OR 1=1 --"))
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000003",
+          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "g folder"))
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000004",
+          "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "g folder"))
+        .addNode(new SimplePopulatorFolder(
+          "10000000-0000-0000-0000-000000000005",
+          "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "h folder"));
+
+      String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_DESC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
+          .withString("folder_id", "LOCAL_ROOT")
+          .withEnum("sort", NodeSort.NAME_ASC)
+          .withInteger("limit", 2)
+          .withWantedResultFormat("{ nodes { id name }, page_token }")
+          .build();
 
-    final HttpRequest httpRequest =
+      final HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    final HttpResponse httpResponse =
+      final HttpResponse httpResponse =
         TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
 
-    final Map<String, Object> page =
+      final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
+      final String pageToken = (String) page.get("page_token");
 
-    String bodyPayloadPage =
+      String bodyPayloadPage =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_DESC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
+          .withString("folder_id", "LOCAL_ROOT")
+          .withEnum("sort", NodeSort.NAME_ASC)
+          .withInteger("limit", 2)
+          .withString("page_token", pageToken)
+          .withWantedResultFormat("{ nodes { id name }, page_token }")
+          .build();
 
-    final HttpRequest httpRequestPage =
+      final HttpRequest httpRequestPage =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-    // When
-    final HttpResponse httpResponsePage =
+      final HttpResponse httpResponsePage =
         TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
 
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
+      Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
-    final Map<String, Object> secondPage =
+      final Map<String, Object> secondPage =
         TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
 
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortSizeAscShouldReturnCorrectlyPaginatedNodes() {
-    // Given
-    createNodesDifferentSizes();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_ASC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_ASC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequestPage =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-        TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "fake");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortSizeDescShouldReturnCorrectlyPaginatedNodes() {
-    // Given
-    createNodesDifferentSizes();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_DESC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.SIZE_DESC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequestPage =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-        TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "10000000-0000-0000-0000-000000000002")
-        .containsEntry("name", "folder");
-  }
-
-  @Test
-  void givenFilesOnRootSearchWithSortLastUpdateAscShouldReturnCorrectlyPaginatedNodes() {
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_ASC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_ASC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequestPage =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-        TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000003")
-        .containsEntry("name", "ccc");
-  }
-
-  @Test
-  void
-      givenFilesOnRootSearchWithSortLastUpdateDescShouldReturnCorrectlyPaginatedNodes() { // recents
-    // Given
-    createNodesDifferentNames();
-    String bodyPayload =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_DESC)
-            .withInteger("limit", 4)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequest =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-        GraphqlCommandBuilder.aQueryBuilder("findNodes")
-            .withString("folder_id", "LOCAL_ROOT")
-            .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.UPDATED_AT_DESC)
-            .withInteger("limit", 1)
-            .withString("page_token", pageToken)
-            .withWantedResultFormat("{ nodes { id name }, page_token }")
-            .build();
-
-    final HttpRequest httpRequestPage =
-        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-        TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-        .containsEntry("id", "00000000-0000-0000-0000-000000000001")
-        .containsEntry("name", "aaa");
-  }
-
-  @Test
-  @DisplayName("""
-    Given a LOCAL_ROOT with three nodes inside, a limit of two elements per page and the second
-    element is a file having a filename with a SQL injected: the findNodes should not be vulnerable
-    by the injection and should return the second page containing the third node and a null
-    page_token
-    """)
-  void givenFilesOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
-    // Given
-    DatabasePopulator
-      .aNodePopulator(simulator.getInjector())
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000001",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "folderA"))
-      .addNode(new SimplePopulatorTextFile(
-        "00000000-0000-0000-0000-000000000001",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "test\')) OR 1=1 --file.txt"))
-      .addNode(new SimplePopulatorTextFile(
-        "00000000-0000-0000-0000-000000000002",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "y file.txt"))
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000002",
-        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "g folder"))
-      .addNode(new SimplePopulatorTextFile(
-        "00000000-0000-0000-0000-000000000003",
-        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "z file.txt"));
-
-    String bodyPayload =
-      GraphqlCommandBuilder.aQueryBuilder("findNodes")
-        .withString("folder_id", "LOCAL_ROOT")
-        .withEnum("sort", NodeSort.NAME_ASC)
-        .withInteger("limit", 2)
-        .withWantedResultFormat("{ nodes { id name }, page_token }")
-        .build();
-
-    final HttpRequest httpRequest =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-      TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-      GraphqlCommandBuilder.aQueryBuilder("findNodes")
-        .withString("folder_id", "LOCAL_ROOT")
-        .withEnum("sort", NodeSort.NAME_ASC)
-        .withInteger("limit", 2)
-        .withString("page_token", pageToken)
-        .withWantedResultFormat("{ nodes { id name }, page_token }")
-        .build();
-
-    final HttpRequest httpRequestPage =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-      TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-      TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-      .containsEntry("id", "00000000-0000-0000-0000-000000000002")
-      .containsEntry("name", "y file");
-  }
-
-  @DisplayName("""
-    Given a LOCAL_ROOT with three nodes inside, a limit of two elements per page and the second
-    element is a folder having a filename with a SQL injected: the findNodes should not be
-    vulnerable by the injection and should return the second page containing the third node and a
-    null page_token
-    """)
-  @Test
-  void givenFoldersOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
-    // Given
-    DatabasePopulator
-      .aNodePopulator(simulator.getInjector())
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000001",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "folderA"))
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000002",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "folderB\')) OR 1=1 --"))
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000003",
-        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "g folder"))
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000004",
-        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "g folder"))
-      .addNode(new SimplePopulatorFolder(
-        "10000000-0000-0000-0000-000000000005",
-        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "h folder"));
-
-    String bodyPayload =
-      GraphqlCommandBuilder.aQueryBuilder("findNodes")
-        .withString("folder_id", "LOCAL_ROOT")
-        .withEnum("sort", NodeSort.NAME_ASC)
-        .withInteger("limit", 2)
-        .withWantedResultFormat("{ nodes { id name }, page_token }")
-        .build();
-
-    final HttpRequest httpRequest =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
-
-    final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
-
-    final Map<String, Object> page =
-      TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
-    final String pageToken = (String) page.get("page_token");
-
-    String bodyPayloadPage =
-      GraphqlCommandBuilder.aQueryBuilder("findNodes")
-        .withString("folder_id", "LOCAL_ROOT")
-        .withEnum("sort", NodeSort.NAME_ASC)
-        .withInteger("limit", 2)
-        .withString("page_token", pageToken)
-        .withWantedResultFormat("{ nodes { id name }, page_token }")
-        .build();
-
-    final HttpRequest httpRequestPage =
-      HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
-
-    // When
-    final HttpResponse httpResponsePage =
-      TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
-
-    // Then
-    Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
-
-    final Map<String, Object> secondPage =
-      TestUtils.jsonResponseToMap(httpResponsePage.getBodyPayload(), "findNodes");
-
-    final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
-
-    Assertions.assertThat(nodes).hasSize(1);
-    Assertions.assertThat(nodes.get(0))
-      .containsEntry("id", "10000000-0000-0000-0000-000000000003")
-      .containsEntry("name", "g folder");
+      final List<Map<String, Object>> nodes = (List<Map<String, Object>>) secondPage.get("nodes");
+
+      Assertions.assertThat(nodes).hasSize(1);
+      Assertions.assertThat(nodes.get(0))
+        .containsEntry("id", "10000000-0000-0000-0000-000000000003")
+        .containsEntry("name", "g folder");
+    }
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
@@ -16,8 +16,12 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionReposit
 import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
+import org.apache.commons.lang3.RandomStringUtils;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public class DatabasePopulator {
   static NodeRepository nodeRepository;
@@ -124,7 +128,7 @@ public class DatabasePopulator {
       linkRepository.createLink(
           UUID.randomUUID().toString(),
           nodeId,
-          org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(32),
+          RandomStringUtils.secure().nextAlphanumeric(32),
           Optional.of(5L),
           Optional.of("bulk-link"),
           Optional.empty());

--- a/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
@@ -149,11 +149,14 @@ public class DatabasePopulator {
     return this;
   }
 
+  /**
+   * Waits until the system clock advances by at least 1ms so that consecutive
+   * inserts get distinct epoch-millis timestamps (needed for sort-by-time tests).
+   */
   private void delay() {
-    try {
-      Thread.sleep(500);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() == start) {
+      Thread.onSpinWait();
     }
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
@@ -113,6 +113,25 @@ public class DatabasePopulator {
     return this;
   }
 
+  /**
+   * Creates multiple links on a node without the per-insert delay.
+   * Use this when testing link count limits where link timestamps are irrelevant.
+   */
+  public DatabasePopulator addLinks(String nodeId, int count) {
+    Optional<Node> optionalNode = nodeRepository.getNode(nodeId);
+    if (optionalNode.isEmpty()) throw new IllegalArgumentException("Node does not exist");
+    for (int i = 0; i < count; i++) {
+      linkRepository.createLink(
+          UUID.randomUUID().toString(),
+          nodeId,
+          org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(32),
+          Optional.of(5L),
+          Optional.of("bulk-link"),
+          Optional.empty());
+    }
+    return this;
+  }
+
   public DatabasePopulator addFlag(String nodeId, String requesterId) {
     nodeRepository.flagForUser(nodeId, requesterId, true);
     delay();

--- a/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbeanIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/NodeRepositoryEbeanIT.java
@@ -10,12 +10,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * This is only an example of test. It must be changed
  */
-@Testcontainers
 class NodeRepositoryEbeanIT {
 
   private static FilesPostgreSQLContainer database;

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.utilities;
+
+import com.zextras.carbonio.user_management.sdk.grpc.GetUserByEmailRequest;
+import com.zextras.carbonio.user_management.sdk.grpc.GetUserByIdRequest;
+import com.zextras.carbonio.user_management.sdk.grpc.GetUserMyselfRequest;
+import com.zextras.carbonio.user_management.sdk.grpc.UserInfoProto;
+import com.zextras.carbonio.user_management.sdk.grpc.UserInfoResponse;
+import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceImplBase;
+import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfProto;
+import com.zextras.carbonio.user_management.sdk.grpc.UserMyselfResponse;
+import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory gRPC service implementation for UserManagement. Supports
+ * {@code getUserMyself} (token lookup), {@code getUserById} (userId lookup),
+ * and {@code getUserByEmail} (email lookup).
+ */
+public class MockUserManagementService extends UserManagementServiceImplBase {
+
+  private final Map<String, UserMyselfResponse> tokenToMyself = new ConcurrentHashMap<>();
+  private final Map<String, UserInfoProto> userIdToInfo = new ConcurrentHashMap<>();
+
+  /**
+   * Registers a minimal token-to-userId mapping. A full {@link UserMyselfResponse} is built
+   * with default values for email, name, domain, status, locale, and the
+   * "carbonioFeatureFilesEnabled" feature enabled.
+   */
+  public void registerToken(String token, String userId) {
+    if (!tokenToMyself.containsKey(token)) {
+      UserInfoProto info = UserInfoProto.newBuilder()
+          .setUserId(userId)
+          .setEmail("fake-email@example.com")
+          .setFullName("Fake User")
+          .setDomain("example.com")
+          .setStatus("active")
+          .setType(UserTypeProto.INTERNAL)
+          .build();
+      UserMyselfProto myself = UserMyselfProto.newBuilder()
+          .setInfo(info)
+          .setLocale("en")
+          .addFeatures("carbonioFeatureFilesEnabled")
+          .build();
+      tokenToMyself.put(token, UserMyselfResponse.newBuilder().setUser(myself).build());
+      userIdToInfo.put(userId, info);
+    }
+  }
+
+  /**
+   * Removes a userId from the {@code getUserById} lookup map so that subsequent
+   * {@code getUserById} calls for this user will return NOT_FOUND.
+   */
+  public void unregisterUserById(String userId) {
+    userIdToInfo.remove(userId);
+  }
+
+  /**
+   * Registers a user profile for lookup by userId via {@code getUserById}.
+   * This is used by integration tests that need to look up users other than
+   * the requester (e.g. transfer ownership target user).
+   */
+  public void registerUserById(String userId, String email, String fullName,
+      String domain, String status) {
+    UserInfoProto info = UserInfoProto.newBuilder()
+        .setUserId(userId)
+        .setEmail(email)
+        .setFullName(fullName)
+        .setDomain(domain)
+        .setStatus(status)
+        .setType(UserTypeProto.INTERNAL)
+        .build();
+    userIdToInfo.put(userId, info);
+  }
+
+  public void clearAll() {
+    tokenToMyself.clear();
+    userIdToInfo.clear();
+  }
+
+  @Override
+  public void getUserMyself(GetUserMyselfRequest request,
+      StreamObserver<UserMyselfResponse> responseObserver) {
+    String token = request.getToken();
+    UserMyselfResponse response = tokenToMyself.get(token);
+    if (response != null) {
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } else {
+      responseObserver.onError(
+          Status.UNAUTHENTICATED.withDescription("Invalid token").asRuntimeException());
+    }
+  }
+
+  @Override
+  public void getUserById(GetUserByIdRequest request,
+      StreamObserver<UserInfoResponse> responseObserver) {
+    String userId = request.getUserId();
+    UserInfoProto info = userIdToInfo.get(userId);
+    if (info != null) {
+      responseObserver.onNext(UserInfoResponse.newBuilder().setUser(info).build());
+      responseObserver.onCompleted();
+    } else {
+      responseObserver.onError(
+          Status.NOT_FOUND.withDescription("User not found").asRuntimeException());
+    }
+  }
+
+  @Override
+  public void getUserByEmail(GetUserByEmailRequest request,
+      StreamObserver<UserInfoResponse> responseObserver) {
+    String email = request.getUserEmail();
+    for (UserInfoProto info : userIdToInfo.values()) {
+      if (info.getEmail().equals(email)) {
+        responseObserver.onNext(UserInfoResponse.newBuilder().setUser(info).build());
+        responseObserver.onCompleted();
+        return;
+      }
+    }
+    responseObserver.onError(
+        Status.NOT_FOUND.withDescription("User not found by email").asRuntimeException());
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
@@ -116,6 +116,7 @@ public class MockUserManagementService extends UserManagementServiceImplBase {
   public void getUserByEmail(GetUserByEmailRequest request,
       StreamObserver<UserInfoResponse> responseObserver) {
     String email = request.getUserEmail();
+    // Search by email across registered users
     for (UserInfoProto info : userIdToInfo.values()) {
       if (info.getEmail().equals(email)) {
         responseObserver.onNext(UserInfoResponse.newBuilder().setUser(info).build());

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/StoragesMockHelper.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/StoragesMockHelper.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.utilities;
+
+import com.zextras.storages.internal.pojo.Query;
+import com.zextras.storages.internal.pojo.StoragesBulkDeleteResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.JsonBody;
+import org.mockserver.model.Parameter;
+
+public class StoragesMockHelper {
+
+  private final MockServerClient storagesMock;
+
+  public StoragesMockHelper(MockServerClient storagesMock) {
+    this.storagesMock = storagesMock;
+  }
+
+  public void getBlob(String nodeId, int version) {
+    storagesMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download")
+                .withQueryStringParameter(Parameter.param("node", nodeId))
+                .withQueryStringParameter(Parameter.param("version", String.valueOf(version)))
+                .withQueryStringParameter(Parameter.param("type", "files")))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody((nodeId + version).getBytes(StandardCharsets.UTF_8)));
+  }
+
+  public void bulkDelete(List<String> ids) {
+    final StoragesBulkDeleteResponse response = new StoragesBulkDeleteResponse();
+    Query queryList = new Query();
+    for (String id : ids) {
+      queryList.setNode(id);
+      queryList.setType("files");
+    }
+    response.setIds(List.of(queryList));
+    storagesMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.POST.toString())
+                .withPath("/bulk-delete"))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(JsonBody.json(response)));
+  }
+}


### PR DESCRIPTION
## Summary

Full IT suite (26 classes, **188 tests**) reduced to **~30 seconds** with no tests removed and no coverage
loss. Four optimization phases, followed by Simulator refactoring for maintainability.

| Phase | Technique |
|---|---|
| 1 — Singleton containers | Reuse Testcontainers across Simulator instances ([singleton pattern](https://testcontainers.com/guides/testcontainers-container-lifecycle/)) |
| 2 — Shared test fixtures | `@Nested` + `@TestInstance(PER_CLASS)` for read-only sort/pagination tests |
| 3 — Bulk link creation | `addLinks(nodeId, count)` without per-insert delay |
| 4 — Reduce entity delay | `DatabasePopulator.delay()`: `Thread.sleep(500)` → 1ms busy-wait |

Final suite wall time: **~30s**.

---

## What changed and why

### Phase 1: Singleton containers (`Simulator.java`)

Previously each `Simulator.start()` launched fresh Postgres/RabbitMQ containers. Now
they are `static final` singletons, started once per JVM with Ryuk cleanup.

Sharing containers exposed hidden issues previously masked by per-test container
destruction:
- **Root node loss** — `resetDatabase()` wiped Flyway-migrated root nodes. Fixed by
preserving rows where `owner_id IS NULL`.
- **Stale notifications** — no FK cascade from `node` to notification tables. Added
explicit cleanup (later replaced with `TRUNCATE CASCADE`).
- **gRPC name collision** — fixed name + async shutdown caused registry conflicts. Now
uses per-instance `AtomicInteger` naming.
- **System property leakage** — properties from `start*()` persisted across instances.
Now cleared in `stopAll()`.
- **HikariCP pool leak** — Ebean doesn't close externally-provided DataSources. Pools
exhausted Postgres connections. Fixed with explicit close in
`DatabaseManagerFlyway.stop()`.

### Phase 2: Shared test fixtures (`FindNodesApiIT`, `PaginationFindNodesApiIT`)

Sort/pagination tests repeatedly created identical datasets for read-only queries.
Restructured with `@Nested` classes: each sort group shares one `@BeforeAll` setup and
`@AfterAll` cleanup. Tests needing unique data per method keep per-test lifecycle.

### Phase 3: Bulk link creation (`DatabasePopulator`)

Link-limit test created 50 links sequentially (50 × 500ms = 25s sleeping). Added
`addLinks(nodeId, count)` for bulk insert without delay.

### Phase 4: Reduce entity delay (`DatabasePopulator`)

`Thread.sleep(500)` after every entity insert ensured distinct timestamps. Replaced with
a 1ms busy-wait:
```java
private void delay() {
  long start = System.currentTimeMillis();
  while (System.currentTimeMillis() == start) {
      Thread.onSpinWait();
  }
}
```

### Simulator refactoring

- Extracted `MockUserManagementService` and `StoragesMockHelper` to their own files
under `utilities/` (`MockFilesConfig` already lived there in CE, no extraction needed)
- Removed instance fields shadowing static singletons — reference statics directly
- Centralized System property management via `setManagedProperty()` + automatic cleanup
in `stopAll()`
- Renamed misleading methods: `resetExternalMocks()` → `reinitializeMocks()`, removed
no-op `stop*()` methods, dropped `"Service"` suffix from `getPreviewServiceMock()` /
`getDocsConnectorServiceMock()`
- Documented MockServer synchronization pattern
- Dropped dead `getServiceDiscoverMock()` getter

### Additional cleanup

- Removed unused simulator modules from test classes (User Management from public
download ITs, message broker from status change ITs)
- Replaced individual DELETEs with `TRUNCATE CASCADE` in `resetDatabase()`
- Moved HikariCP pool close into `DatabaseManagerFlyway.stop()` — the proper lifecycle
owner

---

## Files changed

**26 files** (1,322 insertions, 1,224 deletions)

| Area | Key files | Changes |
|---|---|---|
| Test infrastructure | `Simulator.java` | Singleton containers, shared MockServer, property management, `TRUNCATE CASCADE` |
| Extracted utilities | `MockUserManagementService.java`, `StoragesMockHelper.java` | Separated from Simulator |
| Test data | `DatabasePopulator.java` | 1ms delay, bulk `addLinks()` |
| Notification ITs | `*NotificationApiIT.java` | Per-test → per-class Simulator lifecycle |
| Search ITs (2) | `FindNodesApiIT.java`, `PaginationFindNodesApiIT.java` | `@Nested` restructuring |
| Other ITs | Various `*ApiIT.java` | Updated cleanup calls, removed unused modules |
| Production code | `DatabaseManagerFlyway.java` | `HikariDataSource.close()` in `stop()` — fixes real resource leak |

---

## How to verify

```bash
mvn verify -pl core -Dskip.integration.tests=false

# Expected: 188 tests, ~30s wall time
```

---

## Additional notes for reviewers

- **Only production code change:** `DatabaseManagerFlyway.stop()` now closes the
HikariCP pool — fixes a real resource leak, not just a test concern.
- **1ms busy-wait** relies on `System.currentTimeMillis()` granularity (≤1ms on
Linux/macOS). Coarser platforms would wait longer but never produce incorrect results.
- **Test isolation model changed:** previously, each Simulator destroyed and recreated
all containers, so cleanup was implicit. Now containers are shared singletons, so test
isolation relies on each IT class calling `resetDatabase()` and `reinitializeMocks()` in
`@AfterEach`. All existing classes have been audited and updated. If a future IT class
omits this cleanup, it won't break silently — other tests will fail loudly with stale
data.