### PR TITLE
feat: adopt carbonio-systemd-notify for native sd_notify readiness

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -30,6 +30,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <dependencies>
     <dependency>
+      <groupId>com.zextras.carbonio</groupId>
+      <artifactId>carbonio-systemd-notify</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.zextras.carbonio.files</groupId>
       <artifactId>carbonio-files-ce-core</artifactId>
       <version>${project.parent.version}</version>
@@ -46,6 +52,9 @@ SPDX-License-Identifier: AGPL-3.0-only
           <release>${java-compiler.version}</release>
           <source>${java-compiler.version}</source>
           <target>${java-compiler.version}</target>
+          <compilerArgs>
+            <arg>--enable-preview</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
 

--- a/boot/src/main/java/com/zextras/carbonio/files/NettyServer.java
+++ b/boot/src/main/java/com/zextras/carbonio/files/NettyServer.java
@@ -17,6 +17,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
+import com.zextras.carbonio.systemd.SystemdNotify;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,16 +60,18 @@ public class NettyServer {
         .option(ChannelOption.SO_BACKLOG, 128)
         .childOption(ChannelOption.SO_KEEPALIVE, true);
 
-      bootstrap
+      Channel channel = bootstrap
         .localAddress(
           filesConfig.getFilesHost(),
           Integer.parseInt(filesConfig.getFilesPort())
         )
         .bind()
         .sync()
-        .channel()
-        .closeFuture()
-        .sync();
+        .channel();
+
+      SystemdNotify.ready("files ready");
+
+      channel.closeFuture().sync();
 
     } catch (InterruptedException exception) {
       logger.error("Service stopped unexpectedly: " + exception.getMessage());

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -45,7 +45,6 @@ depends=(
 
 source=(
   "511-carbonio-files.sh"
-  "carbonio-files"
   "carbonio-files.hcl"
   "carbonio-files.service"
   "carbonio-files-setup"
@@ -62,9 +61,8 @@ source=(
 )
 sha256sums=(
   '96f4a551909cd061e95fe06175ff3e2f35578af77ac677023174098c8f940ed3'
-  '88099c1d28b2857bab3b3ebfdaf24a21d7bbd6dbb43eca0078d5e8990f8ef687'
   '1b48886989ad379f5c8ef1024f275a3657801c55cd038fe95ac4c9026ce471a7'
-  '89151c012e0588af6c52625bf393c5b8a331edf39631ab1f4754c7e89f7fe0d4'
+  'a7ee302ad9fbd4b833aaff762434318b1d16fd0dcbf749d44cffa23005a55d4f'
   'ef9409dc0ff2e5096fefa6b6ee06b0253e7a5005f1600771bf1e1bba36381d20'
   '999745be7b0af1051ebc2855d2331585984a80de644553af59e37ce00a2e3297'
   '8963c7a7c3679a3c14550d4a40d353ff20ee6995d77eb7dc2c3c96f40690a7e3'
@@ -83,9 +81,6 @@ backup=(
 )
 
 _package_common() {
-  install -Dm755 "${srcdir}/carbonio-files" \
-    "${pkgdir}/usr/bin/carbonio-files"
-
   install -Dm755 "${srcdir}/carbonio-files-setup" \
     "${pkgdir}/usr/bin/carbonio-files-setup"
 

--- a/package/carbonio-files.service
+++ b/package/carbonio-files.service
@@ -10,14 +10,22 @@ After=network-online.target
 PartOf=carbonio.target
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/carbonio-files
+Type=notify
+NotifyAccess=main
+ExecStart=/opt/zextras/common/bin/java \
+  --enable-preview \
+  --enable-native-access=ALL-UNNAMED \
+  -Djava.net.preferIPv4Stack=true \
+  -Xmx4096m \
+  -Xms4096m \
+  -DFILES_LOG_LEVEL=warn \
+  -jar /usr/share/carbonio/carbonio-files.jar
 User=carbonio-files
 Group=carbonio-files
 Restart=on-failure
-RestartSec=15
-TimeoutSec=60
-TimeoutStopSec=120
+RestartSec=15s
+TimeoutStartSec=120s
+TimeoutStopSec=120s
 
 
 [Install]


### PR DESCRIPTION
Replace Type=simple with Type=notify + NotifyAccess=main, using the shared carbonio-systemd-notify library (FFM-based sd_notify). Drop the shell wrapper in favour of inline java ExecStart.

Ref: CO-3490