### PR TITLE
fix: balance Netty ByteBuf refcount (inbound + outbound leak)

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/GraphQLController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/GraphQLController.java
@@ -166,7 +166,6 @@ public class GraphQLController extends SimpleChannelInboundHandler<FullHttpReque
 
       response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
       response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
-      httpRequest.retain();
       context.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
 
     } catch (GraphQLRequest.InvalidPayloadRequestError | GraphQLException exception) {

--- a/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/graphql/controllers/PublicGraphQLController.java
@@ -84,7 +84,6 @@ public class PublicGraphQLController extends SimpleChannelInboundHandler<FullHtt
 
       response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
       response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
-      httpRequest.retain();
       context.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
 
     } catch (GraphQLRequest.InvalidPayloadRequestError | GraphQLException exception) {

--- a/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.Optional;
 import java.util.Set;
@@ -144,7 +145,7 @@ public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpReque
                   .attr(AttributeKey.valueOf(Constants.API.ContextAttribute.COOKIES))
                   .set(cookies);
 
-              context.fireChannelRead(httpRequest);
+              context.fireChannelRead(ReferenceCountUtil.retain(httpRequest));
             },
             () ->
                 context.fireExceptionCaught(

--- a/core/src/main/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriter.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriter.java
@@ -73,6 +73,7 @@ public class NettyBufferWriter {
             byteBuffer.clear();
             writeStreamChunk(contentStream, promise, byteBuffer);
           } else {
+            ReferenceCountUtil.safeRelease(byteBuffer);
             promise.setFailure(future.cause());
           }
         }

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/BlobController.java
@@ -129,7 +129,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     }
 
     ByteBuf content = fullRequest.content();
-    content.retain();
     if (content.readableBytes() == 0) {
       context.fireExceptionCaught(new IllegalArgumentException("Request body is empty"));
       return;
@@ -200,7 +199,6 @@ public class BlobController extends SimpleChannelInboundHandler<HttpObject> {
     }
 
     ByteBuf content = fullRequest.content();
-    content.retain();
     if (content.readableBytes() == 0) {
       context.fireExceptionCaught(new IllegalArgumentException("Request body is empty"));
       return;

--- a/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/controllers/PublicBlobController.java
@@ -113,7 +113,6 @@ public class PublicBlobController extends SimpleChannelInboundHandler<HttpReques
     }
 
     ByteBuf content = fullRequest.content();
-    content.retain();
 
     String bodyContent = content.toString(StandardCharsets.UTF_8);
     List<String> nodeIds;
@@ -160,7 +159,6 @@ public class PublicBlobController extends SimpleChannelInboundHandler<HttpReques
     }
 
     ByteBuf content = fullRequest.content();
-    content.retain();
 
     String bodyContent = content.toString(StandardCharsets.UTF_8);
     QueryStringDecoder decoder = new QueryStringDecoder(bodyContent, false);

--- a/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
@@ -12,9 +12,12 @@ import com.zextras.carbonio.files.dal.dao.UserStatus;
 import com.zextras.carbonio.files.dal.dao.UserType;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.assertj.core.api.Assertions;
