### PR TITLE
ci(jenkins): switch Prepare Release agent to sm-release-v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ LICENSES
 
 # Build artifacts
 docker/packaging/artifacts/
+
+# Git worktrees
+.worktrees/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
         stage('Prepare Release') {
             agent {
                 node {
-                    label 'nodejs-v1'
+                    label 'sm-release-v1'
                 }
             }
             when {
@@ -113,7 +113,7 @@ pipeline {
             }
             steps {
                 script {
-                    container('nodejs-20') {
+                    container('nodejs-22') {
                         prepareRelease(
                             repoName: 'carbonio-files-ce'
                         )


### PR DESCRIPTION
Fix pod parking deadlock by moving Prepare Release off nodejs-v1 to sm-release-v1.