### PR TITLE
fix: restore buildPackages() to fix pkgrel on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,12 +75,12 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildPackages([
-                    buildStageConfig: [
-                        addCarbonioRepos: true,
-                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
-                    ]
-                ])
+                script {
+                    buildPackages([
+                        pkgbuildPath: 'package/PKGBUILD',
+                        buildStageConfig: [:]
+                    ])
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,10 @@ pipeline {
                 script {
                     buildPackages([
                         pkgbuildPath: 'package/PKGBUILD',
-                        buildStageConfig: [:]
+                        buildStageConfig: [
+                            addCarbonioRepos: true,
+                            carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                        ]
                     ])
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,9 +75,11 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildStage([
-                    addCarbonioRepos: true,
-                    carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                buildPackages([
+                    buildStageConfig: [
+                        addCarbonioRepos: true,
+                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                    ]
                 ])
             }
         }


### PR DESCRIPTION
## Summary
- Restores `buildPackages()` wrapper that was removed in CO-3422 batch commit (Apr 8)
- `buildStage()` alone does not call `updatePkgbuildRelease()`, causing SNAPSHOT pkgrel to leak into RC artifacts on tag builds
- `buildPackages()` calls `updatePkgbuildRelease()` → `buildStage()` → git checkout, ensuring pkgrel=1 on releases

## Test plan
- [ ] Verify devel branch build still produces SNAPSHOT packages
- [ ] Verify tag build produces pkgrel=1 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)