### PR TITLE
fix: probe docs-connector liveness at the Quarkus /q/health/live endpoint

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClient.java
+++ b/core/src/main/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClient.java
@@ -14,7 +14,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 /** Http client to make http requests to the docs-connector using the service discover. */
 public class DocsConnectorHttpClient {
 
-  private static final String HEALTH_LIVE_ENDPOINT = "/health/live/";
+  // carbonio-docs-connector is now a Quarkus service and exposes its liveness probe via
+  // SmallRye Health at /q/health/live (HTTP 200 when UP), instead of the legacy Jetty
+  // /health/live (HTTP 204). See the matching status-code check below.
+  private static final String HEALTH_LIVE_ENDPOINT = "/q/health/live";
   private static final int TIMEOUT_IN_MS = 2 * 1000;
 
   private final String docsConnectorUrl;
@@ -42,7 +45,7 @@ public class DocsConnectorHttpClient {
     request.setConfig(requestConfig);
 
     try (final CloseableHttpResponse docsConnectorResponse = httpClient.execute(request)) {
-      return docsConnectorResponse.getStatusLine().getStatusCode() == 204;
+      return docsConnectorResponse.getStatusLine().getStatusCode() == 200;
     } catch (Exception exception) {
       return false;
     }

--- a/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/HealthApiIT.java
@@ -86,8 +86,8 @@ class HealthApiIT {
 
       docsConnectorServiceMock
           .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live/"))
-          .respond(HttpResponse.response().withStatusCode(204));
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/q/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
 
       com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
           com.zextras.carbonio.files.utilities.http.HttpRequest.of(
@@ -187,8 +187,8 @@ class HealthApiIT {
 
       docsConnectorServiceMock
           .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live/"))
-          .respond(HttpResponse.response().withStatusCode(204));
+              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/q/health/live"))
+          .respond(HttpResponse.response().withStatusCode(200));
 
       com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
           com.zextras.carbonio.files.utilities.http.HttpRequest.of(

--- a/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/clients/DocsConnectorHttpClientTest.java
@@ -38,7 +38,7 @@ class DocsConnectorHttpClientTest {
     // Given
     CloseableHttpResponse httpResponseMock = Mockito.mock(CloseableHttpResponse.class);
     Mockito.when(httpResponseMock.getStatusLine())
-        .thenReturn(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 204, ""));
+        .thenReturn(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, ""));
 
     ArgumentCaptor<HttpGet> httpRequestCaptor = ArgumentCaptor.forClass(HttpGet.class);
     Mockito.when(httpClientMock.execute(httpRequestCaptor.capture())).thenReturn(httpResponseMock);
@@ -52,7 +52,7 @@ class DocsConnectorHttpClientTest {
     HttpGet httpRequest = httpRequestCaptor.getValue();
     Assertions.assertThat(httpRequest.getMethod()).isEqualTo("GET");
     Assertions.assertThat(httpRequest.getURI().toString())
-        .hasToString("http://127.78.0.2:20005/health/live/");
+        .hasToString("http://127.78.0.2:20005/q/health/live");
 
     Assertions.assertThat(httpRequest.getConfig().getConnectTimeout()).isEqualTo(2000L);
     Assertions.assertThat(httpRequest.getConfig().getSocketTimeout()).isEqualTo(2000L);


### PR DESCRIPTION
## Problem

`carbonio-docs-connector` migrated to a Quarkus native service. Its liveness probe moved from the legacy Jetty `GET /health/live` (HTTP **204**) to SmallRye Health `GET /q/health/live` (HTTP **200**).

`DocsConnectorHttpClient.healthLiveCheck()` still called `/health/live/` and required `statusCode == 204`, so against the new connector it **always returned false** → Files reported docs-connector as down (an `OPTIONAL` dependency) and the **Files UI stopped offering "create / open with Docs"**, even though the backend was fully up.

## Fix

- Probe path: `/health/live/` → `/q/health/live`
- Expected status: `204` → `200` (SmallRye returns 200 when UP)
- Test updated.

Verified locally: `DocsConnectorHttpClientTest` — Tests run: 2, Failures: 0.

## Follow-up (out of scope)

Detection should ideally ask **Consul** for healthy `carbonio-docs-connector` instances rather than HTTP-probing the provider's health endpoint directly — decoupled from how the provider implements health, and correct across N instances (mirrors how docs-connector already discovers docs-editor). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgQC5QMc1mTJnsUG8rjGnK