### PR TITLE
chore: [CO-3846] temporary revert to ProtectSystem=yes

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -49,25 +49,19 @@ source=(
   "policies.json"
   "service-protocol.json"
   "service-router.json"
-  "carbonio-files-watches.service"
-  "carbonio-files-start-watches.sh"
-  "carbonio-files-handle-kv-changes.py"
 )
 sha256sums=(
   '96f4a551909cd061e95fe06175ff3e2f35578af77ac677023174098c8f940ed3'
   '1b48886989ad379f5c8ef1024f275a3657801c55cd038fe95ac4c9026ce471a7'
   'a7ee302ad9fbd4b833aaff762434318b1d16fd0dcbf749d44cffa23005a55d4f'
   'ef9409dc0ff2e5096fefa6b6ee06b0253e7a5005f1600771bf1e1bba36381d20'
-  '999745be7b0af1051ebc2855d2331585984a80de644553af59e37ce00a2e3297'
-  '8963c7a7c3679a3c14550d4a40d353ff20ee6995d77eb7dc2c3c96f40690a7e3'
+  '13849da0f25c1a0fa573c7e33f42e39efda0969bffb921d9710a85d722725309'
+  '6997ab298de2d92fc41e07de618e0c3785e586291b504354d8eb43ce54cb8437'
   'SKIP'
   '2f5e8f227d48471e14278068956723ae7dac12c4c6aa0dd6955c00868e1f7ad2'
   'bc4ae477209ec6c64162749a087cd039269bd087647419648bdfee334c87ced3'
   '419211cf2a57b235eaa96d50c46212897e5731589bef96e5cf898f732208bd66'
   '1a1a163fbbca4006ff7951add46d41415fb99948f072a02cd16e408e1fc322da'
-  '28b19e0eadf4afc64bb097878abf666ca4594168c53d03fdb13213e33a31c967'
-  '2fc8cb3533d4a14c7666a91ca5092431ceee469f845feccc20b0b505262da6ec'
-  '6bc85f53bf4470e3251dcb477085336f7e0a674b789f64bb883a4b70603495b4'
 )
 
 backup=(
@@ -101,12 +95,6 @@ _package_common() {
 
   install -Dm644 "${srcdir}/service-router.json" \
     "${pkgdir}/etc/carbonio/files/service-discover/service-router.json"
-
-  install -Dm644 "${srcdir}/carbonio-files-watches.service" \
-    "${pkgdir}/lib/systemd/system/carbonio-files-watches.service"
-
-  install -Dm755 "${srcdir}/carbonio-files-handle-kv-changes.py" \
-    "${pkgdir}/usr/bin/carbonio-files-handle-kv-changes.py"
 }
 
 _package_legacy() {
@@ -125,52 +113,24 @@ build__rocky_8() {
   pip3.8 install \
     --prefix="${pkgdir}/opt/zextras/common" \
     pika
-
-  install -Dm 755 "${srcdir}/carbonio-files-start-watches.sh" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PYTHON_VER/3.8/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PREFIX/common/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
 }
 
 build__rocky_9() {
   pip3 install \
     --prefix="${pkgdir}/opt/zextras/common" \
     pika
-
-  install -Dm 755 "${srcdir}/carbonio-files-start-watches.sh" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PYTHON_VER/3.9/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PREFIX/common/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
 }
 
 build__ubuntu_jammy() {
   pip3 install \
     --prefix="${pkgdir}/opt/zextras/common" \
     pika
-
-  install -Dm 755 "${srcdir}/carbonio-files-start-watches.sh" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PYTHON_VER/3.10/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PREFIX/common\/local/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
 }
 
 build__ubuntu_noble() {
   pip3 install \
     --prefix="${pkgdir}/opt/zextras/common" \
     pika
-
-  install -Dm 755 "${srcdir}/carbonio-files-start-watches.sh" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PYTHON_VER/3.12/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
-  sed -i "s/PREFIX/common\/local/g" \
-    "${pkgdir}/usr/bin/carbonio-files-start-watches.sh"
 }
 
 package() {
@@ -186,10 +146,10 @@ package__ubuntu_jammy() {
 }
 
 postinst() {
-  getent group 'carbonio-files' >/dev/null \
-    || groupadd -r 'carbonio-files'
-  getent passwd 'carbonio-files' >/dev/null \
-    || useradd -r -M -g 'carbonio-files' -s /sbin/nologin 'carbonio-files'
+  getent group 'carbonio-files' >/dev/null ||
+    groupadd -r 'carbonio-files'
+  getent passwd 'carbonio-files' >/dev/null ||
+    useradd -r -M -g 'carbonio-files' -s /sbin/nologin 'carbonio-files'
 
   mkdir -p "/var/log/carbonio/files/"
   chown carbonio-files:carbonio-files "/var/log/carbonio/files"

--- a/package/carbonio-files-sidecar-legacy.service
+++ b/package/carbonio-files-sidecar-legacy.service
@@ -22,7 +22,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes

--- a/package/carbonio-files-sidecar.service
+++ b/package/carbonio-files-sidecar.service
@@ -25,7 +25,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes


### PR DESCRIPTION
## [CO-3846] Release systemd hardening with `ProtectSystem=yes` for 26.6

For 26.6, units with systemd hardening are released with `ProtectSystem=yes` instead of `ProtectSystem=strict`. The switch to `ProtectSystem=strict` as default is planned for 26.9.

### Change
- Comment out `ProtectSystem=strict` and its associated `ReadWritePaths=` entries.
- Set `ProtectSystem=yes`, keeping only `/usr`, `/boot` and `/efi` read-only via `ReadOnlyPaths`.
- Refresh PKGBUILD checksums where a modified `.service` is a local `source=()` entry.

### Why
With `strict` as default the behavior is correct on new installations, but it imposes a breaking change on upgrades: customers using non-standard paths (secondary volumes, local or NFS backups) would find those writes blocked after the upgrade. Releasing with `ProtectSystem=yes` improves the security baseline without breaking any existing installation on upgrade.

The step to `strict` returns in 26.9, giving partners a full release cycle to review their layouts and prepare overrides where needed. This is a choice of sequencing, not feature cancellation — `strict` remains the end state.

Follows the `carbonio-mailbox` CO-3846 pattern.


[CO-3846]: https://zextras.atlassian.net/browse/CO-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