### PR TITLE
chore(packaging): migrate yap build images to v2.4

### DIFF
--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -11,31 +11,36 @@ RUN mkdir -p package && \
     cp ./package/watches/* package/ 2>/dev/null
 
 # Stage Ubuntu 20.04 (Focal)
+# yap-ubuntu-focal has no v2 image upstream; kept on 1.x intentionally
 FROM docker.io/m0rf30/yap-ubuntu-focal:1.55 AS ubuntu-focal-builder
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-focal /tmp/staging/
 
 # Stage Ubuntu 22.04 (Jammy)
-FROM docker.io/m0rf30/yap-ubuntu-jammy:1.55 AS ubuntu-jammy-builder
+FROM docker.io/m0rf30/yap-ubuntu-jammy:2.4 AS ubuntu-jammy-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-jammy /tmp/staging/
 
 # Stage Ubuntu 24.04 (Noble)
-FROM docker.io/m0rf30/yap-ubuntu-noble:1.55 AS ubuntu-noble-builder
+FROM docker.io/m0rf30/yap-ubuntu-noble:2.4 AS ubuntu-noble-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-noble /tmp/staging/
 
 # Stage RHEL/Rocky 8
-FROM docker.io/m0rf30/yap-rocky-8:1.55 AS rocky-8-builder
+FROM docker.io/m0rf30/yap-rocky-8:2.4 AS rocky-8-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-8 /tmp/staging/
 
 # Stage RHEL/Rocky 9
-FROM docker.io/m0rf30/yap-rocky-9:1.55 AS rocky-9-builder
+FROM docker.io/m0rf30/yap-rocky-9:2.4 AS rocky-9-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-9 /tmp/staging/


### PR DESCRIPTION
## Why

Renovate wants to bump `docker/packaging/Dockerfile`'s `m0rf30/yap-*` build images from `1.55` straight to `2.4`. A plain tag-swap breaks the packaging build: the yap v2 images run as a non-root `yap` user (uid 1000) by default, but yap's `package()` step shells out via fakeroot (`op=RunScriptInFakeroot`), which requires root in the container. Non-root + v2 = build failure at the fakeroot step.

## Fix

Add `USER root` immediately after each v2 `FROM ... AS <stage>` line, restoring the capability yap needs:

- `ubuntu-jammy-builder` → `yap-ubuntu-jammy:2.4` + `USER root`
- `ubuntu-noble-builder` → `yap-ubuntu-noble:2.4` + `USER root`
- `rocky-8-builder` → `yap-rocky-8:2.4` + `USER root`
- `rocky-9-builder` → `yap-rocky-9:2.4` + `USER root`

`ubuntu-focal-builder` is left on `1.55` — there is no `yap-ubuntu-focal:2.4` image upstream (confirmed: `docker manifest inspect docker.io/m0rf30/yap-ubuntu-focal:2.4` 404s). A comment in the Dockerfile documents this so Renovate/reviewers don't "fix" it into a broken bump later.

## Validation performed (this repo)

- `docker manifest inspect` confirmed `yap-ubuntu-jammy:2.4`, `yap-ubuntu-noble:2.4`, `yap-rocky-8:2.4`, `yap-rocky-9:2.4` all exist upstream; `yap-ubuntu-focal:2.4` does not.
- Reproduced the root cause directly against this repo's actual base images: `docker run --entrypoint id m0rf30/yap-ubuntu-jammy:1.55` → `uid=0(root)`; the same against `:2.4` → `uid=1000(yap)`.
- Confirmed the fix mechanism: a minimal `FROM yap-ubuntu-jammy:2.4` + `USER root` + `RUN id` build flips the effective user back to `uid=0(root)`.
- Did **not** run a full `yap build`/`.deb` package build in this environment (would require resolving this repo's internal Zextras-artifactory SNAPSHOT dependencies, not available here). No claim is made about a full package build having been run in this repo.

## Cross-repo proof of pattern

This exact `USER root` fix was already validated end-to-end on two sibling repos:
- **carbonio-tasks-ce**: A/B control test — without `USER root` the v2 build fails as non-root (fakeroot step); with it, apt + dependency resolution pass.
- **carbonio-user-management**: full smoke test — resulting `.deb` is byte-equivalent to the 1.x-built package (only expected `md5sums` metadata differences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
