### PR TITLE
fix(deps): bump preview SDK to 2.0.2-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -62,6 +62,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   io.grpc:grpc-util (io.grpc:grpc-util:1.68.2)
   J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.3)
   Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.2)
+  Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2)
   Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.17.2)
   Jackson-core (com.fasterxml.jackson.core:jackson-core:2.17.2)
   jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.17.2)
@@ -114,6 +115,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   proto-google-common-protos (com.google.api.grpc:proto-google-common-protos:2.63.2)
   RabbitMQ Java Client (com.rabbitmq:amqp-client:5.21.0)
   Retrofit (com.squareup.retrofit2:retrofit:2.9.0)
+  swagger-annotations-jakarta (io.swagger.core.v3:swagger-annotations-jakarta:2.2.22)
   Vavr (io.vavr:vavr:0.11.0)
   Vavr Match (io.vavr:vavr-match:0.11.0)
 
@@ -187,5 +189,5 @@ The Apache License, Version 2.0 (https://spdx.org/licenses/The Apache License, V
 
 Unknown license (https://spdx.org/licenses/Unknown license.html) applies to:
 
-  carbonio-preview-sdk (com.zextras.carbonio.preview:carbonio-preview-sdk:2.0.1)
+  Carbonio Preview CE - REST SDK (com.zextras.carbonio.preview:carbonio-preview-ce-rest-sdk:2.0.2-1)
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,7 +108,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <artifactId>carbonio-preview-sdk</artifactId>
+      <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
       <groupId>com.zextras.carbonio.preview</groupId>
     </dependency>
 
@@ -136,6 +136,16 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vavr</groupId>
+      <artifactId>vavr</artifactId>
     </dependency>
 
     <!-- Metrics -->

--- a/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
+++ b/core/src/main/java/com/zextras/carbonio/files/config/FilesModule.java
@@ -29,7 +29,7 @@ import com.zextras.carbonio.files.message_broker.MessageBrokerManagerImpl;
 import com.zextras.carbonio.files.message_broker.interfaces.MessageBrokerManager;
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.config.enums.Service;
-import com.zextras.carbonio.preview.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc;
 import com.zextras.carbonio.user_management.sdk.grpc.UserManagementServiceGrpc.UserManagementServiceBlockingStub;
 import com.zextras.filestore.api.Filestore;

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/HealthService.java
@@ -11,7 +11,7 @@ import com.zextras.carbonio.files.dal.DatabaseManager;
 import com.zextras.carbonio.files.message_broker.interfaces.MessageBrokerManager;
 import com.zextras.carbonio.files.rest.types.health.DependencyType;
 import com.zextras.carbonio.files.rest.types.health.ServiceHealth;
-import com.zextras.carbonio.preview.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
 import com.zextras.filestore.api.Filestore;
 import com.zextras.filestore.api.Filestore.Liveness;
 import io.grpc.ConnectivityState;

--- a/core/src/main/java/com/zextras/carbonio/files/rest/services/PreviewService.java
+++ b/core/src/main/java/com/zextras/carbonio/files/rest/services/PreviewService.java
@@ -10,10 +10,10 @@ import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.rest.types.BlobResponse;
 import com.zextras.carbonio.files.rest.types.PreviewQueryParameters;
-import com.zextras.carbonio.preview.PreviewClient;
-import com.zextras.carbonio.preview.queries.Query;
-import com.zextras.carbonio.preview.queries.Query.QueryBuilder;
-import com.zextras.carbonio.preview.queries.enums.ServiceType;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewResponse;
+import com.zextras.carbonio.preview.sdk.Query;
+import com.zextras.carbonio.preview.sdk.QueryBuilder;
 import io.vavr.control.Try;
 import java.text.MessageFormat;
 import java.util.Optional;
@@ -54,10 +54,8 @@ public class PreviewService {
 
     logger.debug(MessageFormat.format("Image preview query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getPreviewOfImage(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getPreviewOfImage(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -81,10 +79,8 @@ public class PreviewService {
 
     logger.debug(MessageFormat.format("Image thumbnail query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getThumbnailOfImage(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getThumbnailOfImage(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -101,10 +97,8 @@ public class PreviewService {
     Query query = generateQuery(nodeId, version, ownerId, Optional.empty(), queryParameters);
     logger.debug(MessageFormat.format("Pdf preview query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getPreviewOfPdf(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getPreviewOfPdf(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -127,10 +121,8 @@ public class PreviewService {
 
     logger.debug(MessageFormat.format("Pdf thumbnail query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getThumbnailOfPdf(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getThumbnailOfPdf(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -148,10 +140,8 @@ public class PreviewService {
 
     logger.info(MessageFormat.format("Document preview query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getPreviewOfDocument(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getPreviewOfDocument(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -174,10 +164,8 @@ public class PreviewService {
 
     logger.debug(MessageFormat.format("Document thumbnail query built: {0}", query));
 
-    Try<com.zextras.carbonio.preview.queries.BlobResponse> response =
-        previewClient.getThumbnailOfDocument(query);
-
-    return mapResponseToBlobResponse(response, nodeId);
+    return Try.of(() -> previewClient.getThumbnailOfDocument(query))
+        .map(response -> mapResponseToBlobResponse(response, nodeId));
   }
 
   /**
@@ -198,41 +186,41 @@ public class PreviewService {
       PreviewQueryParameters queryParameters) {
     QueryBuilder parameterBuilder =
         new QueryBuilder()
-            .setServiceType(ServiceType.FILES)
-            .setFileId(nodeId)
-            .setVersion(version)
-            .setFileOwnerId(ownerId);
+            .serviceType("files")
+            .fileId(nodeId)
+            .version(version)
+            .ownerId(ownerId);
 
-    optArea.ifPresent(parameterBuilder::setPreviewArea);
-    queryParameters.getQuality().ifPresent(parameterBuilder::setQuality);
-    queryParameters.getOutputFormat().ifPresent(parameterBuilder::setOutputFormat);
-    queryParameters.getCrop().ifPresent(parameterBuilder::setCrop);
-    queryParameters.getShape().ifPresent(parameterBuilder::setShape);
-    queryParameters.getFirstPage().ifPresent(parameterBuilder::setFirstPage);
-    queryParameters.getLastPage().ifPresent(parameterBuilder::setLastPage);
-    queryParameters.getLangTag().ifPresent(parameterBuilder::setLangTag);
+    optArea.ifPresent(parameterBuilder::area);
+    // The REST SDK forwards these values verbatim as query-string parameters, so they must
+    // already be in the lower-case form the carbonio-preview server expects (the old gRPC SDK
+    // lower-cased its enums internally; PreviewQueryParameters still exposes the upper-case
+    // enum names, so we lower-case them here instead).
+    queryParameters.getQuality().ifPresent(quality -> parameterBuilder.quality(quality.toLowerCase()));
+    queryParameters.getOutputFormat()
+        .ifPresent(outputFormat -> parameterBuilder.outputFormat(outputFormat.toLowerCase()));
+    parameterBuilder.crop(queryParameters.getCrop().orElse(false));
+    queryParameters.getShape().ifPresent(shape -> parameterBuilder.shape(shape.toLowerCase()));
+    queryParameters.getFirstPage().ifPresent(parameterBuilder::firstPage);
+    queryParameters.getLastPage().ifPresent(parameterBuilder::lastPage);
+    queryParameters.getLangTag().ifPresent(parameterBuilder::langTag);
 
     return parameterBuilder.build();
   }
 
   /**
-   * This method maps all fields of a {@link com.zextras.carbonio.preview.queries.BlobResponse}
-   * object to the corresponding fields of a {@link BlobResponse} object.
+   * This method maps all fields of a {@link PreviewResponse} object to the corresponding fields
+   * of a {@link BlobResponse} object.
    *
-   * @param response is a {@link com.zextras.carbonio.preview.queries.BlobResponse} object to
-   *     convert.
+   * @param response is a {@link PreviewResponse} object to convert.
    * @param nodeId is a {@link String} representing the node id.
-   * @return generated {@link Query}
+   * @return the mapped {@link BlobResponse}
    */
-  private Try<BlobResponse> mapResponseToBlobResponse(
-      Try<com.zextras.carbonio.preview.queries.BlobResponse> response, String nodeId) {
-    return (response.isSuccess())
-        ? Try.success(
-            new BlobResponse(
-                response.get().getContent(),
-                nodeRepository.getNode(nodeId).get().getFullName(),
-                response.get().getLength(),
-                response.get().getMimeType()))
-        : Try.failure(response.failed().get());
+  private BlobResponse mapResponseToBlobResponse(PreviewResponse response, String nodeId) {
+    return new BlobResponse(
+        response.getContent(),
+        nodeRepository.getNode(nodeId).get().getFullName(),
+        response.getLength(),
+        response.getMimeType());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
     <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
     <grpc.version>1.68.2</grpc.version>
-    <carbonio-preview-ce-rest-sdk.version>2.0.1-1</carbonio-preview-ce-rest-sdk.version>
+    <carbonio-preview-ce-rest-sdk.version>2.0.2-1</carbonio-preview-ce-rest-sdk.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-validator.version>1.9.0</commons-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-storages-ce.version>0.0.15-SNAPSHOT</carbonio-storages-ce.version>
     <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
     <grpc.version>1.68.2</grpc.version>
-    <carbonio-preview-sdk.version>2.0.1</carbonio-preview-sdk.version>
+    <carbonio-preview-ce-rest-sdk.version>2.0.1-1</carbonio-preview-ce-rest-sdk.version>
+    <commons-io.version>2.11.0</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-validator.version>1.9.0</commons-validator.version>
     <ebean.version>13.26.1</ebean.version>
@@ -62,6 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <testcontainers.junit.jupiter.version>1.21.3</testcontainers.junit.jupiter.version>
     <testcontainers.postgresql.version>1.21.3</testcontainers.postgresql.version>
     <testcontainers.rabbitmq.version>1.21.3</testcontainers.rabbitmq.version>
+    <vavr.version>0.11.0</vavr.version>
     <flyway-database-postgresql.version>11.8.1</flyway-database-postgresql.version>
 
     <!-- Plugins -->
@@ -204,8 +206,27 @@ SPDX-License-Identifier: AGPL-3.0-only
 
       <dependency>
         <groupId>com.zextras.carbonio.preview</groupId>
-        <artifactId>carbonio-preview-sdk</artifactId>
-        <version>${carbonio-preview-sdk.version}</version>
+        <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
+        <version>${carbonio-preview-ce-rest-sdk.version}</version>
+      </dependency>
+
+      <!--
+        The old carbonio-preview-sdk transitively pulled in commons-io and vavr; the new
+        carbonio-preview-ce-rest-sdk is dependency-lean and does not. Both libraries are used
+        directly across the codebase (io.vavr.control.Try, org.apache.commons.io.IOUtils), so
+        they must now be declared explicitly. Versions match what was previously resolved
+        transitively (commons-io 2.11.0, vavr 0.11.0) to avoid an unintended version bump.
+      -->
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.vavr</groupId>
+        <artifactId>vavr</artifactId>
+        <version>${vavr.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bump the preview dependency to the released split REST SDK **carbonio-preview-ce-rest-sdk:2.0.2-1**.

The Python→Go preview rewrite replaced the single `carbonio-preview-sdk` with two edition-specific REST SDKs; `2.0.2-1` carries the enum-case lowercasing fix in the SDK `QueryBuilder` (quality/shape/output_format/service_type), so uppercase enum names sent by consumers no longer trigger the preview service's 422.

Branch = current `devel` + the SDK migration/bump. Compiled + unit-tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)