### PR TITLE
chore(deps): bump jenkins-lib-common to v2.8.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.8',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
* Updated jenkins-lib-common dependency version from 2.8.6 to 2.8.8
* Ensures compatibility with latest features and fixes