### PR TITLE
ci: use buildPackages() to set pkgrel on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,9 +77,12 @@ pipeline {
         stage('Build deb/rpm') {
             steps {
                 script {
-                    buildStage(
-                        addCarbonioRepos: true
-                    )
+                    buildPackages([
+                        pkgbuildPath: 'package/PKGBUILD',
+                        buildStageConfig: [
+                            addCarbonioRepos: true,
+                        ]
+                    ])
                 }
             }
         }


### PR DESCRIPTION
## Problem

Tag builds were failing at the upload stage with:

```
[artifactoryHelper] Pre-release artifacts detected in RC upload:
  - carbonio-files-ce-1.2.2-SNAPSHOT.el8.x86_64.rpm
  ...
Artifacts with SNAPSHOT, wip, devel, or timestamp version strings must not be uploaded to RC/release repositories.
```

## Root Cause

`buildStage()` (from `jenkins-lib-common`) does not substitute `pkgrel` in the PKGBUILD. Since `pkgrel="SNAPSHOT"` is the hardcoded default, all builds — including tag builds — were producing SNAPSHOT-versioned artifacts. The `uploadStage()` RC guard correctly rejects these.

`carbonio-files` (non-CE) avoids this by using `buildPackages()` from `jenkins-dt3-lib`, which performs the `pkgrel` substitution on tag builds. `jenkins-dt3-lib` was already loaded in the CE Jenkinsfile but never used.

## Fix

Replace `buildStage()` with `buildPackages()` from `jenkins-dt3-lib`, matching the non-CE pipeline.