### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,6 +122,7 @@ pipeline {
             steps {
                 dockerStage(
                     imageName: 'carbonio-files-ce',
+                    platforms: ['linux/amd64', 'linux/arm64'] as Set,
                     dockerfile: 'docker/minimal/carbonio-files/Dockerfile',
                     ocLabels: [
                         title: 'Carbonio Files CE',

--- a/docker/minimal/carbonio-files/Dockerfile
+++ b/docker/minimal/carbonio-files/Dockerfile
@@ -1,8 +1,13 @@
+# Prep stage runs on BUILDPLATFORM (amd64 CI builder) — no QEMU. Creates the
+# arch-independent config dir so the final image needs no RUN step.
+FROM --platform=$BUILDPLATFORM busybox AS prep
+RUN mkdir -p /staging/etc/carbonio/files
+
 FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 
-RUN mkdir -p /etc/carbonio/files
+COPY --from=prep /staging/etc /etc
 
 COPY ../../boot/target/carbonio-files-*-jar-with-dependencies.jar .
 


### PR DESCRIPTION
Adds `platforms: ['linux/amd64', 'linux/arm64'] as Set` to each `dockerStage` call so images build for arm64 (Apple Silicon / MacOS) in addition to amd64.

Mirrors the merged carbonio-mailbox pattern (PR #994). The `as Set` cast is required: dockerHelper only emits `--platform` when platforms is a Set.

Ref: IN-951