### PR TITLE
chore(deps): bump user-management SDK + remove setToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ LICENSES
 
 # VS Code
 .vscode/.run/
+
+# Build artifacts
+docker/packaging/artifacts/

--- a/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/UserRepositoryRest.java
+++ b/core/src/main/java/com/zextras/carbonio/files/dal/repositories/impl/ebean/UserRepositoryRest.java
@@ -59,10 +59,8 @@ public class UserRepositoryRest implements UserRepository {
   @Override
   public Optional<UserInfo> getUserById(String cookies, String userId) {
     try {
-      String token = extractToken(cookies);
       GetUserByIdRequest request =
           GetUserByIdRequest.newBuilder()
-              .setToken(token)
               .setUserId(userId)
               .build();
       UserInfoResponse response = userManagementStub.getUserById(request);
@@ -76,10 +74,8 @@ public class UserRepositoryRest implements UserRepository {
   @Override
   public Optional<UserInfo> getUserByEmail(String cookies, String userEmail) {
     try {
-      String token = extractToken(cookies);
       GetUserByEmailRequest request =
           GetUserByEmailRequest.newBuilder()
-              .setToken(token)
               .setUserEmail(userEmail)
               .build();
       UserInfoResponse response = userManagementStub.getUserByEmail(request);

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-message-broker-sdk.version>1.0.1</carbonio-message-broker-sdk.version>
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
     <grpc.version>1.68.2</grpc.version>
     <carbonio-preview-sdk.version>2.0.1</carbonio-preview-sdk.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-message-broker-sdk.version>1.0.1</carbonio-message-broker-sdk.version>
     <carbonio-storages-common.version>0.0.15-SNAPSHOT</carbonio-storages-common.version>
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.1.324e7740</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
     <grpc.version>1.68.2</grpc.version>
     <carbonio-preview-sdk.version>2.0.1</carbonio-preview-sdk.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
## Summary
- Bumps `carbonio-user-management-grpc-sdk` to `1.0.3-dev.21.79fc3fa2`
- Removes `.setToken(token)` and unused `extractToken()` calls (field removed in SDK)
- New SDK version includes protobuf-java 4.33.2 pin from `sdk-parent:1.8.2-1`

## Test plan
- [x] Jenkins build GREEN on `update-um`

🤖 Generated with [Claude Code](https://claude.com/claude-code)