@@ -306,5 +309,59 @@ class AuthenticationHandlerTest {
     Assertions
         .assertThat(captorException.getValue().getMessage())
         .isEqualTo("Failed to authenticate request /test/: User is not internal");
+  }
+
+  @Test
+  void givenSuccessfulAuth_fireChannelReadShouldRetainTheRequest() {
+    // Given
+    DefaultFullHttpRequest realRequest =
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test/");
+    realRequest.headers().add(HttpHeaderNames.COOKIE, "IRIS=ui; ZM_AUTH_TOKEN=valid-token");
+
+    UserMyself userMock = Mockito.mock(UserMyself.class);
+    Attribute<Object> requesterAttr = Mockito.mock(Attribute.class);
+    Attribute<Object> cookiesAttr = Mockito.mock(Attribute.class);
+
+    Mockito.when(userMock.getStatus()).thenReturn(UserStatus.ACTIVE);
+    Mockito.when(userMock.getType()).thenReturn(UserType.INTERNAL);
+    Mockito.when(userMock.getCarbonioAttributes())
+        .thenReturn(Map.of("carbonioFeatureFilesEnabled", "TRUE"));
+    Mockito.when(
+            userRepositoryMock.getUserMyselfByCookieNotCached("IRIS=ui; ZM_AUTH_TOKEN=valid-token"))
+        .thenReturn(Optional.of(userMock));
+    Mockito.when(channelMock.attr(AttributeKey.valueOf("requester"))).thenReturn(requesterAttr);
+    Mockito.when(channelMock.attr(AttributeKey.valueOf("cookies"))).thenReturn(cookiesAttr);
+
+    AuthenticationHandler handler = new AuthenticationHandler(userRepositoryMock);
+
+    // When
+    Assertions.assertThat(realRequest.refCnt()).isEqualTo(1);
+    handler.channelRead0(channelHandlerContextMock, realRequest);
+
+    // Then: refCnt must be 2 — proves ReferenceCountUtil.retain() was called
+    Assertions.assertThat(realRequest.refCnt()).isEqualTo(2);
+    Mockito.verify(channelHandlerContextMock).fireChannelRead(realRequest);
+
+    realRequest.release(2);
+  }
+
+  @Test
+  void givenFailedAuth_requestShouldNotBeRetained() {
+    // Given
+    DefaultFullHttpRequest realRequest =
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test/");
+    realRequest.headers().add(HttpHeaderNames.COOKIE, "IRIS=ui; ZM_AUTH_TOKEN=invalid-token");
+
+    AuthenticationHandler handler = new AuthenticationHandler(userRepositoryMock);
+
+    // When
+    Assertions.assertThat(realRequest.refCnt()).isEqualTo(1);
+    handler.channelRead0(channelHandlerContextMock, realRequest);
+
+    // Then: refCnt stays at 1 — no accidental retain on failure path
+    Assertions.assertThat(realRequest.refCnt()).isEqualTo(1);
+    Mockito.verify(channelHandlerContextMock, Mockito.never()).fireChannelRead(Mockito.any());
+
+    realRequest.release();
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriterTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/utilities/NettyBufferWriterTest.java
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.netty.utilities;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.GenericFutureListener;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NettyBufferWriterTest {
+
+  @Test
+  void givenAWriteFailure_writeStream_shouldReleaseBufferToAvoidLeak() throws Exception {
+    // Given
+    ChannelHandlerContext contextMock = Mockito.mock(ChannelHandlerContext.class);
+    ByteBufAllocator allocatorMock = Mockito.mock(ByteBufAllocator.class);
+    ChannelPromise promiseMock = Mockito.mock(ChannelPromise.class);
+    ChannelFuture failedFutureMock = Mockito.mock(ChannelFuture.class);
+
+    ByteBuf buffer = Unpooled.buffer(64 * 1024);
+
+    Mockito.when(contextMock.alloc()).thenReturn(allocatorMock);
+    Mockito.when(allocatorMock.buffer(64 * 1024)).thenReturn(buffer);
+
+    // Simulate Netty: release the buffer by 1 after writeAndFlush, then return a failed future
+    Mockito.when(contextMock.writeAndFlush(Mockito.any(ByteBuf.class))).thenAnswer(inv -> {
+      ((ByteBuf) inv.getArgument(0)).release();
+      return failedFutureMock;
+    });
+
+    Mockito.when(failedFutureMock.isSuccess()).thenReturn(false);
+    Mockito.when(failedFutureMock.cause()).thenReturn(new RuntimeException("write failed"));
+
+    // Invoke the listener synchronously when addListener is called
+    Mockito.doAnswer(inv -> {
+      @SuppressWarnings("unchecked")
+      GenericFutureListener<ChannelFuture> listener = inv.getArgument(0);
+      listener.operationComplete(failedFutureMock);
+      return failedFutureMock;
+    }).when(failedFutureMock).addListener(Mockito.any(GenericFutureListener.class));
+
+    InputStream inputStream =
+        new ByteArrayInputStream("test data".getBytes(StandardCharsets.UTF_8));
+
+    // When
+    new NettyBufferWriter(contextMock).writeStream(inputStream, promiseMock);
+
+    // Then: buffer should be fully released (refCnt = 0) with no leak
+    Assertions.assertThat(buffer.refCnt()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
## Summary
- **Inbound leak fix**: remove spurious `httpRequest.retain()` in GraphQLController/PublicGraphQLController, remove spurious `content.retain()` in BlobController/PublicBlobController, add `ReferenceCountUtil.retain(httpRequest)` in `AuthenticationHandler.fireChannelRead` to keep the request alive past `SimpleChannelInboundHandler`'s auto-release
- **Outbound leak fix**: release `byteBuffer` via `ReferenceCountUtil.safeRelease()` in `NettyBufferWriter.writeStreamChunk` failure callback — previously a 64KB pooled buffer was leaked every time a download failed mid-stream
- **Tests**: refcount regression tests for both fixes using real `DefaultFullHttpRequest` / `Unpooled.buffer` to assert exact `refCnt` values

## Context
Mirror of the same fix applied to `carbonio-files` (OSS). Both fixes have been co-running on the OSS `custom_16-02-2026` branch since mid-March without issues. They are orthogonal: the inbound fix covers every HTTP/GraphQL request path, the outbound fix covers download streaming failures.

## Test plan
- [x] `AuthenticationHandlerTest` — 10 tests pass (2 new refcount tests)
- [x] `NettyBufferWriterTest` — 1 new test verifying buffer release on write failure
- [ ] CI green
- [ ] Run with `-Dio.netty.leakDetection.level=paranoid` to verify no LEAK warnings under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)