### PR TITLE
ci(release): fix semantic-release branch from pre-release to devel

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["pre-release"],
+  "branches": ["devel"],
   "repositoryUrl": "https://github.com/zextras/carbonio-files-ce",
   "tagFormat": "v${version}",
   "plugins": [


### PR DESCRIPTION
## Problem

`.releaserc.json` had `"branches": ["pre-release"]` — a branch that doesn't exist in this repo's workflow. When the `Prepare Release` stage ran on `devel` with `PREPARE_RELEASE=true`, semantic-release logged:

> _This test run was triggered on the branch devel, while semantic-release is configured to only publish from pre-release, therefore a new version won't be published._

And exited silently without creating a tag or release.

## Fix

Change the allowed branch to `devel`, which is where releases are actually prepared from (as enforced by the Jenkinsfile `when { branch 'devel' }` guard).