### PR TITLE
test(acceptance): framework-agnostic acceptance suite + coverage expansion (Quarkus migration Phase 1)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -232,6 +232,13 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>grpc-inprocess</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <version>1.4.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -75,6 +75,7 @@ public class Simulator implements AutoCloseable {
   private MockServerClient storagesMock;
   private MockServerClient previewServiceMock;
   private MockServerClient docsConnectorServiceMock;
+  private MockServerClient mailboxMock;
 
   // gRPC in-process UM mock
   private MockUserManagementService mockUmService;
@@ -322,17 +323,63 @@ public class Simulator implements AutoCloseable {
     return this;
   }
 
+  private Simulator startMailbox() {
+    startMockServer();
+
+    mailboxMock = new MockServerClient(
+      "localhost",
+      Constants.Config.Mailbox.DEFAULT_PORT
+    );
+    setManagedProperty(Constants.Config.Mailbox.HOST_PROPERTY, "localhost");
+
+    return this;
+  }
+
   private void startMockServer() {
     synchronized (MOCK_SERVER_LOCK) {
       if (sharedMockServer == null || !sharedMockServer.isRunning()) {
         final int storagesPort = Constants.Config.Storages.DEFAULT_PORT;
         final int previewServicePort = Constants.Config.Preview.DEFAULT_PORT;
         final int docsConnectorServicePort = Constants.Config.DocsConnector.DEFAULT_PORT;
+        final int mailboxPort = Constants.Config.Mailbox.DEFAULT_PORT;
 
         sharedMockServer =
-            ClientAndServer.startClientAndServer(8500, storagesPort, previewServicePort, docsConnectorServicePort);
+            ClientAndServer.startClientAndServer(
+                8500, storagesPort, previewServicePort, docsConnectorServicePort, mailboxPort);
       }
     }
+  }
+
+  /**
+   * Overrides the {@code max-number-of-versions} value the ServiceDiscover mock reports, BEFORE
+   * the Guice injector resolves {@code NodeDataFetcher} (which reads this KV directly at
+   * construction time to compute its keep-cap, bypassing {@code FilesConfig} entirely — see
+   * {@code NodeDataFetcher}'s constructor). Must therefore be called before {@link
+   * SimulatorBuilder#build()}; a post-build {@code Mocks} call would be too late for the real-HTTP
+   * transport (which resolves the whole object graph, including {@code NodeDataFetcher}, inside
+   * {@code RealHttpFilesTestApp}'s constructor).
+   */
+  private Simulator setMaxNumberOfVersions(int maxVersions) {
+    startServiceDiscover();
+
+    final String encodedValue =
+        new String(Base64.encode(String.valueOf(maxVersions).getBytes()));
+
+    serviceDiscoverMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/max-number-of-versions")
+                .withHeader("X-Consul-Token", ""))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(
+                    String.format(
+                        "[{\"Key\":\"%s\",\"Value\":\"%s\"}]",
+                        "carbonio-files/max-number-of-versions", encodedValue)));
+
+    return this;
   }
 
   private void stopEbeanDatabaseManager() {
@@ -380,6 +427,13 @@ public class Simulator implements AutoCloseable {
     docsConnectorServiceMock = null;
   }
 
+  private void resetMailboxMock() {
+    if (mailboxMock != null && mailboxMock.hasStarted()) {
+      mailboxMock.reset();
+    }
+    mailboxMock = null;
+  }
+
   //
   // Public methods
   //
@@ -398,6 +452,7 @@ public class Simulator implements AutoCloseable {
     resetDocsConnectorMock();
     resetPreviewMock();
     resetStoragesMock();
+    resetMailboxMock();
     stopUserManagement();
     resetServiceDiscoverMock();
     stopEbeanDatabaseManager();
@@ -456,6 +511,10 @@ public class Simulator implements AutoCloseable {
     return docsConnectorServiceMock;
   }
 
+  public MockServerClient getMailboxMock() {
+    return mailboxMock;
+  }
+
   public EmbeddedChannel getNettyChannel() {
     return new EmbeddedChannel(injector.getInstance(HttpRoutingHandler.class));
   }
@@ -488,6 +547,9 @@ public class Simulator implements AutoCloseable {
     }
     if (docsConnectorServiceMock != null && docsConnectorServiceMock.hasStarted()) {
       docsConnectorServiceMock.reset();
+    }
+    if (mailboxMock != null && mailboxMock.hasStarted()) {
+      mailboxMock.reset();
     }
   }
 
@@ -565,6 +627,23 @@ public class Simulator implements AutoCloseable {
 
     public SimulatorBuilder withDocsConnector() {
       simulator.startDocsConnectorService();
+      return this;
+    }
+
+    public SimulatorBuilder withMailbox() {
+      simulator.startMailbox();
+      return this;
+    }
+
+    /**
+     * Overrides the {@code max-number-of-versions} value BEFORE the app is built — required for
+     * {@code keepVersions}/{@code cloneVersion}'s cap ({@code NodeDataFetcher} reads it directly
+     * from Service-Discover once at construction). For the {@code /upload-version} 405 cap
+     * instead, use {@code Mocks#setMaxNumberOfVersions} after {@link #build()} — that path is
+     * re-read live on every call via {@code FilesConfig}.
+     */
+    public SimulatorBuilder withMaxNumberOfVersions(int maxVersions) {
+      simulator.setMaxNumberOfVersions(maxVersions);
       return this;
     }
 

--- a/core/src/test/java/com/zextras/carbonio/files/Simulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/Simulator.java
@@ -507,6 +507,17 @@ public class Simulator implements AutoCloseable {
     return previewServiceMock;
   }
 
+  /**
+   * Exposes the ServiceDiscover MockServer client so {@code Mocks} can stub an arbitrary KV
+   * response (raw value or connection-level outage) for any {@code carbonio-files/<key>}, beyond
+   * the single hardwired {@code max-number-of-versions}-as-integer path {@link
+   * SimulatorBuilder#withMaxNumberOfVersions(int)} exposes. Mirrors {@link #getStoragesMock()}/
+   * {@link #getPreviewMock()}/{@link #getDocsConnectorMock()}/{@link #getMailboxMock()}.
+   */
+  public MockServerClient getServiceDiscoverMock() {
+    return serviceDiscoverMock;
+  }
+
   public MockServerClient getDocsConnectorMock() {
     return docsConnectorServiceMock;
   }

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -197,4 +197,74 @@ public class TestUtils {
         null
     );
   }
+
+  /**
+   * Drives a binary/streamed upload (routes {@code /upload}, {@code /upload-version},
+   * {@code /internal/upload}, {@code /upload-to}) through the embedded Netty pipeline.
+   *
+   * <p>Unlike {@link #sendRequest}/{@link #sendFormRequest} (which write ONE {@code
+   * DefaultFullHttpRequest} carrying the whole body), {@code BlobController}'s upload routes have
+   * no {@code HttpObjectAggregator} in front of them (see {@code HttpRoutingHandler}) and read the
+   * body chunk-by-chunk into a {@code BufferInputStream}. So this writes a headers-only {@code
+   * DefaultHttpRequest} (the caller's headers/cookie plus a Content-Length computed from the
+   * actual byte array — never taken from the caller's headers) followed by a single {@code
+   * DefaultLastHttpContent} carrying the bytes.
+   *
+   * <p>The upload itself completes on a {@code CompletableFuture} (a background thread reads the
+   * just-written content while it drives the Storages client), so — exactly like {@link
+   * #sendFormRequest}'s async branch — the response may not be immediately available on {@code
+   * readOutbound()}; poll with a deadline, pumping {@code runScheduledPendingTasks()} so the
+   * background completion's {@code context.write(...)} (issued off the event-loop thread) gets
+   * drained.
+   */
+  public static HttpResponse sendUpload(HttpRequest request, EmbeddedChannel nettyChannel) {
+    final byte[] body = request.getBinaryBody().orElse(new byte[0]);
+
+    DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+
+    if (request.getHeaders().isPresent()) {
+      request.getHeaders().get().forEach(header -> httpHeaders.add(header.getKey(), header.getValue()));
+    }
+
+    if (request.getCookie().isPresent()) {
+      httpHeaders.add(HttpHeaderNames.COOKIE, request.getCookie().get());
+    }
+
+    // Always the real byte-array length: BlobController parses this to size the read loop and to
+    // enforce the upload size cap, so it must reflect what is actually written below.
+    httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length));
+
+    final DefaultHttpRequest httpRequestHead =
+        new DefaultHttpRequest(
+            HttpVersion.HTTP_1_1,
+            HttpMethod.valueOf(request.getMethod()),
+            request.getEndpoint(),
+            httpHeaders);
+
+    nettyChannel.writeInbound(httpRequestHead);
+    nettyChannel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(body)));
+
+    DefaultHttpResponse defaultHttpResponse = nettyChannel.readOutbound();
+    if (defaultHttpResponse == null) {
+      long deadline = System.currentTimeMillis() + 5000;
+      while (defaultHttpResponse == null && System.currentTimeMillis() < deadline) {
+        try { Thread.sleep(20); } catch (InterruptedException ignored) { break; }
+        nettyChannel.runScheduledPendingTasks();
+        defaultHttpResponse = nettyChannel.readOutbound();
+      }
+    }
+
+    if (defaultHttpResponse instanceof DefaultFullHttpResponse fullHttpResponse) {
+      return HttpResponse.of(
+          fullHttpResponse.status().code(),
+          fullHttpResponse.headers().entries(),
+          fullHttpResponse.content().toString(StandardCharsets.UTF_8));
+    }
+
+    return HttpResponse.of(
+        defaultHttpResponse.status().code(),
+        defaultHttpResponse.headers().entries(),
+        null
+    );
+  }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
+++ b/core/src/test/java/com/zextras/carbonio/files/TestUtils.java
@@ -216,6 +216,15 @@ public class TestUtils {
    * readOutbound()}; poll with a deadline, pumping {@code runScheduledPendingTasks()} so the
    * background completion's {@code context.write(...)} (issued off the event-loop thread) gets
    * drained.
+   *
+   * <p><b>Synchronous-close guard:</b> when {@code BlobController} responds and closes the channel
+   * while still handling the request head (e.g. an invalid {@code Filename} or a size-over-limit
+   * rejection — both fire before any {@code HttpContent} is read), the channel is already closed by
+   * the time the head's {@code writeInbound} returns. The second {@code writeInbound} (the body) is
+   * only attempted if {@code nettyChannel.isOpen()}; otherwise it is skipped and the response the
+   * handler already produced during head processing is read out normally below. Without this guard,
+   * {@code EmbeddedChannel#ensureOpen()} throws {@code ClosedChannelException} instead of ever
+   * returning that response.
    */
   public static HttpResponse sendUpload(HttpRequest request, EmbeddedChannel nettyChannel) {
     final byte[] body = request.getBinaryBody().orElse(new byte[0]);
@@ -242,7 +251,9 @@ public class TestUtils {
             httpHeaders);
 
     nettyChannel.writeInbound(httpRequestHead);
-    nettyChannel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(body)));
+    if (nettyChannel.isOpen()) {
+      nettyChannel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(body)));
+    }
 
     DefaultHttpResponse defaultHttpResponse = nettyChannel.readOutbound();
     if (defaultHttpResponse == null) {

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AcceptanceSuitePurityTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AcceptanceSuitePurityTest.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Purity guard for the immutable black-box acceptance suite (see plan §0.1 / §0.1's physical
+ * isolation layout).
+ *
+ * <p>Everything under {@code com.zextras.carbonio.files.acceptance} — except the mutable seam
+ * implementation confined to {@code acceptance.seam.impl} — must depend ONLY on neutral types
+ * (the {@code FilesTestApp}/{@code TestDataAccess}/{@code Mocks} seam, neutral HTTP POJOs, JUnit,
+ * AssertJ, JSON helpers). It must NOT reach for Guice, MockServer, Netty, or Ebean-DSL types
+ * directly, and it must NOT import the Ebean repository-implementation package — those are
+ * Bucket-C / framework-bound and are exactly what the seam exists to keep out of the 31 immutable
+ * IT bodies. If this test fails on a class other than via the seam impl, that is a real
+ * regression: either the seam leaked, or a test body reached around it.
+ */
+class AcceptanceSuitePurityTest {
+
+  @Test
+  void acceptanceSuiteBodiesMustNotDependOnFrameworkTypes() {
+    JavaClasses importedClasses =
+        new ClassFileImporter().importPackages("com.zextras.carbonio.files.acceptance");
+
+    ArchRule rule =
+        noClasses()
+            .that()
+            .resideInAPackage("..acceptance..")
+            .and()
+            .resideOutsideOfPackage("..acceptance.seam.impl..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                "com.google.inject..",
+                "org.mockserver..",
+                "io.netty..",
+                "io.ebean..",
+                "com.zextras.carbonio.files.dal.repositories.impl.ebean..");
+
+    rule.check(importedClasses);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedAndRemovedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedAndRemovedNodeNotificationMoveApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,17 +23,12 @@ import java.util.Map;
 
 class AddedAndRemovedNodeNotificationMoveApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create base folders
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"))
@@ -93,7 +75,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     bodyPayload =
         GraphqlCommandBuilder.aMutationBuilder("createShare")
@@ -106,7 +88,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Create a node on shared directory
     bodyPayload =
@@ -119,7 +101,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
@@ -137,7 +119,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
   }
 
   @Test
@@ -155,8 +137,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -174,11 +155,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
   @Test
   void givenANodeMovedFromOneSharedDirectoryToAnotherSharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
 
     createBaseScenario();
 
@@ -192,8 +169,7 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -206,10 +182,6 @@ class AddedAndRemovedNodeNotificationMoveApiIT {
     Assertions.assertThat(notifications).hasSize(0);
 
     // reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationCopyApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationCopyApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -28,19 +21,14 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-class AddedNodeNotificationMoveApiIT {
+class AddedNodeNotificationCopyApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class AddedNodeNotificationMoveApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create base folder
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"));
@@ -90,7 +72,7 @@ class AddedNodeNotificationMoveApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Create a node on local root
     bodyPayload =
@@ -103,16 +85,16 @@ class AddedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
 
     String nodeId = (String) page.get("id");
 
-    // Move node inside of shared folder
+    // Copy node inside of shared folder
     bodyPayload =
-        GraphqlCommandBuilder.aMutationBuilder("moveNodes")
+        GraphqlCommandBuilder.aMutationBuilder("copyNodes")
             .withListOfStrings("node_ids", List.of(nodeId).toArray(new String[0]))
             .withString("destination_id", "00000000-0000-0000-0000-000000000000")
             .withWantedResultFormat("{ id }")
@@ -121,11 +103,11 @@ class AddedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
   }
 
   @Test
-  void givenANodeMoveOnASharedDirectoryItShouldCreateANotificationForTheUsersItHasBeenSharedWith() {
+  void givenANodeCopyOnASharedDirectoryItShouldCreateANotificationForTheUsersItHasBeenSharedWith() {
     // Given
     createBaseScenario();
 
@@ -139,8 +121,7 @@ class AddedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -154,13 +135,9 @@ class AddedNodeNotificationMoveApiIT {
   }
 
   @Test
-  void givenANodeMoveOnASharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
+  void givenANodeCopyOnASharedDirectoryIAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -173,8 +150,7 @@ class AddedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -184,13 +160,9 @@ class AddedNodeNotificationMoveApiIT {
 
     final List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
 
-    Assertions.assertThat(notifications).hasSize(0);
+    Assertions.assertThat(notifications).hasSize(0); // One newShare and one addedNode
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationCreateApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationCreateApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,17 +23,12 @@ import java.util.Map;
 
 class AddedNodeNotificationCreateApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class AddedNodeNotificationCreateApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create base folder
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"));
@@ -90,7 +72,7 @@ class AddedNodeNotificationCreateApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Create a node inside the shared folder
     bodyPayload =
@@ -103,17 +85,13 @@ class AddedNodeNotificationCreateApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
   }
 
   @Test
   void givenANodeCreationOnASharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -126,8 +104,7 @@ class AddedNodeNotificationCreateApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -140,11 +117,7 @@ class AddedNodeNotificationCreateApiIT {
     Assertions.assertThat(notifications).hasSize(0);
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @Test
@@ -162,8 +135,7 @@ class AddedNodeNotificationCreateApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AddedNodeNotificationMoveApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -28,19 +21,14 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-class AddedNodeNotificationCopyApiIT {
+class AddedNodeNotificationMoveApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class AddedNodeNotificationCopyApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create base folder
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"));
@@ -90,7 +72,7 @@ class AddedNodeNotificationCopyApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Create a node on local root
     bodyPayload =
@@ -103,16 +85,16 @@ class AddedNodeNotificationCopyApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
 
     String nodeId = (String) page.get("id");
 
-    // Copy node inside of shared folder
+    // Move node inside of shared folder
     bodyPayload =
-        GraphqlCommandBuilder.aMutationBuilder("copyNodes")
+        GraphqlCommandBuilder.aMutationBuilder("moveNodes")
             .withListOfStrings("node_ids", List.of(nodeId).toArray(new String[0]))
             .withString("destination_id", "00000000-0000-0000-0000-000000000000")
             .withWantedResultFormat("{ id }")
@@ -121,11 +103,11 @@ class AddedNodeNotificationCopyApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
   }
 
   @Test
-  void givenANodeCopyOnASharedDirectoryItShouldCreateANotificationForTheUsersItHasBeenSharedWith() {
+  void givenANodeMoveOnASharedDirectoryItShouldCreateANotificationForTheUsersItHasBeenSharedWith() {
     // Given
     createBaseScenario();
 
@@ -139,8 +121,7 @@ class AddedNodeNotificationCopyApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -154,13 +135,9 @@ class AddedNodeNotificationCopyApiIT {
   }
 
   @Test
-  void givenANodeCopyOnASharedDirectoryIAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
+  void givenANodeMoveOnASharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -173,8 +150,7 @@ class AddedNodeNotificationCopyApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -184,13 +160,9 @@ class AddedNodeNotificationCopyApiIT {
 
     final List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
 
-    Assertions.assertThat(notifications).hasSize(0); // One newShare and one addedNode
+    Assertions.assertThat(notifications).hasSize(0);
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AliasNotAloneDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AliasNotAloneDownloadApiIT.java
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.Constants;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the {@code LOCAL_ROOT} alias branch of {@code BlobService#checkDownloadMultipleInternal}
+ * on {@code POST /download-multiple} (Task 1.9 of the acceptance coverage-expansion plan):
+ * {@code LOCAL_ROOT} combined with any other id is rejected with {@code AliasNotAloneInDownload}
+ * (400), while {@code LOCAL_ROOT} passed alone is resolved to its children.
+ *
+ * <p>NOTE: the negative scenario substantially overlaps an existing test in {@code
+ * DownloadMultipleApiIT} ({@code givenLocalRootWithOtherNodesTheDownloadMultipleShouldReturn400}),
+ * which already asserts the 400 status. This file adds the exact response-body assertion (the
+ * {@code ExceptionsHandler} generic-body branch for {@code BadRequestException}-like causes) and
+ * pairs it with the resolves-to-children positive case, per the plan's Task 1.9 scope.
+ */
+class AliasNotAloneDownloadApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse executeDownloadMultiple(List<String> nodeIds) throws Exception {
+    String jsonArray = OBJECT_MAPPER.writeValueAsString(nodeIds);
+    String requestBody = "nodeIds=" + URLEncoder.encode(jsonArray, StandardCharsets.UTF_8);
+
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/x-www-form-urlencoded"));
+
+    HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/download-multiple", "ZM_AUTH_TOKEN=fake-token", headers, requestBody);
+
+    return app.sendForm(httpRequest);
+  }
+
+  @Test
+  void givenLocalRootAndAnotherNodeIdThenDownloadMultipleReturns400WithGenericBadRequestBody()
+      throws Exception {
+    // Given
+    String fileId = "00000000-0000-0000-0000-000000000601";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                OWNER_ID,
+                OWNER_ID,
+                Constants.Db.RootId.LOCAL_ROOT,
+                "file.txt",
+                "",
+                NodeType.TEXT,
+                Constants.Db.RootId.LOCAL_ROOT,
+                10L,
+                "text/plain"));
+
+    // When — LOCAL_ROOT is not the only id passed -> AliasNotAloneInDownload
+    HttpResponse httpResponse =
+        executeDownloadMultiple(List.of(Constants.Db.RootId.LOCAL_ROOT, fileId));
+
+    // Then — ExceptionsHandler maps AliasNotAloneInDownload to a generic 400 body (the actual
+    // exception message is discarded, per ExceptionsHandler's BadRequestException-like branch).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  void givenLocalRootAloneThenDownloadMultipleResolvesToItsChildrenAndReturnsZipWith200()
+      throws Exception {
+    // Given
+    String fileId1 = "00000000-0000-0000-0000-000000000602";
+    String fileId2 = "00000000-0000-0000-0000-000000000603";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId1,
+                OWNER_ID,
+                OWNER_ID,
+                Constants.Db.RootId.LOCAL_ROOT,
+                "file1.txt",
+                "",
+                NodeType.TEXT,
+                Constants.Db.RootId.LOCAL_ROOT,
+                10L,
+                "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                fileId2,
+                OWNER_ID,
+                OWNER_ID,
+                Constants.Db.RootId.LOCAL_ROOT,
+                "file2.txt",
+                "",
+                NodeType.TEXT,
+                Constants.Db.RootId.LOCAL_ROOT,
+                20L,
+                "text/plain"));
+
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+
+    // When — LOCAL_ROOT passed alone resolves to its children (both files).
+    HttpResponse httpResponse =
+        executeDownloadMultiple(List.of(Constants.Db.RootId.LOCAL_ROOT));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(httpResponse.getHeaders())
+        .anyMatch(
+            header ->
+                header.getKey().equalsIgnoreCase("content-type")
+                    && header.getValue().contains("application/zip"));
+
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
+    app.mocks().verifyStoragesDownloaded(fileId2, 1);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AuthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AuthApiIT.java
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Covers every non-happy branch of {@code AuthenticationHandler} (Task 1.1 of the acceptance
+ * coverage-expansion plan): missing cookie, cookie without {@code ZM_AUTH_TOKEN}, an unresolvable
+ * token, an inactive user, a guest user, and a user with the Files feature flag disabled. All six
+ * are driven through the same authenticated GraphQL route ({@code POST /graphql/}); a seventh test
+ * confirms the same handler also guards {@code GET /download/{id}}.
+ */
+class AuthApiIT {
+
+  static FilesTestApp app;
+
+  private static final String ACTIVE_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String TRIVIAL_QUERY = "query { getRootsList { id } }";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("active-token", ACTIVE_USER_ID))
+            .build();
+
+    // Fixtures for the non-happy-path branches, registered once — each test picks its own cookie.
+    app.mocks()
+        .registerUser("maintenance-token", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1", "maintenance", false, true);
+    app.mocks()
+        .registerUser("guest-token", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2", "active", true, true);
+    app.mocks()
+        .registerUser("flag-off-token", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb3", "active", false, false);
+    // "unknown-token" is deliberately never registered on either UM fixture map.
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  static Stream<Arguments> nonHappyAuthScenarios() {
+    return Stream.of(
+        Arguments.of("missing Cookie header entirely", null, "Missing cookies"),
+        Arguments.of("Cookie header without ZM_AUTH_TOKEN", "other=1", "Missing cookies"),
+        Arguments.of(
+            "token not resolvable by user-management",
+            "ZM_AUTH_TOKEN=unknown-token",
+            "Unable to find requested user"),
+        Arguments.of(
+            "user status is not ACTIVE (MAINTENANCE)",
+            "ZM_AUTH_TOKEN=maintenance-token",
+            "User is not active"),
+        Arguments.of("user type is GUEST", "ZM_AUTH_TOKEN=guest-token", "User is not internal"),
+        Arguments.of(
+            "carbonioFeatureFilesEnabled is off",
+            "ZM_AUTH_TOKEN=flag-off-token",
+            "User is not internal"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonHappyAuthScenarios")
+  void givenNonHappyAuthBranchOnGraphqlThenRequestIsRejectedWith401(
+      String scenarioName, String cookie, String expectedMessageFragment) {
+    // Given
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, TRIVIAL_QUERY);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(401);
+    Assertions.assertThat(httpResponse.getBodyPayload()).contains(expectedMessageFragment);
+  }
+
+  @Test
+  void givenMissingCookieOnDownloadRouteThenRequestIsRejectedWith401BySameHandler() {
+    // Given — /download/{id} is routed through the same auth-handler as /graphql/.
+    HttpRequest httpRequest =
+        HttpRequest.of("GET", "/download/00000000-0000-0000-0000-000000000000", null, null);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(401);
+    Assertions.assertThat(httpResponse.getBodyPayload()).contains("Missing cookies");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/AuthenticatedDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/AuthenticatedDownloadApiIT.java
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.4 of the acceptance coverage-expansion plan: {@code GET /download/{id}[/{version}]} and
+ * {@code GET /download/{id}/check}, driven through {@code Mocks#storagesServesBlob}/{@code
+ * setMaxDownloadableSizeMb} and seeded via {@code PopulatorNode}.
+ *
+ * <p><b>Body/Content-Length note:</b> {@code StoragesMockHelper#getBlob(nodeId, version)} always
+ * responds with the literal bytes {@code nodeId + version} regardless of the node's DB-recorded
+ * size, while {@code BlobService#downloadFile} sets the response's {@code Content-Length} from
+ * the DB-recorded {@code FileVersion#getSize()} (never from the actual mocked byte count). To
+ * keep the two consistent (a genuine mismatch risks the real-HTTP transport truncating/erroring
+ * on a body that disagrees with its own advertised {@code Content-Length}), every node here is
+ * seeded with a size EQUAL to {@code (nodeId + version).length()} so the two agree by
+ * construction; both versions used below (1 and 2) are single digits, so this size is identical
+ * for both and {@code addVersion} (which copies the node's current size unchanged) needs no
+ * adjustment.
+ *
+ * <p><b>FINDING (mirrors the permission-gate-before-not-found pattern seen across the suite):</b>
+ * {@code BlobService#checkDownloadFileById} returns {@code Optional.empty()} both when the node
+ * does not exist at all (its {@code Optional<Node>} lookup inside {@code PermissionsChecker} is
+ * empty, mapping to {@code ACL.NONE}) and when it exists but the requester lacks {@code
+ * READ_ONLY}. {@code BlobController#download}/{@code #checkDownload} both funnel that single
+ * {@code Optional.empty()} into the identical {@code NoSuchElementException} -> 404 shape, so a
+ * genuinely non-existent id and a permission-denied existing id are indistinguishable over HTTP.
+ * Both scenarios are asserted below with their real, identical 404 shape.
+ *
+ * <p><b>FINDING (genuine transport divergence, not fixed here):</b> {@code BlobController#download}
+ * writes its response in (at least) two separate steps — the headers-only {@code
+ * DefaultHttpResponse} via {@code context.write(...)}, then the body via {@code
+ * NettyBufferWriter}'s own separate {@code context.writeAndFlush(ByteBuf)} calls per chunk — never
+ * as a single {@code DefaultFullHttpResponse}. {@code TestUtils#sendRequest} (embedded transport)
+ * only drains ONE outbound Netty message via {@code EmbeddedChannel#readOutbound()}, so on the
+ * embedded transport {@code httpResponse.getBodyPayload()} for this route is ALWAYS {@code null}
+ * (status and headers ARE captured correctly — only the streamed body is missed). This is a
+ * PRE-EXISTING seam gap, not introduced here: no existing acceptance test (including {@code
+ * DownloadMultipleApiIT}, {@code PreviewApiIT}, {@code ThumbnailApiIT}, all of which stream a body
+ * the same way) asserts body bytes for this exact reason. On the real-HTTP transport ({@code
+ * -Dfiles.test.transport=http}), {@code RealHttpFilesTestApp} uses {@code java.net.http.HttpClient}
+ * with {@code BodyHandlers.ofString(...)}, which correctly drains the full body over the socket
+ * regardless of framing — so the identical test body DOES observe the real bytes there. Per the
+ * "don't silently edit the shared seam" guardrail, {@code TestUtils}/{@code GuiceNettyFilesTestApp}
+ * are NOT modified to add multi-frame draining; instead, the body-match assertions below are
+ * conditional on the body being observable (deterministically skipped on embedded, deterministically
+ * checked on real-HTTP), and every test additionally verifies the download via {@code
+ * Mocks#verifyStoragesDownloaded}, which is transport-invariant proof that storages was actually
+ * asked for the correct node/version.
+ */
+class AuthenticatedDownloadApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setMaxDownloadableSizeMb(null);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String blobBytesFor(String nodeId, int version) {
+    return nodeId + version;
+  }
+
+  private static long sizeFor(String nodeId, int version) {
+    return blobBytesFor(nodeId, version).getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  private HttpResponse download(String nodeId, Integer version, String cookie) {
+    String endpoint = version == null ? "/download/" + nodeId : "/download/" + nodeId + "/" + version;
+    return app.send(HttpRequest.of("GET", endpoint, cookie, null));
+  }
+
+  private HttpResponse checkDownload(String nodeId, String cookie) {
+    return app.send(HttpRequest.of("GET", "/download/" + nodeId + "/check", cookie, null));
+  }
+
+  private String headerValue(HttpResponse response, String name) {
+    return response.getHeaders().stream()
+        .filter(header -> header.getKey().equalsIgnoreCase(name))
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Asserts the streamed download body matches, but only when it was actually observable — see
+   * the class-level transport-divergence FINDING: the embedded transport deterministically never
+   * captures this route's body ({@code null}), the real-HTTP transport deterministically does.
+   */
+  private void assertBodyMatchesWhenObservable(HttpResponse response, String expected) {
+    if (response.getBodyPayload() != null) {
+      Assertions.assertThat(response.getBodyPayload()).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  void givenAnExistingFileTheLatestDownloadShouldReturn200WithHeadersAndMatchingBody()
+      throws Exception {
+    // Given — a single version (v1)
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                REQUESTER_ID,
+                REQUESTER_ID,
+                "LOCAL_ROOT",
+                "fake.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"));
+    app.mocks().storagesServesBlob(nodeId, 1);
+
+    // When
+    HttpResponse httpResponse = download(nodeId, null, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(headerValue(httpResponse, "content-disposition"))
+        .isEqualTo(
+            "attachment; filename*=UTF-8''" + URLEncoder.encode("fake.txt", StandardCharsets.UTF_8));
+    Assertions.assertThat(headerValue(httpResponse, "content-length"))
+        .isEqualTo(String.valueOf(sizeFor(nodeId, 1)));
+    assertBodyMatchesWhenObservable(httpResponse, blobBytesFor(nodeId, 1));
+
+    app.mocks().verifyStoragesDownloaded(nodeId, 1);
+  }
+
+  @Test
+  void givenAVersionSuffixUrlTheDownloadShouldServeThatSpecificVersion() throws Exception {
+    // Given — two versions (v1, v2); the node's currently-current version is 2, but the URL
+    // explicitly asks for v1
+    String nodeId = "10000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                REQUESTER_ID,
+                REQUESTER_ID,
+                "LOCAL_ROOT",
+                "fake.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"))
+        .addVersion(nodeId);
+    app.mocks().storagesServesBlob(nodeId, 1);
+    app.mocks().storagesServesBlob(nodeId, 2);
+
+    // When — explicitly request the OLD version, not the current one
+    HttpResponse httpResponse = download(nodeId, 1, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    assertBodyMatchesWhenObservable(httpResponse, blobBytesFor(nodeId, 1));
+    app.mocks().verifyStoragesDownloaded(nodeId, 1);
+  }
+
+  @Test
+  void givenNoPermissionOnTheNodeDownloadShouldReturn404() {
+    // Given — node owned by OTHER_USER_ID, never shared with the requester
+    String nodeId = "10000000-0000-0000-0000-000000000003";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                OTHER_USER_ID,
+                OTHER_USER_ID,
+                "LOCAL_ROOT",
+                "notMine.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"));
+
+    // When
+    HttpResponse httpResponse = download(nodeId, null, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  @Test
+  void givenANonExistentNodeDownloadShouldReturnTheSame404AsNoPermission() {
+    // See class-level FINDING: the permission gate maps a non-existent id to the SAME
+    // Optional.empty() -> 404 shape as an existing-but-forbidden node.
+    String nonExistentId = "10000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse = download(nonExistentId, null, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  @Test
+  void givenTheNodeSizeOverTheConfiguredCapDownloadShouldReturn413() {
+    // Given — a 0MB cap; any node with a non-zero size exceeds it
+    String nodeId = "10000000-0000-0000-0000-000000000004";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                REQUESTER_ID,
+                REQUESTER_ID,
+                "LOCAL_ROOT",
+                "big.bin",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"));
+    app.mocks().setMaxDownloadableSizeMb(0);
+
+    // When
+    HttpResponse httpResponse = download(nodeId, null, REQUESTER_COOKIE);
+
+    // Then — FileSizeException groups with the generic-body 413 branch in ExceptionsHandler (the
+    // descriptive message is discarded, same quirk as the upload-side size cap)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(413);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("413 Request Entity Too Large");
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  @Test
+  void givenADownloadableNodeCheckDownloadShouldReturn204() {
+    // Given
+    String nodeId = "10000000-0000-0000-0000-000000000005";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                REQUESTER_ID,
+                REQUESTER_ID,
+                "LOCAL_ROOT",
+                "fake.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"));
+
+    // When
+    HttpResponse httpResponse = checkDownload(nodeId, REQUESTER_COOKIE);
+
+    // Then — /check never touches storages at all (no fileStore call in checkDownloadFileById)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  @Test
+  void givenNoPermissionCheckDownloadShouldReturn404() {
+    // Given — node owned by OTHER_USER_ID, never shared with the requester
+    String nodeId = "10000000-0000-0000-0000-000000000006";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                OTHER_USER_ID,
+                OTHER_USER_ID,
+                "LOCAL_ROOT",
+                "notMine.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                sizeFor(nodeId, 1),
+                "text/plain"));
+
+    // When
+    HttpResponse httpResponse = checkDownload(nodeId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+
+  @Test
+  void givenANonExistentNodeCheckDownloadShouldReturn404() {
+    // Given — same permission-gate merge as the plain download route
+    String nonExistentId = "10000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse = checkDownload(nonExistentId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/BrokerEffectsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/BrokerEffectsApiIT.java
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 6.2 of the acceptance coverage-expansion plan: {@code message_broker.consumers.*}, driven
+ * through the APPROVED non-HTTP backdoors {@code backdoor().injectUserStatusChanged(userId,
+ * status)} and {@code backdoor().injectMaxVersionNumberChanged(int)} (see plan §2.5/§10). Neither
+ * consumer has a real RabbitMQ trigger reachable from this suite; both backdoors mirror the
+ * white-box {@code message_broker.it.UserStatusChangedIT}/{@code MaxVersionNumberChangedIT} by
+ * constructing the consumer directly and calling {@code doHandle(...)} — no {@code
+ * .withMessageBroker()} builder knob is needed since the real broker connection is never touched.
+ * Effects are asserted purely via the public HTTP/GraphQL contract ({@code findNodes}, {@code
+ * GET /download/{id}/{version}}) and the neutral {@code remainingVersionNumbers} inspector.
+ *
+ * <p><b>FINDING (confirms/refines the plan's mapping):</b> {@code UserStatusChangedConsumer}'s
+ * hide/unhide is NOT a 3-way switch keyed on the literal status string — {@code
+ * shouldNodesHideByUserStatus} only special-cases {@code CLOSED} (hide); EVERY other status
+ * (including {@code ACTIVE} and {@code MAINTENANCE}) maps to the same "should be visible" value.
+ * The consumer is also a TOGGLE, not a set: {@code shouldChangeHiddenFlag} inspects one arbitrary
+ * node owned by the user and only flips ALL of the user's nodes if that one node's current hidden
+ * flag disagrees with the new status's implied value. So "{@code MAINTENANCE} -> unchanged" is
+ * only true starting from a non-hidden baseline (the normal, freshly-seeded case exercised below);
+ * sending {@code MAINTENANCE} right after a {@code CLOSED} would unhide nodes exactly like {@code
+ * ACTIVE} would, since both are simply "not {@code CLOSED}". Not fixed (Phase-1 forbids {@code
+ * src/main} changes) — documented here and worth a ticket.
+ */
+class BrokerEffectsApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withStorages()
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> findNodeIdsOwnedByRequester() {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", "LOCAL_ROOT")
+            .withBoolean("cascade", true)
+            .withInteger("limit", 20)
+            .withWantedResultFormat("{ nodes { id }, page_token }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+    List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+    return nodes.stream().map(node -> (String) node.get("id")).toList();
+  }
+
+  private HttpResponse download(String nodeId, int version) {
+    return app.send(HttpRequest.of("GET", "/download/" + nodeId + "/" + version, OWNER_COOKIE, null));
+  }
+
+  // --- UserStatusChanged: CLOSED hides, ACTIVE unhides, MAINTENANCE is a no-op ------------
+
+  @Test
+  void givenAVisibleNodeUserStatusChangedClosedThenNodeExcludedFromFindNodes() {
+    // Given
+    String fileId = "00000000-0000-0000-0000-600000000101";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).contains(fileId);
+
+    // When
+    app.backdoor().injectUserStatusChanged(OWNER_ID, "CLOSED");
+
+    // Then — SearchBuilder's base query unconditionally excludes hidden nodes.
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).doesNotContain(fileId);
+  }
+
+  @Test
+  void givenANodeHiddenByAPriorClosedEventUserStatusChangedActiveThenNodeVisibleAgainInFindNodes() {
+    // Given — get to the hidden state the only way the seam allows: via the CLOSED backdoor.
+    String fileId = "00000000-0000-0000-0000-600000000102";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+    app.backdoor().injectUserStatusChanged(OWNER_ID, "CLOSED");
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).doesNotContain(fileId);
+
+    // When
+    app.backdoor().injectUserStatusChanged(OWNER_ID, "ACTIVE");
+
+    // Then
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).contains(fileId);
+  }
+
+  @Test
+  void givenAVisibleNodeUserStatusChangedMaintenanceThenNodeStaysVisible() {
+    // Given — freshly-seeded, non-hidden baseline (see class-level FINDING for why this
+    // starting state matters: MAINTENANCE is a no-op here only because it agrees with the
+    // current "not hidden" state, not because MAINTENANCE is special-cased).
+    String fileId = "00000000-0000-0000-0000-600000000103";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).contains(fileId);
+
+    // When
+    app.backdoor().injectUserStatusChanged(OWNER_ID, "MAINTENANCE");
+
+    // Then
+    Assertions.assertThat(findNodeIdsOwnedByRequester()).contains(fileId);
+  }
+
+  // --- MaxVersionNumberChanged: least-recent versions trimmed, current/keptForever spared -
+
+  @Test
+  void givenANodeWithFiveVersionsMaxVersionNumberChangedToThreeTrimsTheTwoOldest() {
+    // Given — versions 1..5, none kept forever.
+    String fileId = "00000000-0000-0000-0000-600000000104";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"))
+        .addVersion(fileId)
+        .addVersion(fileId)
+        .addVersion(fileId)
+        .addVersion(fileId);
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(fileId))
+        .containsExactly(1, 2, 3, 4, 5);
+
+    // When
+    app.backdoor().injectMaxVersionNumberChanged(3);
+
+    // Then — HTTP-observable via the neutral inspector: oldest two (1, 2) trimmed.
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(fileId))
+        .containsExactly(3, 4, 5);
+  }
+
+  @Test
+  void givenANodeWithKeptForeverAndCurrentVersionsMaxVersionNumberChangedSparesBoth() {
+    // Given — versions 2 and 3 marked keepForever, version 5 is current; only 1 and 4 are
+    // eligible for trimming. Mirrors MaxVersionNumberChangedIT's second scenario.
+    String fileId = "00000000-0000-0000-0000-600000000105";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"))
+        .addVersion(fileId, true)
+        .addVersion(fileId, true)
+        .addVersion(fileId)
+        .addVersion(fileId);
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(fileId))
+        .containsExactly(1, 2, 3, 4, 5);
+
+    // When — requesting max=2 can only actually remove 1 and 4 (2, 3 keptForever; 5 current).
+    app.backdoor().injectMaxVersionNumberChanged(2);
+
+    // Then
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(fileId))
+        .containsExactly(2, 3, 5);
+  }
+
+  @Test
+  void givenATrimmedVersionDownloadOfTheOldVersionReturns404WhileASurvivingVersionStillServes() {
+    // Given — same trim as the first scenario: versions 1, 2 removed; 3, 4, 5 remain.
+    String fileId = "00000000-0000-0000-0000-600000000106";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"))
+        .addVersion(fileId)
+        .addVersion(fileId)
+        .addVersion(fileId)
+        .addVersion(fileId);
+    app.backdoor().injectMaxVersionNumberChanged(3);
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(fileId)).containsExactly(3, 4, 5);
+
+    // When / Then — the trimmed version 1 is gone: BlobService#downloadFile can't find its
+    // FileVersion row, funnelling into the same generic 404 as a non-existent node/version.
+    HttpResponse trimmedDownload = download(fileId, 1);
+    Assertions.assertThat(trimmedDownload.getStatus()).isEqualTo(404);
+    Assertions.assertThat(trimmedDownload.getBodyPayload()).isEqualTo("404 Not Found");
+
+    // A surviving version is unaffected.
+    app.mocks().storagesServesBlob(fileId, 3);
+    HttpResponse survivingDownload = download(fileId, 3);
+    Assertions.assertThat(survivingDownload.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId, 3);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CloneVersionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CloneVersionApiIT.java
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.6 (part 2) of the acceptance coverage-expansion plan: the {@code cloneVersion} mutation
+ * (bound to {@code NodeDataFetcher#cloneVersionFetcher}), driven through {@code
+ * Mocks#storagesCopySucceeds}/{@code storagesCopyFails} and the builder's {@code
+ * withMaxNumberOfVersions(int)} (the total-version cap, {@code maxNumberOfVersions}, read ONCE at
+ * {@code NodeDataFetcher} construction — same seam constraint documented on {@code
+ * KeepVersionsApiIT}). A class-wide cap of 3 is generous enough for the happy/not-found/hard-abort
+ * fixtures (which each seed at most 2 pre-existing versions) while still letting the dedicated cap
+ * test trip it by seeding exactly 3.
+ *
+ * <p><b>FINDING (NEW, more severe than the plan anticipated) — the graceful "version not found"
+ * branch is DEAD CODE, killed by an eager debug-log {@code Optional#get()}:</b> immediately before
+ * the safe {@code fileVersionRepository.getFileVersion(nodeId, versionToClone).map(...).orElse(
+ * fileVersionNotFound(...))} chain, {@code cloneVersionFetcher} builds a debug log line via:
+ *
+ * <pre>{@code
+ * logger.debug(MessageFormat.format(
+ *   "Version to clone {0}, id fetched to clone {1}, node current version {2}",
+ *   versionToClone,
+ *   fileVersionRepository.getFileVersion(nodeId, versionToClone).get().getNodeId(), // unconditional .get()
+ *   node.getCurrentVersion()
+ * ));
+ * }</pre>
+ *
+ * <p>{@code MessageFormat.format}'s arguments are plain Java method arguments, evaluated EAGERLY
+ * regardless of whether DEBUG logging is even enabled — so this {@code .get()} runs on every
+ * call, unconditionally, BEFORE the graceful chain below it ever executes. When {@code
+ * versionToClone} does not correspond to any {@code FileVersion} row, this throws a plain {@code
+ * NoSuchElementException("No value present")} straight out of the {@code
+ * CompletableFuture.supplyAsync} callback. graphql-java's default {@code
+ * SimpleDataFetcherExceptionHandler} (no custom handler is registered — see {@code
+ * GraphQLProvider#setup}) wraps ANY such fetch exception into a field-scoped {@code
+ * ExceptionWhileDataFetching} error, message {@code "Exception while fetching data (/cloneVersion)
+ * : No value present"} (verified empirically and against graphql-java 22.4 bytecode; the same
+ * message shape is asserted elsewhere in this suite, e.g. {@code PublicFindNodesApiIT}'s {@code
+ * "Exception while fetching data (/findNodes) : Invalid token signature"}). The DELIBERATE,
+ * well-formed {@code fileVersionNotFound(nodeId, versionToClone, path)} error on the {@code
+ * .orElse(...)} branch a few lines below can therefore NEVER be produced by a genuinely
+ * non-existent version — asserted below as the REAL (crash-shaped) behaviour, not fixed (Phase 1
+ * forbids {@code src/main} changes).
+ *
+ * <p><b>FINDING — hard abort, unlike copy/move/delete's graceful degradation (see plan §1/§9),
+ * but surfacing as a SINGLE error, not doubled:</b> {@code cloneVersionFetcher}'s filestore-copy
+ * failure path ({@code Try#onFailure(failure -> { ...; throw new AbortExecutionException(error);
+ * })}) THROWS rather than degrading, exactly like the dead-code case above: the exception is
+ * thrown from INSIDE the async {@code CompletableFuture} callback, so it never reaches
+ * graphql-java's synchronous, TOP-LEVEL {@code AbortExecutionException} handling in {@code
+ * ExecutionStrategy#handleNonNullException} — instead it is caught by the SAME {@code
+ * handleFetchingException}/{@code SimpleDataFetcherExceptionHandler} path, producing ONE {@code
+ * ExceptionWhileDataFetching} error (message {@code "Exception while fetching data (/cloneVersion)
+ * : Copy error with nodeId: <id> and version <v>"}) and a null {@code data}. Verified empirically
+ * that — UNLIKE {@code CopyNodesApiIT}'s blocked-destination/filestore-copy-fail cases (which
+ * return a deliberately-null LIST ITEM through a normal {@code DataFetcherResult}, tripping
+ * graphql-java's separate per-item non-null-list-element check for a SECOND error) — a top-level,
+ * non-list {@code File!} field failing via a THROWN fetch exception does NOT also trip a
+ * redundant null-propagation error here: the field is already in an "errored" state from the fetch
+ * exception itself, so graphql-java does not additionally report "wrongly returned a null value"
+ * for it. So "hard abort" is real in the sense that the DATA-FETCHER code deliberately throws
+ * instead of degrading like {@code copyFile}'s {@code Try#onFailure} does — but it surfaces as
+ * exactly ONE ordinary GraphQL error, not a distinct HTTP status, not a doubled error count, and
+ * not a full top-level {@code AbortExecutionException} envelope.
+ */
+class CloneVersionApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withMaxNumberOfVersions(3) // see class javadoc
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse cloneVersion(String nodeId, int version) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("cloneVersion")
+            .withString("node_id", nodeId)
+            .withInteger("version", version)
+            .withWantedResultFormat("{ id version keep_forever cloned_from_version }")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @Test
+  void givenAnExistingVersionCloningItShouldAppendANewVersionMarkedWithTheSourceItWasClonedFrom() {
+    // Given — v2 is kept-forever AND current; cloning it proves the NEW version does NOT inherit
+    // the keep-forever flag from its source (createNewFileVersion(..., false) hardcodes it false)
+    String nodeId = "60000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt")) // v1
+        .addVersion(nodeId, true); // v2, keepForever=true, current
+    app.mocks().storagesCopySucceeds();
+
+    // When — clone v2 (source == current); new version must be current(2) + 1 == 3
+    HttpResponse httpResponse = cloneVersion(nodeId, 2);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> cloned = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "cloneVersion");
+    Assertions.assertThat(cloned)
+        .containsEntry("id", nodeId)
+        .containsEntry("version", 3)
+        .containsEntry("cloned_from_version", 2)
+        .containsEntry("keep_forever", false); // hardcoded false by createNewFileVersion(..., false)
+
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void givenTheTotalVersionCapAlreadyReachedCloningShouldReturnTooManyVersionsError() {
+    // Given — cap is 3 (maxNumberOfVersions); node already has exactly 3 versions
+    String nodeId = "60000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId)
+        .addVersion(nodeId);
+
+    // When — the cap check (`size() >= maxNumberOfVersions`) runs BEFORE the copy attempt, so no
+    // storages mock is required for this scenario to reach its error
+    HttpResponse httpResponse = cloneVersion(nodeId, 1);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + nodeId);
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "cloneVersion")).isEmpty();
+
+    // no new version was created
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void givenAVersionThatDoesNotExistCloningCrashesOnAnEagerDebugLogGetInsteadOfReturningFileVersionNotFound() {
+    // Given — only v1 (current) exists
+    String nodeId = "60000000-0000-0000-0000-000000000003";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When
+    HttpResponse httpResponse = cloneVersion(nodeId, 999);
+
+    // Then — see class javadoc: the well-formed `fileVersionNotFound` branch is dead code; the
+    // REAL behaviour is a NoSuchElementException from the eager debug-log `.get()`, wrapped by
+    // graphql-java into a plain ExceptionWhileDataFetching error.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Exception while fetching data (/cloneVersion) : No value present");
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "cloneVersion")).isEmpty();
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1);
+  }
+
+  @Test
+  void givenAFilestoreCopyFailureCloningShouldHardAbortWithAnExceptionWhileFetchingDataError() {
+    // Given — v1 (source to clone), v2 (current)
+    String nodeId = "60000000-0000-0000-0000-000000000004";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId);
+    app.mocks().storagesCopyFails();
+
+    // When
+    HttpResponse httpResponse = cloneVersion(nodeId, 1);
+
+    // Then — see class javadoc: the AbortExecutionException surfaces as ONE ordinary
+    // ExceptionWhileDataFetching error (NOT a distinct HTTP status, NOT doubled like
+    // CopyNodesApiIT's blocked-destination cases — those are a deliberately-null LIST item, a
+    // different graphql-java mechanism than a thrown fetch exception on a single object field).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Exception while fetching data (/cloneVersion) : Copy error with nodeId: " + nodeId + " and version 1");
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "cloneVersion")).isEmpty();
+
+    // no new version row was created (createNewFileVersion only runs inside Try#onSuccess, which
+    // never fires on a copy failure) — unlike copyFile's Try#onFailure, cloneVersion's failure
+    // path does not need to roll anything back because nothing was ever written
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CopyNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CopyNodesApiIT.java
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.5 of the acceptance coverage-expansion plan: the {@code copyNodes} mutation (bound to
+ * {@code NodeDataFetcher#copyNodesFetcher}), driven through {@code Mocks#storagesCopySucceeds}/
+ * {@code storagesCopyFails} and seeded via {@code PopulatorNode}/{@code DatabasePopulator}.
+ *
+ * <p><b>Reading the source (behaviour this class pins down):</b>
+ *
+ * <ul>
+ *   <li>The requester needs {@code READ_AND_WRITE} on {@code destination_id}, which must resolve
+ *       to an existing {@code FOLDER}/{@code ROOT} node. Both a non-existent destination and an
+ *       existing-but-wrong-type destination fall through the SAME top-level {@code if}/{@code
+ *       else} into the SAME single-element {@code nodeWriteError(destination_id)} result — there
+ *       is no separate not-found branch here (unlike {@code createFolder}'s two-branch shape).
+ *   <li>Each source node only needs {@code canRead()} (a plain {@code READ_ONLY} share suffices).
+ *   <li>A source {@code FOLDER} is excluded from the copy (and reported via {@code
+ *       nodeWriteError(sourceId)}, NOT a distinct "descendant" error) when the destination is
+ *       nested somewhere under it (i.e. the destination's ancestor chain contains the source's
+ *       id) — UNLESS the source's own current parent IS the destination, which is the explicit
+ *       "copy a folder into its own parent" exception carved out in the filter condition.
+ *   <li>Name-clash handling reuses {@code searchAlternativeName} exactly like {@code createFolder}/
+ *       upload (" (1)" suffix, extension preserved separately for files).
+ *   <li>A filestore-copy failure ({@code copyFile}'s {@code Try#onFailure}) deletes the just-created
+ *       node row and reports {@code nodeCopyError(sourceId, sourceVersion, path)} — using the
+ *       SOURCE node's id/version, not the (deleted) destination copy's. This degrades gracefully,
+ *       unlike {@code cloneVersion}'s hard abort on the same failure (a separate, already-filed
+ *       finding — not exercised here).
+ *   <li>Both single-element-error shapes above (destination-rejected and per-source-node
+ *       rejected/failed) leave the {@code copyNodes} GraphQL list value itself {@code null} (the
+ *       schema declares {@code copyNodes: [Node!]}, so a single non-null list item resolving to
+ *       null propagates to the nearest nullable ancestor, the list field) while the top-level
+ *       {@code errors} array still carries the message — asserted below via the {@code errors}
+ *       array and via an EMPTY {@code data} extraction (which reads the same whether the raw JSON
+ *       is {@code null} or {@code []}), not by asserting the raw JSON shape of {@code data} itself.
+ * </ul>
+ */
+class CopyNodesApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse copyNodes(String[] nodeIds, String destinationId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("copyNodes")
+            .withListOfStrings("node_ids", nodeIds)
+            .withString("destination_id", destinationId)
+            .withWantedResultFormat(
+                "{ id name parent { id } owner { id } ... on File { extension } }")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> copiedNodes(HttpResponse httpResponse) {
+    Map<String, Object> page =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "copyNodes");
+    Object data = page.get("data");
+    return data == null ? List.of() : (List<Map<String, Object>>) data;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> childrenOf(String folderId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", folderId)
+            .withWantedResultFormat(
+                "{ ... on Folder { children(limit: 50, sort: NAME_ASC) { nodes { id name } } } }")
+            .build();
+    HttpResponse httpResponse = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Map<String, Object> children = (Map<String, Object>) node.get("children");
+    return (List<Map<String, Object>>) children.get("nodes");
+  }
+
+  @Test
+  void givenAPlainFileCopyItShouldCreateACopyInDestinationAndLeaveTheOriginalIntact() {
+    // Given
+    String sourceId = "40000000-0000-0000-0000-000000000001";
+    String destFolderId = "40000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "source.txt"))
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    List<Map<String, Object>> copied = copiedNodes(httpResponse);
+    Assertions.assertThat(copied).hasSize(1);
+    Map<String, Object> copiedNode = copied.get(0);
+    Assertions.assertThat(copiedNode.get("id")).isNotEqualTo(sourceId);
+    Assertions.assertThat(copiedNode).containsEntry("name", "source").containsEntry("extension", "txt");
+    Assertions.assertThat((Map<String, Object>) copiedNode.get("parent")).containsEntry("id", destFolderId);
+
+    // the source is a COPY, not a move: it still exists, unchanged, at its original location
+    Assertions.assertThat(app.backdoor().nodeExists(sourceId)).isTrue();
+    Assertions.assertThat(childrenOf("LOCAL_ROOT", REQUESTER_COOKIE))
+        .extracting(node -> node.get("id"))
+        .contains(sourceId);
+  }
+
+  @Test
+  void givenAFolderWithNestedContentCopyShouldCascadeAllDescendants() {
+    // Given — srcFolder/child.txt, srcFolder/subFolder/grandchild.txt
+    String srcFolderId = "40000000-0000-0000-0000-000000000101";
+    String childFileId = "40000000-0000-0000-0000-000000000102";
+    String subFolderId = "40000000-0000-0000-0000-000000000103";
+    String grandchildFileId = "40000000-0000-0000-0000-000000000104";
+    String destFolderId = "40000000-0000-0000-0000-000000000105";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(srcFolderId, REQUESTER_ID, "srcFolder"))
+        .addNode(
+            new PopulatorNode(
+                childFileId, REQUESTER_ID, REQUESTER_ID, srcFolderId, "child.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + srcFolderId, 1L, "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                subFolderId, REQUESTER_ID, REQUESTER_ID, srcFolderId, "subFolder", "",
+                NodeType.FOLDER, "LOCAL_ROOT," + srcFolderId, 0L, null))
+        .addNode(
+            new PopulatorNode(
+                grandchildFileId, REQUESTER_ID, REQUESTER_ID, subFolderId, "grandchild.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + srcFolderId + "," + subFolderId, 1L, "text/plain"))
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest2"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {srcFolderId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> copied = copiedNodes(httpResponse);
+    Assertions.assertThat(copied).hasSize(1);
+    String copiedFolderId = (String) copied.get(0).get("id");
+    Assertions.assertThat(copiedFolderId).isNotEqualTo(srcFolderId);
+    Assertions.assertThat(copied.get(0)).containsEntry("name", "srcFolder");
+
+    List<Map<String, Object>> copiedFolderChildren = childrenOf(copiedFolderId, REQUESTER_COOKIE);
+    Assertions.assertThat(copiedFolderChildren)
+        .extracting(node -> node.get("name"))
+        .containsExactlyInAnyOrder("child", "subFolder");
+
+    String copiedSubFolderId =
+        copiedFolderChildren.stream()
+            .filter(node -> "subFolder".equals(node.get("name")))
+            .findFirst()
+            .orElseThrow()
+            .get("id")
+            .toString();
+    Assertions.assertThat(copiedSubFolderId).isNotEqualTo(subFolderId);
+    List<Map<String, Object>> copiedSubChildren = childrenOf(copiedSubFolderId, REQUESTER_COOKIE);
+    Assertions.assertThat(copiedSubChildren).extracting(node -> node.get("name")).containsExactly("grandchild");
+
+    // the original subtree is untouched
+    Assertions.assertThat(app.backdoor().nodeExists(srcFolderId)).isTrue();
+    Assertions.assertThat(app.backdoor().nodeExists(childFileId)).isTrue();
+    Assertions.assertThat(app.backdoor().nodeExists(subFolderId)).isTrue();
+    Assertions.assertThat(app.backdoor().nodeExists(grandchildFileId)).isTrue();
+  }
+
+  @Test
+  void givenANameClashInDestinationCopyShouldDedupTheName() {
+    // Given — destination already has a file named "clash.txt"
+    String destFolderId = "40000000-0000-0000-0000-000000000201";
+    String existingId = "40000000-0000-0000-0000-000000000202";
+    String sourceId = "40000000-0000-0000-0000-000000000203";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest3"))
+        .addNode(
+            new PopulatorNode(
+                existingId, REQUESTER_ID, REQUESTER_ID, destFolderId, "clash.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + destFolderId, 1L, "text/plain"))
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "clash.txt"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> copied = copiedNodes(httpResponse);
+    Assertions.assertThat(copied).hasSize(1);
+    Assertions.assertThat(copied.get(0)).containsEntry("name", "clash (1)").containsEntry("extension", "txt");
+  }
+
+  @Test
+  void givenNoNameClashCopyShouldKeepTheOriginalName() {
+    // Given — destination has an unrelated file; no clash with the source's name
+    String destFolderId = "40000000-0000-0000-0000-000000000211";
+    String existingId = "40000000-0000-0000-0000-000000000212";
+    String sourceId = "40000000-0000-0000-0000-000000000213";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest4"))
+        .addNode(
+            new PopulatorNode(
+                existingId, REQUESTER_ID, REQUESTER_ID, destFolderId, "other.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + destFolderId, 1L, "text/plain"))
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "unique.txt"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> copied = copiedNodes(httpResponse);
+    Assertions.assertThat(copied).hasSize(1);
+    Assertions.assertThat(copied.get(0)).containsEntry("name", "unique").containsEntry("extension", "txt");
+  }
+
+  @Test
+  void givenSourceWithOnlyReadPermissionCopyShouldSucceed() {
+    // Given — source owned by OTHER_USER_ID, shared READ_ONLY (no write) with the requester
+    String sourceId = "40000000-0000-0000-0000-000000000301";
+    String destFolderId = "40000000-0000-0000-0000-000000000302";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(sourceId, OTHER_USER_ID, "shared.txt"))
+        .addShare(sourceId, REQUESTER_ID, ACL.SharePermission.READ_ONLY)
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest5"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(copiedNodes(httpResponse)).hasSize(1);
+  }
+
+  @Test
+  void givenCopyIntoOwnDescendantItShouldBeBlockedWithNodeWriteError() {
+    // Given — parentF contains childF; copying parentF INTO childF would nest it inside its own
+    // descendant
+    String parentFolderId = "40000000-0000-0000-0000-000000000401";
+    String childFolderId = "40000000-0000-0000-0000-000000000402";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, REQUESTER_ID, "parentF"))
+        .addNode(
+            new PopulatorNode(
+                childFolderId, REQUESTER_ID, REQUESTER_ID, parentFolderId, "childF", "",
+                NodeType.FOLDER, "LOCAL_ROOT," + parentFolderId, 0L, null));
+
+    // When
+    HttpResponse httpResponse =
+        copyNodes(new String[] {parentFolderId}, childFolderId, REQUESTER_COOKIE);
+
+    // Then — the single blocked source node bubbles TWO errors: the app's own nodeWriteError, PLUS
+    // a graphql-java-generated null-propagation error (see class javadoc) because the schema
+    // declares `copyNodes: [Node!]` (non-null items) and this one item resolved with a null value.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + parentFolderId);
+    Assertions.assertThat(copiedNodes(httpResponse)).isEmpty();
+    Assertions.assertThat(childrenOf(childFolderId, REQUESTER_COOKIE)).isEmpty();
+  }
+
+  @Test
+  void givenCopyIntoItsOwnCurrentParentItShouldBeAllowedAndDedupTheName() {
+    // Given — childF7 already sits inside parentF7; copying it back into parentF7 (its OWN
+    // current parent) is the explicit exception to the descendant-block rule, and collides with
+    // itself by name
+    String parentFolderId = "40000000-0000-0000-0000-000000000411";
+    String folderId = "40000000-0000-0000-0000-000000000412";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, REQUESTER_ID, "parentF7"))
+        .addNode(
+            new PopulatorNode(
+                folderId, REQUESTER_ID, REQUESTER_ID, parentFolderId, "childF7", "",
+                NodeType.FOLDER, "LOCAL_ROOT," + parentFolderId, 0L, null));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {folderId}, parentFolderId, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    List<Map<String, Object>> copied = copiedNodes(httpResponse);
+    Assertions.assertThat(copied).hasSize(1);
+    Assertions.assertThat(copied.get(0).get("id")).isNotEqualTo(folderId);
+    Assertions.assertThat(copied.get(0)).containsEntry("name", "childF7 (1)");
+  }
+
+  @Test
+  void givenANonExistentDestinationCopyShouldReturnNodeWriteError() {
+    // Given
+    String sourceId = "40000000-0000-0000-0000-000000000501";
+    String nonExistentDest = "40000000-0000-0000-0000-00000000ffff";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "src8.txt"));
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, nonExistentDest, REQUESTER_COOKIE);
+
+    // Then — see the descendant-block test above for why this is 2 errors, not 1
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + nonExistentDest);
+    Assertions.assertThat(copiedNodes(httpResponse)).isEmpty();
+  }
+
+  @Test
+  void givenADestinationThatIsAFileNotAFolderCopyShouldReturnTheSameNodeWriteError() {
+    // Given — destination exists and the requester owns it (so permission alone would pass), but
+    // it is a FILE, not a FOLDER/ROOT
+    String sourceId = "40000000-0000-0000-0000-000000000511";
+    String destFileId = "40000000-0000-0000-0000-000000000512";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "src9.txt"))
+        .addNode(new SimplePopulatorTextFile(destFileId, REQUESTER_ID, "notAFolder.txt"));
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFileId, REQUESTER_COOKIE);
+
+    // Then — see the descendant-block test above for why this is 2 errors, not 1
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + destFileId);
+  }
+
+  @Test
+  void givenNoWritePermissionOnDestinationCopyShouldReturnNodeWriteError() {
+    // Given — destination folder owned by OTHER_USER_ID, never shared with the requester
+    String sourceId = "40000000-0000-0000-0000-000000000521";
+    String destFolderId = "40000000-0000-0000-0000-000000000522";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "src10.txt"))
+        .addNode(new SimplePopulatorFolder(destFolderId, OTHER_USER_ID, "privateDest"));
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then — see the descendant-block test above for why this is 2 errors, not 1
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + destFolderId);
+  }
+
+  @Test
+  void givenAFilestoreCopyFailureCopyShouldReturnNodeCopyErrorAndLeaveNoOrphan() {
+    // Given
+    String sourceId = "40000000-0000-0000-0000-000000000601";
+    String destFolderId = "40000000-0000-0000-0000-000000000602";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "src11.txt"))
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "dest11"));
+    app.mocks().storagesCopyFails();
+
+    // When
+    HttpResponse httpResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+
+    // Then — copyFile's Try#onFailure deletes the just-created node row and reports the error
+    // using the SOURCE node's id/version (a freshly-seeded file's current version is 1). See the
+    // descendant-block test above for why this is 2 errors, not 1.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while copying the node " + sourceId + " with version 1");
+    Assertions.assertThat(copiedNodes(httpResponse)).isEmpty();
+
+    // the source is untouched, and no orphan row was left behind in the destination
+    Assertions.assertThat(app.backdoor().nodeExists(sourceId)).isTrue();
+    Assertions.assertThat(childrenOf(destFolderId, REQUESTER_COOKIE)).isEmpty();
+  }
+
+  @Test
+  void givenACopyIntoASharedFolderItShouldNotifyTheShareTargetWithAddedNodeTypeCopy() {
+    // Given — destination folder owned by the requester, shared with OTHER_USER_ID
+    String destFolderId = "40000000-0000-0000-0000-000000000701";
+    String sourceId = "40000000-0000-0000-0000-000000000702";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, REQUESTER_ID, "sharedDest12"))
+        .addShare(destFolderId, OTHER_USER_ID, ACL.SharePermission.READ_AND_WRITE)
+        .addNode(new SimplePopulatorTextFile(sourceId, REQUESTER_ID, "toCopy12.txt"));
+    app.mocks().storagesCopySucceeds();
+
+    // When
+    HttpResponse copyResponse = copyNodes(new String[] {sourceId}, destFolderId, REQUESTER_COOKIE);
+    Assertions.assertThat(copyResponse.getStatus()).isEqualTo(200);
+
+    String notificationsPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNotifications")
+            .withBoolean("update_last_seen", true)
+            .withWantedResultFormat(
+                "{ notifications { ... on AddedNode { added_node_type added_node { node_id } } } }")
+            .build();
+    HttpResponse notificationsResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OTHER_COOKIE, notificationsPayload));
+
+    // Then
+    Assertions.assertThat(notificationsResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page =
+        TestUtils.jsonResponseToMap(notificationsResponse.getBodyPayload(), "getNotifications");
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
+    Assertions.assertThat(notifications).hasSize(1);
+    Assertions.assertThat(notifications.get(0)).containsEntry("added_node_type", "COPY");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateCollaborationLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateCollaborationLinkApiIT.java
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 3.1 of the acceptance coverage-expansion plan: {@code createCollaborationLink} mutation,
+ * exercising {@code CollaborationLinkDataFetcher#createCollaborationLink} (0% before this file).
+ *
+ * <p><b>URL shape:</b> {@code <domain><Endpoints.COLLABORATION_LINK_URL><8-char invitationId>}
+ * (here {@code example.com/services/files/invite/<8 chars>}). The invitation id is deliberately
+ * 8 alphanumeric characters — distinct from the 36-char UUID {@code id} field of the link itself
+ * — matching {@code CollaborationLinkRepository#createLink}'s {@code invitationId} contract (see
+ * also {@code InviteRedirectApiIT}, which consumes this same 8-char id via {@code GET
+ * /invite/{id}}).
+ *
+ * <p><b>Permission gate:</b> {@code CollaborationLinkDataFetcher#createCollaborationLink} checks
+ * {@code permissionsChecker.getPermissions(nodeId, requesterId).has(permission)} where {@code
+ * permission} is literally the mutation's {@code permission} argument — the requester must
+ * ALREADY hold (as a bitwise subset of their own ACL) the exact tier they are requesting a link
+ * for. A missing node maps to {@code ACL.NONE} (see {@code PermissionsChecker#getPermissions}), so
+ * a non-existing node collapses into the identical {@code nodeWriteError} shape as a genuine
+ * permission denial — asserted explicitly below rather than assumed.
+ */
+class CreateCollaborationLinkApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String SHARE_TARGET_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String NODE_ID = "00000000-0000-0000-0000-000000000000";
+  private static final String URL_PREFIX = "example.com/services/files/invite/";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", SHARE_TARGET_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void createFile(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+  }
+
+  private void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
+  }
+
+  private HttpResponse createCollaborationLink(
+      String cookie, String nodeId, SharePermission permission) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createCollaborationLink")
+            .withString("node_id", nodeId)
+            .withEnumLiteral("permission", permission.name())
+            .withWantedResultFormat("{ id url created_at permission node { id } }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenAnOwnerTheCreateCollaborationLinkShouldCreateANewLinkWithTheExpectedShape() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+
+    // When
+    HttpResponse httpResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> link =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createCollaborationLink");
+
+    String id = (String) link.get("id");
+    String url = (String) link.get("url");
+    Assertions.assertThat(id).isNotNull().hasSize(36);
+    Assertions.assertThat(url).startsWith(URL_PREFIX).hasSize(URL_PREFIX.length() + 8);
+    Assertions.assertThat(link).containsEntry("permission", "READ_AND_SHARE");
+    Assertions.assertThat((Map<String, Object>) link.get("node")).containsEntry("id", NODE_ID);
+    Assertions.assertThat(link.get("created_at")).isNotNull();
+  }
+
+  @Test
+  void givenAnExistingLinkWithTheSamePermissionTheCreateCollaborationLinkShouldReturnItIdempotently() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+    HttpResponse first =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_AND_SHARE);
+    String firstId =
+        (String)
+            TestUtils.jsonResponseToMap(first.getBodyPayload(), "createCollaborationLink")
+                .get("id");
+
+    // When — same node, same requester, same permission tier requested again
+    HttpResponse second =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // Then — the system returns the EXISTING link, it does not create a duplicate
+    Assertions.assertThat(second.getStatus()).isEqualTo(200);
+    Map<String, Object> link =
+        TestUtils.jsonResponseToMap(second.getBodyPayload(), "createCollaborationLink");
+    Assertions.assertThat(link.get("id")).isEqualTo(firstId);
+  }
+
+  @Test
+  void givenADifferentPermissionTheCreateCollaborationLinkShouldCreateASecondDistinctLink() {
+    // Given — a node can have at most 2 collaboration links, one per R/W tier
+    createFile(NODE_ID, OWNER_ID);
+    HttpResponse readShareResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_AND_SHARE);
+    String readShareId =
+        (String)
+            TestUtils.jsonResponseToMap(readShareResponse.getBodyPayload(), "createCollaborationLink")
+                .get("id");
+
+    // When
+    HttpResponse readWriteShareResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+
+    // Then — a second, distinct link is created for the other tier
+    Assertions.assertThat(readWriteShareResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> link =
+        TestUtils.jsonResponseToMap(readWriteShareResponse.getBodyPayload(), "createCollaborationLink");
+    Assertions.assertThat(link.get("id")).isNotNull().isNotEqualTo(readShareId);
+    Assertions.assertThat(link).containsEntry("permission", "READ_WRITE_AND_SHARE");
+  }
+
+  @Test
+  void givenAShareTargetWithoutShareRightsTheCreateCollaborationLinkShouldReturnAPermissionDeniedError() {
+    // Given — READ_ONLY carries no SHARE bit
+    createFile(NODE_ID, OWNER_ID);
+    createShare(NODE_ID, SHARE_TARGET_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token-b", NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + NODE_ID);
+  }
+
+  @Test
+  void givenAShareTargetWithWriteButNoShareRightsTheCreateCollaborationLinkShouldReturnAPermissionDeniedError() {
+    // Given — READ_AND_WRITE has the WRITE bit but not the SHARE bit: holding write alone is not
+    // enough to request a share-tier collaboration link (documents that the gate checks the
+    // exact requested tier, not just "some" permission)
+    createFile(NODE_ID, OWNER_ID);
+    createShare(NODE_ID, SHARE_TARGET_ID, SharePermission.READ_AND_WRITE);
+
+    // When
+    HttpResponse httpResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token-b", NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + NODE_ID);
+  }
+
+  @Test
+  void givenANonExistingNodeTheCreateCollaborationLinkShouldReturnTheSamePermissionDeniedErrorShape() {
+    // Given — no node is created at all: PermissionsChecker#getPermissions maps a missing node to
+    // ACL.NONE, the same shape as an existing-but-forbidden node (mirrors the analogous finding in
+    // AuthenticatedDownloadApiIT/CreatePublicLinkApiIT for their respective operations)
+
+    // When
+    HttpResponse httpResponse =
+        createCollaborationLink(
+            "ZM_AUTH_TOKEN=fake-token", NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + NODE_ID);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateFolderApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateFolderApiIT.java
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.5 (part 1) of the acceptance coverage-expansion plan: direct HTTP coverage of {@code
+ * createFolder}, which so far has only been exercised indirectly as a notification trigger (see
+ * {@code AddedNodeNotificationCreateApiIT}). Covers happy path (including owner inheritance in a
+ * shared parent), name-collision dedup, permission-denied, and parent-not-found/wrong-type.
+ *
+ * <p><b>FINDING (overrides the plan's combined "not-found/wrong-type" prediction):</b> {@code
+ * createFolderFetcher} checks {@code permissionsChecker.getPermissions(parentId,
+ * requesterId).has(READ_AND_WRITE)} BEFORE it ever calls {@code nodeRepository.getNode(parentId)}.
+ * {@code PermissionsChecker#getPermissions} returns {@code ACL.NONE} for ANY non-existent node id
+ * (its {@code Optional<Node>} lookup is empty, so it falls through to {@code
+ * ACL.decode(ACL.NONE)}), which always fails the {@code READ_AND_WRITE} check. So a genuinely
+ * non-existent {@code destination_id} is rejected by the PERMISSION branch and returns {@code
+ * nodeWriteError}, NOT {@code nodeNotFound} — the plan's predicted {@code nodeNotFound} message is
+ * only reachable for the DIFFERENT "wrong type" scenario (parent exists, requester already has
+ * write permission on it, but it is a {@code FILE} rather than a {@code FOLDER}/{@code ROOT}).
+ * These two scenarios are asserted separately below with their real, different error shapes.
+ */
+class CreateFolderApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse createFolder(String destinationId, String name, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createFolder")
+            .withString("destination_id", destinationId)
+            .withString("name", name)
+            .withWantedResultFormat("{ id name owner { id } }")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @Test
+  void givenValidDestinationCreateFolderShouldReturnTheNewFolder() {
+    // When
+    HttpResponse httpResponse = createFolder("LOCAL_ROOT", "newFolder", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> folder = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
+    Assertions.assertThat(folder).containsEntry("name", "newFolder");
+    Assertions.assertThat(((Map<String, Object>) folder.get("owner"))).containsEntry("id", REQUESTER_ID);
+    Assertions.assertThat(app.backdoor().nodeExists((String) folder.get("id"))).isTrue();
+  }
+
+  @Test
+  void givenParentFolderOwnedBySomeoneElseCreateFolderShouldInheritTheParentOwner() {
+    // Given — parent folder owned by OTHER_USER_ID, shared with the requester with write access
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder("10000000-0000-0000-0000-000000000001", OTHER_USER_ID, "sharedParent"))
+        .addShare(
+            "10000000-0000-0000-0000-000000000001", REQUESTER_ID, ACL.SharePermission.READ_AND_WRITE);
+
+    // When
+    HttpResponse httpResponse =
+        createFolder("10000000-0000-0000-0000-000000000001", "childFolder", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — the new folder's owner is the PARENT's owner, not the requester who created it
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> folder = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
+    Assertions.assertThat(((Map<String, Object>) folder.get("owner"))).containsEntry("id", OTHER_USER_ID);
+  }
+
+  @Test
+  void givenADuplicateNameCreateFolderShouldDedupTheName() {
+    // Given
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder("10000000-0000-0000-0000-000000000001", REQUESTER_ID, "sameName"));
+
+    // When
+    HttpResponse httpResponse = createFolder("LOCAL_ROOT", "sameName", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> folder = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
+    Assertions.assertThat(folder).containsEntry("name", "sameName (1)");
+  }
+
+  @Test
+  void givenNoWritePermissionOnParentCreateFolderShouldReturnNodeWriteError() {
+    // Given — parent folder owned by OTHER_USER_ID, no share at all with the requester
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder("10000000-0000-0000-0000-000000000001", OTHER_USER_ID, "privateParent"));
+
+    // When
+    HttpResponse httpResponse =
+        createFolder("10000000-0000-0000-0000-000000000001", "childFolder", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: "
+                + "10000000-0000-0000-0000-000000000001");
+  }
+
+  /**
+   * See the class-level FINDING: a non-existent parent fails the READ_AND_WRITE permission gate
+   * (ACL.NONE for a missing node) BEFORE the not-found filter is ever reached, so the real error
+   * is {@code nodeWriteError}, not {@code nodeNotFound}.
+   */
+  @Test
+  void givenNonExistentParentCreateFolderShouldReturnNodeWriteErrorNotNodeNotFound() {
+    // Given — a syntactically-valid (36-char) but non-existent parent id
+    String nonExistentParentId = "10000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse = createFolder(nonExistentParentId, "childFolder", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + nonExistentParentId);
+  }
+
+  @Test
+  void givenParentIsAFileNotAFolderCreateFolderShouldReturnNodeNotFound() {
+    // Given
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile("00000000-0000-0000-0000-000000000001", REQUESTER_ID, "aFile.txt"));
+
+    // When
+    HttpResponse httpResponse =
+        createFolder("00000000-0000-0000-0000-000000000001", "childFolder", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — the parent exists, but createFolder filters it out for having the wrong node type
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id 00000000-0000-0000-0000-000000000001");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CreatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CreatePublicLinkApiIT.java
@@ -2,20 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -34,10 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class CreatePublicLinkApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static ShareRepository shareRepository;
+  static FilesTestApp app;
 
   // It is needed since strings cannot be generated as constants in the @ValueSource definition
   static Stream<Arguments> invalidAccessCodesProvider() {
@@ -49,9 +41,8 @@ class CreatePublicLinkApiIT {
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -60,37 +51,29 @@ class CreatePublicLinkApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-account-for-sharing",
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
-            .build()
-            .start();
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFile(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
   }
 
   void createFolder(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorFolder(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(nodeId, ownerId));
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addShare(nodeId, targetUserId, permission);
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
   }
 
   @Test
@@ -110,8 +93,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -146,8 +128,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -183,8 +164,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -220,8 +200,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -253,8 +232,7 @@ class CreatePublicLinkApiIT {
       HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-      TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -280,8 +258,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -312,8 +289,7 @@ class CreatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -343,8 +319,7 @@ class CreatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -372,8 +347,7 @@ class CreatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -390,8 +364,7 @@ class CreatePublicLinkApiIT {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addLinks("00000000-0000-0000-0000-000000000000", 50);
+    app.backdoor().populator().addLinks("00000000-0000-0000-0000-000000000000", 50);
 
     final String bodyPayload =
         GraphqlCommandBuilder.aMutationBuilder("createLink")
@@ -403,8 +376,7 @@ class CreatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateShareApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/CreateShareApiIT.java
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NEW canonical file: the {@code createShare}/{@code getShare} queries (bound to {@code
+ * ShareDataFetcher#createShareFetcher}/{@code getShareFetcher}) had no dedicated direct coverage —
+ * every other {@code *ApiIT} only ever calls {@code createShare} as a happy-path SETUP trigger
+ * (always with permission, never targeting the node's own owner, never on a multi-level folder
+ * tree), so several real branches were never exercised:
+ *
+ * <ul>
+ *   <li>{@code createShare} permission-denied ({@code READ_AND_SHARE} missing) -&gt; {@code
+ *       shareCreationError}.
+ *   <li>{@code createShare} targeting the shared node's OWN owner -&gt; {@code shareCreationError}
+ *       (self-share is rejected).
+ *   <li>{@code createShare} on a folder with a NESTED sub-folder -&gt; {@code
+ *       ShareDataFetcher#cascadeUpsertShare}'s {@code getNodeType() == FOLDER} recursion branch,
+ *       which every existing single-level-share test never reaches (needs a folder-type CHILD to
+ *       recurse into).
+ *   <li>{@code getShare} permission-denied -&gt; {@code shareNotfound}.
+ *   <li>{@code deleteShares} on a FOLDER (not a file) -&gt; the {@code getNodeType() == FOLDER}
+ *       cascade-trigger branch and {@code cascadeDeleteShare}'s own body, neither reached by
+ *       {@code DeleteSharesApiIT} (file-only).
+ * </ul>
+ */
+class CreateShareApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String TARGET_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String TARGET_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", TARGET_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse createShare(
+      String nodeId, String targetUserId, SharePermission permission, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createShare")
+            .withString("node_id", nodeId)
+            .withString("share_target_id", targetUserId)
+            .withEnum("permission", permission)
+            .withWantedResultFormat("{ created_at }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  private HttpResponse getShare(String nodeId, String targetUserId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getShare")
+            .withString("node_id", nodeId)
+            .withString("share_target_id", targetUserId)
+            .withWantedResultFormat("{ permission }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @Test
+  void givenShareRightsCreateShareShouldSucceed() {
+    // Given
+    String nodeId = "80000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When
+    HttpResponse httpResponse =
+        createShare(nodeId, TARGET_ID, SharePermission.READ_ONLY, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, TARGET_ID)).isTrue();
+  }
+
+  @Test
+  void givenNoShareRightsCreateShareShouldReturnShareCreationError() {
+    // Given — owned by OWNER_ID, never shared with the requester at all (no READ_AND_SHARE)
+    String nodeId = "80000000-0000-0000-0000-000000000002";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When — a third, unrelated user attempts to create a share on a node they cannot access
+    HttpResponse httpResponse =
+        createShare(nodeId, TARGET_ID, SharePermission.READ_ONLY, TARGET_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not create share for node: " + nodeId + " and user: " + TARGET_ID);
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, TARGET_ID)).isFalse();
+  }
+
+  @Test
+  void givenTheNodesOwnOwnerAsTargetCreateShareShouldReturnShareCreationError() {
+    // Given
+    String nodeId = "80000000-0000-0000-0000-000000000003";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When — the owner tries to share the node with themselves
+    HttpResponse httpResponse =
+        createShare(nodeId, OWNER_ID, SharePermission.READ_ONLY, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not create share for node: " + nodeId + " and user: " + OWNER_ID);
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, OWNER_ID)).isFalse();
+  }
+
+  @Test
+  void givenAFolderWithANestedSubFolderCreateShareShouldCascadeToTheGrandchild() {
+    // Given — folder/subFolder/grandchild.txt, all owned by OWNER_ID; sharing the TOP folder must
+    // recurse THROUGH the folder-type child (subFolder) to reach the file-type grandchild — the
+    // single-level shares used everywhere else in the suite never exercise this recursion branch.
+    String topFolderId = "80000000-0000-0000-0000-000000000101";
+    String subFolderId = "80000000-0000-0000-0000-000000000102";
+    String grandchildId = "80000000-0000-0000-0000-000000000103";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(topFolderId, OWNER_ID, "topFolder"))
+        .addNode(
+            new PopulatorNode(
+                subFolderId, OWNER_ID, OWNER_ID, topFolderId, "subFolder", "",
+                NodeType.FOLDER, "LOCAL_ROOT," + topFolderId, 0L, null))
+        .addNode(
+            new PopulatorNode(
+                grandchildId, OWNER_ID, OWNER_ID, subFolderId, "grandchild.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + topFolderId + "," + subFolderId, 1L, "text/plain"));
+
+    // When
+    HttpResponse httpResponse =
+        createShare(topFolderId, TARGET_ID, SharePermission.READ_ONLY, OWNER_COOKIE);
+
+    // Then — the share cascaded all the way down to the grandchild file
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().shareExists(topFolderId, TARGET_ID)).isTrue();
+    Assertions.assertThat(app.backdoor().shareExists(subFolderId, TARGET_ID)).isTrue();
+    Assertions.assertThat(app.backdoor().shareExists(grandchildId, TARGET_ID)).isTrue();
+  }
+
+  @Test
+  void givenNoPermissionGetShareShouldReturnShareNotFoundError() {
+    // Given — a real share exists, but the CALLER has no rights to read it at all
+    String nodeId = "80000000-0000-0000-0000-000000000201";
+    String thirdUserId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addShare(nodeId, thirdUserId, SharePermission.READ_ONLY);
+
+    // When — TARGET_ID has no share/permission on this node at all
+    HttpResponse httpResponse = getShare(nodeId, thirdUserId, TARGET_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find share for node: " + nodeId + " and user " + thirdUserId);
+  }
+
+  @Test
+  void givenAFolderWithASharedChildDeleteSharesOnTheFolderShouldCascadeDeleteToTheChild() {
+    // Given — folder shared to TARGET_ID (creating a DIRECT share on the folder AND an INHERITED
+    // one on its child via createShareFetcher's own cascadeUpsertShare); deleting the share on the
+    // FOLDER must cascade the deletion down to the child too (deleteSharesFetcher's
+    // `getNodeType() == FOLDER` branch, unreached by DeleteSharesApiIT which only ever uses files).
+    String folderId = "80000000-0000-0000-0000-000000000301";
+    String childId = "80000000-0000-0000-0000-000000000302";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(folderId, OWNER_ID, "folder"))
+        .addNode(
+            new PopulatorNode(
+                childId, OWNER_ID, OWNER_ID, folderId, "child.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"));
+
+    HttpResponse createResponse =
+        createShare(folderId, TARGET_ID, SharePermission.READ_ONLY, OWNER_COOKIE);
+    Assertions.assertThat(createResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().shareExists(childId, TARGET_ID))
+        .as("the child must have inherited the share before we can prove cascade-delete removes it")
+        .isTrue();
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteShares")
+            .withString("node_id", folderId)
+            .withListOfStrings("share_target_ids", new String[] {TARGET_ID})
+            .withWantedResultFormat("")
+            .build();
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then — both the folder's own share AND the child's inherited share are gone
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().shareExists(folderId, TARGET_ID)).isFalse();
+    Assertions.assertThat(app.backdoor().shareExists(childId, TARGET_ID)).isFalse();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DateTimeScalarApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DateTimeScalarApiIT.java
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Gap-closing pass: {@code DateTimeScalar}'s coercion edges (the {@code DateTime} custom scalar
+ * bound to, among other fields, {@code createLink(expires_at:)}). Every existing test in the suite
+ * that touches {@code expires_at} passes a plain unquoted integer literal (via {@code
+ * GraphqlCommandBuilder#withInteger}) — this always takes the SAME two branches:
+ * {@code parseLiteral}'s {@code instanceof IntValue} (true), and never touches {@code parseValue}
+ * at all (that method only runs for variable-supplied values, and no test in this suite uses
+ * GraphQL {@code variables} before this file).
+ *
+ * <h2>{@code parseLiteral} (inline literal in the query text)</h2>
+ *
+ * <ul>
+ *   <li>{@code instanceof StringValue} true (a QUOTED numeric literal, e.g. {@code
+ *       expires_at: "1690000000"}) — never exercised before; GraphQL itself allows a string
+ *       literal for a custom scalar argument, and {@code DateTimeScalar} explicitly accepts it.
+ *   <li>Neither {@code StringValue} nor {@code IntValue} (e.g. a float literal, {@code
+ *       expires_at: 3.14}) -&gt; {@code CoercingParseLiteralException}, surfaced by graphql-java as
+ *       a document-validation error (HTTP 200, one {@code errors} entry) BEFORE any resolver runs.
+ * </ul>
+ *
+ * <h2>{@code parseValue} (value supplied via GraphQL {@code variables})</h2>
+ *
+ * <p>Reachable via the real HTTP/GraphQL contract (the JSON body's top-level {@code variables}
+ * field, read by {@code GraphQLRequest#buildFromPayload} and fed into {@code
+ * ExecutionInput#variables}, see {@code GraphQLController}) — no seam extension needed: the
+ * existing generic {@code FilesTestApp#sendForm(HttpRequest)} already forwards a raw body
+ * verbatim, so a hand-built {@code {"query":...,"variables":{...}}} JSON payload reaches {@code
+ * /graphql/} exactly as a real client's would. Jackson's untyped {@code Map.class} deserialization
+ * (used by {@code GraphQLRequest.buildFromPayload}) maps a small JSON integer to {@code Integer},
+ * a JSON integer outside the {@code int} range to {@code Long}, and a JSON string to {@code
+ * String} — which is what lets each of the three source branches be triggered independently:
+ *
+ * <ul>
+ *   <li>{@code instanceof Long} true — a variable value outside the {@code int} range.
+ *   <li>{@code instanceof Integer} true — an ordinary small variable value (the realistic case a
+ *       real GraphQL client would send).
+ *   <li>Neither -&gt; {@code CoercingParseValueException} (e.g. a string variable value) —
+ *       surfaced the same way as the {@code parseLiteral} throw case above.
+ * </ul>
+ */
+class DateTimeScalarApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private String seedLinkableNode(String nodeId) {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId,
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "linkable.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"));
+    return nodeId;
+  }
+
+  // --- parseLiteral -------------------------------------------------------------------------
+
+  @Test
+  void givenAQuotedNumericStringLiteralExpiresAtCreateLinkShouldSucceed() {
+    // Given
+    String nodeId = seedLinkableNode("00000000-0000-0000-0000-000000000230");
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createLink")
+            .withString("node_id", nodeId)
+            .withString("expires_at", "1690000000")
+            .withWantedResultFormat("{ id expires_at }")
+            .build();
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then — DateTimeScalar#parseLiteral's `instanceof StringValue` branch: a quoted numeric
+    // literal is accepted exactly like an unquoted one.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> link = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+    Assertions.assertThat(link).containsEntry("expires_at", 1690000000);
+  }
+
+  @Test
+  void givenAFloatLiteralExpiresAtCreateLinkShouldSurfaceACoercionError() {
+    // Given — neither StringValue nor IntValue -> DateTimeScalar#parseLiteral's throw branch.
+    String nodeId = seedLinkableNode("00000000-0000-0000-0000-000000000231");
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createLink")
+            .withString("node_id", nodeId)
+            .withEnumLiteral("expires_at", "3.14") // raw unquoted literal, not a real enum
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then — a document-validation error, before createLink's resolver ever runs.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1);
+    Assertions.assertThat(errors.get(0)).contains("date");
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "createLink"))
+        .isEmpty();
+  }
+
+  // --- parseValue (GraphQL variables) --------------------------------------------------------
+
+  private HttpResponse createLinkWithVariableExpiresAt(String nodeId, String rawJsonExpiresAtValue) {
+    String body =
+        "{\"query\":\"mutation($nodeId: ID!, $exp: DateTime) { createLink(node_id: $nodeId,"
+            + " expires_at: $exp) { id expires_at } }\","
+            + "\"variables\":{\"nodeId\":\""
+            + nodeId
+            + "\",\"exp\":"
+            + rawJsonExpiresAtValue
+            + "}}";
+    return app.sendForm(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, body));
+  }
+
+  @Test
+  void givenASmallIntegerVariableExpiresAtCreateLinkShouldSucceed() {
+    // Given — Jackson deserializes a small JSON number into an Integer -> parseValue's
+    // `instanceof Integer` branch (the realistic case: a real client sends a JSON number).
+    String nodeId = seedLinkableNode("00000000-0000-0000-0000-000000000232");
+
+    // When
+    HttpResponse httpResponse = createLinkWithVariableExpiresAt(nodeId, "5");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> link = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+    Assertions.assertThat(link).containsEntry("expires_at", 5);
+  }
+
+  @Test
+  void givenALargeIntegerVariableExpiresAtCreateLinkShouldSucceed() {
+    // Given — a JSON number outside the int range deserializes to a Long -> parseValue's
+    // `instanceof Long` branch, never exercised by the small-integer scenario above.
+    String nodeId = seedLinkableNode("00000000-0000-0000-0000-000000000233");
+
+    // When
+    HttpResponse httpResponse = createLinkWithVariableExpiresAt(nodeId, "99999999999999");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> link = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createLink");
+    Assertions.assertThat(link).containsEntry("expires_at", 99999999999999L);
+  }
+
+  @Test
+  void givenAStringVariableExpiresAtCreateLinkShouldSurfaceACoercionError() {
+    // Given — neither Long nor Integer -> DateTimeScalar#parseValue's throw branch.
+    String nodeId = seedLinkableNode("00000000-0000-0000-0000-000000000234");
+
+    // When
+    HttpResponse httpResponse = createLinkWithVariableExpiresAt(nodeId, "\"not-a-timestamp\"");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1);
+    Assertions.assertThat(errors.get(0)).contains("date");
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "createLink"))
+        .isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeadFieldsDocumentingApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeadFieldsDocumentingApiIT.java
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 5.3 (APPROVED, plan §10) of the acceptance coverage-expansion plan: documents four
+ * dead/no-op schema surfaces so the current, actual behaviour is pinned as a contract the Quarkus
+ * rewrite must either preserve or deliberately change. None of these branches are reachable-but-
+ * untested application logic — they are genuinely dead or no-op, so these tests add no branch
+ * coverage; they exist purely to lock in behaviour (plan §10 decision 3) and to double as the §9
+ * findings below.
+ *
+ * <h2>Findings documented here</h2>
+ *
+ * <ul>
+ *   <li><b>{@code getUserById} has no bound resolver.</b> {@code GraphQLProvider} wires {@code
+ *       Constants.GraphQL.Queries.GET_USER} (the string {@code "getUser"}) to {@code
+ *       UserDataFetcher#getUserFetcher}, but the schema's query is named {@code getUserById} —
+ *       confirmed by reading both {@code GraphQLProvider} and {@code schema.graphql} directly.
+ *       There is no {@code GET_USER_BY_ID} constant at all. Consequently {@code getUserById} falls
+ *       through to graphql-java's default {@code PropertyDataFetcher} against the (null) root
+ *       Query source object, which always returns {@code null} for ANY {@code user_id} value —
+ *       and since NO {@code InputFieldsController} rule is bound to this field either, not even a
+ *       malformed/empty id trips a validation error first. Likely a real, shipped bug (a
+ *       find-and-replace or copy-paste slip when the query was renamed from {@code getUser} to
+ *       {@code getUserById}).
+ *   <li><b>{@code Node.share(share_target_id)} has no bound resolver</b> on {@code File}/{@code
+ *       Folder} either (confirmed against {@code GraphQLProvider}'s {@code FILE}/{@code FOLDER}
+ *       type wirings, which bind {@code creator/owner/last_editor/parent/permissions/shares/links/
+ *       collaboration_links} but never {@code share}) — same default-{@code PropertyDataFetcher}-
+ *       on-a-{@code Map}-without-that-key fallthrough, always {@code null}, no validation, no
+ *       matter the argument.
+ *   <li><b>{@code Share.sorts} is a no-op.</b> {@code ShareDataFetcher#getSharesFetcher} never
+ *       calls {@code environment.getArgument(...SORTS...)} at all (confirmed by reading the method
+ *       body, which carries an explicit {@code // TODO: At the moment the sorting is not
+ *       supported} comment) — passing any {@code sorts} value changes nothing.
+ *   <li><b>The {@code DistributionList} union member is never constructed.</b> {@code
+ *       Constants.GraphQL.ENTITY_TYPE} is set to {@code Types.USER} in {@code
+ *       UserDataFetcher#convertUserToDataFetcherResult} and NOWHERE in the whole {@code
+ *       src/main} tree is it ever set to {@code Types.DISTRIBUTION_LIST} (confirmed by a full-tree
+ *       grep) — so {@code getAccountTypeResolver}'s {@code DistributionList} branch is unreachable
+ *       dead code, on both union fields that use it ({@code Account}: {@code getAccountByEmail}/
+ *       {@code getAccountsByEmail}; {@code SharedTarget}: {@code Share.share_target}).
+ * </ul>
+ */
+class DeadFieldsDocumentingApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String TARGET_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String TARGET_C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  private static final String TARGET_D = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", TARGET_B,
+                    "fake-token-c", TARGET_C,
+                    "fake-token-d", TARGET_D))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse execute(String bodyPayload) {
+    return app.send(HttpRequest.of("POST", "/graphql/", REQUESTER_COOKIE, bodyPayload));
+  }
+
+  @Test
+  void givenAnyUserIdGetUserByIdShouldAlwaysReturnNullWithNoError() {
+    // Given — a syntactically valid-looking id and an obviously invalid one; the finding is that
+    // NEITHER path is even reachable, so both behave identically.
+    String validLookingId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String invalidId = "";
+
+    for (String userId : List.of(validLookingId, invalidId)) {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("getUserById")
+              .withString("user_id", userId)
+              .withWantedResultFormat("{ id email full_name }")
+              .build();
+
+      // When
+      HttpResponse httpResponse = execute(bodyPayload);
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Assertions.assertThat(
+              TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "getUserById"))
+          .isEmpty();
+    }
+  }
+
+  @Test
+  void givenAnyShareTargetIdNodeShareFieldShouldAlwaysReturnNull() {
+    // Given — a node the requester owns (so getNode itself succeeds trivially), and three
+    // meaningfully different share_target_id combinations: the requester's own id, a registered
+    // other user, and an id that resolves to nobody at all.
+    String nodeId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID));
+
+    for (String shareTargetId : List.of(REQUESTER_ID, TARGET_B, "ffffffff-ffff-ffff-ffff-ffffffffffff")) {
+      String bodyPayload =
+          GraphqlCommandBuilder.aQueryBuilder("getNode")
+              .withString("node_id", nodeId)
+              .withWantedResultFormat(
+                  "{ id share(share_target_id: \\\"" + shareTargetId + "\\\") { permission } }")
+              .build();
+
+      // When
+      HttpResponse httpResponse = execute(bodyPayload);
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+      Assertions.assertThat(node).containsEntry("id", nodeId);
+      Assertions.assertThat(node.get("share")).isNull();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenSortsArgumentSharesOrderShouldBeIdenticalToOmittingIt() {
+    // Given — one node shared with three distinct, distinguishable targets, inserted in a fixed
+    // order (B, then C, then D; DatabasePopulator delays between inserts to guarantee distinct
+    // timestamps).
+    String nodeId = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID))
+        .addShare(nodeId, TARGET_B, ACL.SharePermission.READ_ONLY)
+        .addShare(nodeId, TARGET_C, ACL.SharePermission.READ_ONLY)
+        .addShare(nodeId, TARGET_D, ACL.SharePermission.READ_ONLY);
+
+    String withSortsPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat(
+                "{ shares(limit: 50, sorts: [CREATION_DESC]) { share_target { ... on User { id } } } }")
+            .build();
+    String withoutSortsPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ shares(limit: 50) { share_target { ... on User { id } } } }")
+            .build();
+
+    // When
+    HttpResponse withSortsResponse = execute(withSortsPayload);
+    HttpResponse withoutSortsResponse = execute(withoutSortsPayload);
+
+    // Then — both must be error-free (all three targets are registered UM users) and, crucially,
+    // the ORDER of target ids must be IDENTICAL between the two calls: `sorts` changed nothing.
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(withSortsResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(withoutSortsResponse.getBodyPayload())).isEmpty();
+
+    List<String> withSortsOrder = shareTargetIds(withSortsResponse);
+    List<String> withoutSortsOrder = shareTargetIds(withoutSortsResponse);
+
+    Assertions.assertThat(withSortsOrder).containsExactlyInAnyOrder(TARGET_B, TARGET_C, TARGET_D);
+    Assertions.assertThat(withSortsOrder).isEqualTo(withoutSortsOrder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> shareTargetIds(HttpResponse httpResponse) {
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    List<Map<String, Object>> shares = (List<Map<String, Object>>) node.get("shares");
+    return shares.stream()
+        .map(share -> (Map<String, Object>) share.get("share_target"))
+        .map(shareTarget -> (String) shareTarget.get("id"))
+        .toList();
+  }
+
+  @Test
+  void givenTheOnlyTwoUnionFieldsInTheSchemaNeitherEverResolvesToADistributionList() {
+    // Given — the Account union (getAccountByEmail) and the SharedTarget union (Share.share_target)
+    // are the ONLY two places in the schema a DistributionList could ever appear. Both share the
+    // exact same type resolver (UserDataFetcher#getAccountTypeResolver), which is unconditionally
+    // wired to Types.USER by every account-producing code path (confirmed by a whole-tree grep: the
+    // DISTRIBUTION_LIST literal is never assigned to ENTITY_TYPE anywhere in src/main).
+    String nodeId = "00000000-0000-0000-0000-000000000003";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID))
+        .addShare(nodeId, TARGET_B, ACL.SharePermission.READ_ONLY);
+
+    String accountByEmailPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getAccountByEmail")
+            .withString("email", "fake-email@example.com")
+            .withWantedResultFormat(
+                "{ __typename ... on User { id } ... on DistributionList { id name } }")
+            .build();
+    String shareTargetPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat(
+                "{ shares(limit: 10) { share_target { __typename ... on User { id } "
+                    + "... on DistributionList { id name } } } }")
+            .build();
+
+    // When
+    HttpResponse accountByEmailResponse = execute(accountByEmailPayload);
+    HttpResponse shareTargetResponse = execute(shareTargetPayload);
+
+    // Then — Account union: always User
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(accountByEmailResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> account =
+        TestUtils.jsonResponseToMap(accountByEmailResponse.getBodyPayload(), "getAccountByEmail");
+    Assertions.assertThat(account).containsEntry("__typename", "User");
+
+    // Then — SharedTarget union: always User
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(shareTargetResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(shareTargetResponse.getBodyPayload(), "getNode");
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> shares = (List<Map<String, Object>>) node.get("shares");
+    Assertions.assertThat(shares).hasSize(1);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> shareTarget = (Map<String, Object>) shares.get(0).get("share_target");
+    Assertions.assertThat(shareTarget).containsEntry("__typename", "User");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteAllNodesAndBlobsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteAllNodesAndBlobsApiIT.java
@@ -2,22 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -32,46 +26,33 @@ import java.util.Optional;
 
 class DeleteAllNodesAndBlobsApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static TombstoneRepository tombstoneRepository;
+  static FilesTestApp app;
 
   private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withStorages()
             .withUserManagement(
                 Map.of("fake-token", OWNER_ID))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    tombstoneRepository = injector.getInstance(TombstoneRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
     // Tombstones are not FK-linked to NODE so resetDatabase() doesn't clean them.
-    tombstoneRepository.getTombstones().forEach(t ->
-        tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
-    simulator.reinitializeMocks();
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private HttpResponse executeDeleteAllNodesAndBlobs() {
@@ -83,7 +64,7 @@ class DeleteAllNodesAndBlobsApiIT {
     List<Map.Entry<String, String>> headers = List.of(Map.entry("Internal", ""));
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", headers, bodyPayload);
-    return TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    return app.send(httpRequest);
   }
 
   // --- Test 1: Happy path — all blobs succeed, returns true ---
@@ -91,7 +72,8 @@ class DeleteAllNodesAndBlobsApiIT {
   @Test
   void givenNodesOwnedByUserTheDeleteAllNodesAndBlobsShouldDeleteTheNodesAndTheBlobs() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000002", OWNER_ID, "name.txt"))
@@ -99,7 +81,7 @@ class DeleteAllNodesAndBlobsApiIT {
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000003", OWNER_ID, "folder"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When
     final HttpResponse httpResponse = executeDeleteAllNodesAndBlobs();
@@ -115,11 +97,11 @@ class DeleteAllNodesAndBlobsApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Nodes deleted from DB.
-    Assertions.assertThat(nodeRepository.getNode("00000000-0000-0000-0000-000000000002")).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode("00000000-0000-0000-0000-000000000003")).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists("00000000-0000-0000-0000-000000000002")).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists("00000000-0000-0000-0000-000000000003")).isFalse();
 
     // Tombstones cleaned up.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 2: PowerStore fails — nodes still deleted (DB-first), returns true, tombstones remain ---
@@ -132,12 +114,12 @@ class DeleteAllNodesAndBlobsApiIT {
     String fileId   = "00000000-0000-0000-0000-000000000000";
     String folderId = "00000000-0000-0000-0000-000000000001";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "name.txt"))
         .addNode(new SimplePopulatorFolder(folderId, OWNER_ID, "folder"));
 
     // PowerStore HTTP 500 — complete failure.
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     // When
     final HttpResponse httpResponse = executeDeleteAllNodesAndBlobs();
@@ -151,11 +133,11 @@ class DeleteAllNodesAndBlobsApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Both nodes deleted from DB (already committed before PowerStore call).
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(folderId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(folderId)).isFalse();
 
     // Tombstone remains for PurgeService retry.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(1);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
   }
 
   // --- Test 3: Folder with file, all blobs succeed — everything deleted ---
@@ -168,13 +150,13 @@ class DeleteAllNodesAndBlobsApiIT {
     String folderBId = "00000000-0000-0000-0000-000000000042";
     String file2Id   = "00000000-0000-0000-0000-000000000043";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(new SimplePopulatorFolder(folderAId, OWNER_ID, "folderA"))
         .addNode(new PopulatorNode(file1Id, OWNER_ID, OWNER_ID, folderAId, "file1.txt", "", NodeType.TEXT, "LOCAL_ROOT," + folderAId, 1L, "text/plain"))
         .addNode(new SimplePopulatorFolder(folderBId, OWNER_ID, "folderB"))
         .addNode(new PopulatorNode(file2Id, OWNER_ID, OWNER_ID, folderBId, "file2.txt", "", NodeType.TEXT, "LOCAL_ROOT," + folderBId, 1L, "text/plain"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     HttpResponse httpResponse = executeDeleteAllNodesAndBlobs();
 
@@ -183,12 +165,12 @@ class DeleteAllNodesAndBlobsApiIT {
     Assertions.assertThat(result).contains(true);
 
     // Everything deleted.
-    Assertions.assertThat(nodeRepository.getNode(folderAId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(file1Id)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(folderBId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(file2Id)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(folderAId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(file1Id)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(folderBId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(file2Id)).isFalse();
 
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 4: Folder + file, PowerStore fails — all deleted (DB-first), tombstones remain ---
@@ -198,11 +180,11 @@ class DeleteAllNodesAndBlobsApiIT {
     String folderId = "00000000-0000-0000-0000-000000000020";
     String fileId   = "00000000-0000-0000-0000-000000000021";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(new SimplePopulatorFolder(folderId, OWNER_ID, "folder"))
         .addNode(new PopulatorNode(fileId, OWNER_ID, OWNER_ID, folderId, "file.txt", "", NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"));
 
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     HttpResponse httpResponse = executeDeleteAllNodesAndBlobs();
 
@@ -214,10 +196,10 @@ class DeleteAllNodesAndBlobsApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Both deleted from DB.
-    Assertions.assertThat(nodeRepository.getNode(folderId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(folderId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
 
     // Tombstone remains.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(1);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteCollaborationLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteCollaborationLinksApiIT.java
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 3.3 of the acceptance coverage-expansion plan: {@code deleteCollaborationLinks} mutation.
+ *
+ * <p><b>FINDING (documented, not fixed):</b> {@code
+ * CollaborationLinkDataFetcher#deleteCollaborationLinks} computes "forbidden" as {@code
+ * collaborationLinkRepository.getLinkById(id).filter(requesterHasShareRights).isEmpty()} — this
+ * single boolean conflates TWO distinct causes (the id does not exist at all, and the id exists
+ * but the requester lacks {@code READ_AND_SHARE}/{@code READ_WRITE_AND_SHARE} on its node) into
+ * the SAME generic {@code missingField} error ("Could not find data to retrieve for requested
+ * field", {@code errorCode: MISSING_FIELD}) with no id-specific detail — a genuine not-found and a
+ * genuine permission-denial are indistinguishable over HTTP. Both scenarios are asserted below
+ * with their real, identical shape; see also the analogous {@code
+ * AuthenticatedDownloadApiIT}/{@code GetPublicLinksApiIT} not-found-vs-forbidden findings.
+ */
+class DeleteCollaborationLinksApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String SHARE_TARGET_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String NODE_ID = "00000000-0000-0000-0000-000000000000";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", SHARE_TARGET_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void createFile(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+  }
+
+  private void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
+  }
+
+  private String createCollaborationLink(String nodeId, SharePermission permission) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createCollaborationLink")
+            .withString("node_id", nodeId)
+            .withEnumLiteral("permission", permission.name())
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse response =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    return (String)
+        TestUtils.jsonResponseToMap(response.getBodyPayload(), "createCollaborationLink").get("id");
+  }
+
+  private HttpResponse deleteCollaborationLinks(String cookie, String... linkIds) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteCollaborationLinks")
+            .withListOfStrings("collaboration_link_ids", linkIds)
+            .withWantedResultFormat("")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  private List<String> remainingLinkIds(String nodeId) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getCollaborationLinks")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse response =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+    return TestUtils.jsonResponseToList(response.getBodyPayload(), "getCollaborationLinks").stream()
+        .map(link -> (String) link.get("id"))
+        .toList();
+  }
+
+  @Test
+  void givenAnOwnedLinkTheDeleteCollaborationLinksShouldDeleteItAndReturnItsId() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+    String linkId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+
+    // When
+    HttpResponse httpResponse = deleteCollaborationLinks("ZM_AUTH_TOKEN=fake-token", linkId);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>)
+            TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteCollaborationLinks")
+                .orElse(List.of());
+    Assertions.assertThat(deletedIds).containsExactly(linkId);
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).isEmpty();
+
+    Assertions.assertThat(remainingLinkIds(NODE_ID)).doesNotContain(linkId);
+  }
+
+  @Test
+  void givenAForbiddenLinkTheDeleteCollaborationLinksShouldReturnAMissingFieldError() {
+    // Given — the share target has READ_ONLY (no SHARE bit) on the node that owns the link
+    createFile(NODE_ID, OWNER_ID);
+    String linkId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createShare(NODE_ID, SHARE_TARGET_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = deleteCollaborationLinks("ZM_AUTH_TOKEN=fake-token-b", linkId);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>)
+            TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteCollaborationLinks")
+                .orElse(List.of());
+    Assertions.assertThat(deletedIds).isEmpty();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find data to retrieve for requested field");
+
+    // The link is untouched.
+    Assertions.assertThat(remainingLinkIds(NODE_ID)).containsExactly(linkId);
+  }
+
+  @Test
+  void givenANotExistingLinkIdTheDeleteCollaborationLinksShouldReturnTheSameMissingFieldError() {
+    // Given — see the class-level FINDING: not-found collapses into the identical shape as
+    // permission-denied
+    String notExistingLinkId = UUID.randomUUID().toString();
+
+    // When
+    HttpResponse httpResponse =
+        deleteCollaborationLinks("ZM_AUTH_TOKEN=fake-token", notExistingLinkId);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>)
+            TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteCollaborationLinks")
+                .orElse(List.of());
+    Assertions.assertThat(deletedIds).isEmpty();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find data to retrieve for requested field");
+  }
+
+  @Test
+  void givenAnAllowedAndAForbiddenLinkTheDeleteCollaborationLinksShouldReturnAPartialSuccess() {
+    // Given — one link the owner may delete, one forbidden id (not-found) in the same call
+    createFile(NODE_ID, OWNER_ID);
+    String allowedLinkId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    String forbiddenLinkId = UUID.randomUUID().toString();
+
+    // When
+    HttpResponse httpResponse =
+        deleteCollaborationLinks("ZM_AUTH_TOKEN=fake-token", allowedLinkId, forbiddenLinkId);
+
+    // Then — the allowed id is deleted and returned, the forbidden one produces one error
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>)
+            TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteCollaborationLinks")
+                .orElse(List.of());
+    Assertions.assertThat(deletedIds).containsExactly(allowedLinkId);
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find data to retrieve for requested field");
+
+    Assertions.assertThat(remainingLinkIds(NODE_ID)).doesNotContain(allowedLinkId);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteLinksApiIT.java
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NEW canonical file: the {@code deleteLinks} mutation (bound to {@code
+ * LinkDataFetcher#deleteLinks()}) had ZERO branch coverage before this file — {@code
+ * ValidationErrorsApiIT} only exercises the request-VALIDATION layer (invalid link-id length),
+ * which rejects the request before the data fetcher's own body ever runs.
+ *
+ * <p>Also closes two small {@code LinkDataFetcher} gaps opportunistically:
+ *
+ * <ul>
+ *   <li>{@code getLinks} as a FIELD RESOLVER ({@code File.links}) — every existing {@code
+ *       GetPublicLinksApiIT} test only calls the TOP-LEVEL {@code getLinks(node_id: ...)} query
+ *       (argument-driven), never the {@code links} field on a {@code getNode} result
+ *       (localContext-driven) — the two paths are the same fetcher instance but read the node id
+ *       from a different source ({@code getLinks()}'s {@code optLocalContext.isPresent()} ternary).
+ *   <li>{@code createLink} targeting {@code LOCAL_ROOT} itself (a {@code ROOT} node) — {@code
+ *       createLink} explicitly excludes {@code NodeType.ROOT} even when the permission check would
+ *       otherwise pass, a branch no existing {@code CreatePublicLinkApiIT} test reaches (every one
+ *       of them targets a real file/folder).
+ * </ul>
+ */
+class DeleteLinksApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void createFile(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+  }
+
+  private void addLink(String linkId, String nodeId) {
+    app.backdoor()
+        .populator()
+        .addLink(linkId, nodeId, "publicid1234", Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private HttpResponse deleteLinks(String[] linkIds, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteLinks")
+            .withListOfStrings("link_ids", linkIds)
+            .withWantedResultFormat("")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @Test
+  void givenShareRightsDeleteLinksShouldDeleteTheLinkAndReturnItsId() {
+    // Given
+    String nodeId = "90000000-0000-0000-0000-000000000001";
+    String linkId = "aaaaaaaa-0000-0000-0000-000000000001";
+    createFile(nodeId, OWNER_ID);
+    addLink(linkId, nodeId);
+
+    // When
+    HttpResponse httpResponse = deleteLinks(new String[] {linkId}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>) TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteLinks")
+            .orElse(List.of());
+    Assertions.assertThat(deletedIds).containsExactly(linkId);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+  }
+
+  @Test
+  void givenNoShareRightsDeleteLinksShouldReturnLinkNotFoundError() {
+    // Given — link exists, but the caller has no READ_AND_SHARE on its node
+    String nodeId = "90000000-0000-0000-0000-000000000002";
+    String linkId = "aaaaaaaa-0000-0000-0000-000000000002";
+    createFile(nodeId, OWNER_ID);
+    addLink(linkId, nodeId);
+
+    // When
+    HttpResponse httpResponse = deleteLinks(new String[] {linkId}, OTHER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>) TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteLinks")
+            .orElse(List.of());
+    Assertions.assertThat(deletedIds).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1).containsExactly("Could not find link with id " + linkId);
+  }
+
+  @Test
+  void givenANonExistentLinkIdDeleteLinksShouldReturnLinkNotFoundError() {
+    // Given
+    String nonExistentLinkId = "aaaaaaaa-0000-0000-0000-0000000000ff";
+
+    // When
+    HttpResponse httpResponse = deleteLinks(new String[] {nonExistentLinkId}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find link with id " + nonExistentLinkId);
+  }
+
+  @Test
+  void givenAMixOfDeletableAndForbiddenLinksDeleteLinksShouldReturnPartialSuccess() {
+    // Given — one link the caller can delete (own node), one they cannot (someone else's node)
+    String ownNodeId = "90000000-0000-0000-0000-000000000003";
+    String otherNodeId = "90000000-0000-0000-0000-000000000004";
+    String ownLinkId = "aaaaaaaa-0000-0000-0000-000000000003";
+    String otherLinkId = "aaaaaaaa-0000-0000-0000-000000000004";
+    createFile(ownNodeId, OWNER_ID);
+    createFile(otherNodeId, OTHER_USER_ID);
+    addLink(ownLinkId, ownNodeId);
+    addLink(otherLinkId, otherNodeId);
+
+    // When
+    HttpResponse httpResponse = deleteLinks(new String[] {ownLinkId, otherLinkId}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> deletedIds =
+        (List<String>) TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteLinks")
+            .orElse(List.of());
+    Assertions.assertThat(deletedIds).containsExactly(ownLinkId);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find link with id " + otherLinkId);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void givenAFileWithALinkTheLinksFieldResolverShouldReturnItFromLocalContextNotAnArgument() {
+    // Given — the `File.links` field resolver (getNode -> links), as opposed to the top-level
+    // getLinks(node_id: ...) query every GetPublicLinksApiIT test uses
+    String nodeId = "90000000-0000-0000-0000-000000000005";
+    String linkId = "aaaaaaaa-0000-0000-0000-000000000005";
+    createFile(nodeId, OWNER_ID);
+    addLink(linkId, nodeId);
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id links { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    List<Map<String, Object>> links = (List<Map<String, Object>>) node.get("links");
+    Assertions.assertThat(links).hasSize(1);
+    Assertions.assertThat(links.get(0)).containsEntry("id", linkId);
+  }
+
+  @Test
+  void givenLocalRootAsTargetCreateLinkShouldReturnNodeWriteErrorNotCreateALink() {
+    // Given — LOCAL_ROOT is a NodeType.ROOT; createLink explicitly excludes ROOT nodes even though
+    // permissionsChecker grants some access to it
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createLink")
+            .withString("node_id", "LOCAL_ROOT")
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: LOCAL_ROOT");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteNodesApiIT.java
@@ -2,22 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -31,45 +25,32 @@ import java.util.Map;
 
 class DeleteNodesApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static TombstoneRepository tombstoneRepository;
+  static FilesTestApp app;
 
   private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withStorages()
             .withUserManagement(Map.of("fake-token", OWNER_ID))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    tombstoneRepository = injector.getInstance(TombstoneRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
     // Tombstones are not FK-linked to NODE so resetDatabase() doesn't clean them.
-    tombstoneRepository.getTombstones().forEach(t ->
-        tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
-    simulator.reinitializeMocks();
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private HttpResponse executeDeleteNodes(String... nodeIds) {
@@ -80,7 +61,7 @@ class DeleteNodesApiIT {
             .build();
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", null, bodyPayload);
-    return TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    return app.send(httpRequest);
   }
 
   // --- Test 1: Happy path — 2 files, all blobs succeed ---
@@ -92,11 +73,12 @@ class DeleteNodesApiIT {
     String file1Id = "00000000-0000-0000-0000-100000000001";
     String file2Id = "00000000-0000-0000-0000-100000000002";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(file1Id, OWNER_ID, "file1.txt"))
         .addNode(new SimplePopulatorTextFile(file2Id, OWNER_ID, "file2.txt"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(file1Id, file2Id);
@@ -113,11 +95,11 @@ class DeleteNodesApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Both files deleted from DB.
-    Assertions.assertThat(nodeRepository.getNode(file1Id)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(file2Id)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(file1Id)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(file2Id)).isFalse();
 
     // Tombstones cleaned up after confirmed blob delete.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 2: PowerStore fails (exception) — files still deleted from DB, no error to user ---
@@ -129,12 +111,13 @@ class DeleteNodesApiIT {
     String file1Id = "00000000-0000-0000-0000-100000000003";
     String file2Id = "00000000-0000-0000-0000-100000000004";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(file1Id, OWNER_ID, "file1.txt"))
         .addNode(new SimplePopulatorTextFile(file2Id, OWNER_ID, "file2.txt"));
 
     // PowerStore returns HTTP 500 — complete failure.
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(file1Id, file2Id);
@@ -151,11 +134,11 @@ class DeleteNodesApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Both nodes deleted from DB (already committed before PowerStore call).
-    Assertions.assertThat(nodeRepository.getNode(file1Id)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(file2Id)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(file1Id)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(file2Id)).isFalse();
 
     // Tombstones remain for PurgeService retry.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(2);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(2);
   }
 
   // --- Test 3: Folder with file, all blobs succeed — both deleted, no errors ---
@@ -166,13 +149,14 @@ class DeleteNodesApiIT {
     String folderId = "00000000-0000-0000-0000-100000000007";
     String fileId   = "00000000-0000-0000-0000-100000000008";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorFolder(folderId, OWNER_ID, "folder"))
         .addNode(new PopulatorNode(
             fileId, OWNER_ID, OWNER_ID, folderId, "file.txt", "",
             NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When — request the folder
     HttpResponse httpResponse = executeDeleteNodes(folderId);
@@ -188,10 +172,10 @@ class DeleteNodesApiIT {
     List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
     Assertions.assertThat(errors).isEmpty();
 
-    Assertions.assertThat(nodeRepository.getNode(folderId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(folderId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
     // Tombstones cleaned up.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 4: Folder with file, PowerStore fails — both folder AND file still deleted (DB-first) ---
@@ -202,13 +186,14 @@ class DeleteNodesApiIT {
     String folderId = "00000000-0000-0000-0000-100000000005";
     String fileId   = "00000000-0000-0000-0000-100000000006";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorFolder(folderId, OWNER_ID, "folder"))
         .addNode(new PopulatorNode(
             fileId, OWNER_ID, OWNER_ID, folderId, "file.txt", "",
             NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"));
 
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     // When — request the folder (which contains the file)
     HttpResponse httpResponse = executeDeleteNodes(folderId);
@@ -225,11 +210,11 @@ class DeleteNodesApiIT {
     Assertions.assertThat(errors).isEmpty();
 
     // Both deleted from DB (PowerStore failure does not block DB delete).
-    Assertions.assertThat(nodeRepository.getNode(folderId)).isEmpty();
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(folderId)).isFalse();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
 
     // Tombstone remains for PurgeService retry.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(1);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
   }
 
   // --- Test 5: Protective filter — nodeNotFound for missing/no-perm IDs ---
@@ -240,10 +225,11 @@ class DeleteNodesApiIT {
     String presentFileId = "00000000-0000-0000-0000-100000000009";
     String missingId     = "00000000-0000-0000-0000-100000000099";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(presentFileId, OWNER_ID, "file.txt"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(presentFileId, missingId);
@@ -259,7 +245,7 @@ class DeleteNodesApiIT {
     List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
     Assertions.assertThat(errors).hasSize(1);
 
-    Assertions.assertThat(nodeRepository.getNode(presentFileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(presentFileId)).isFalse();
   }
 
   // --- Test 6: Null/empty JSON response from PowerStore — CORRECTED: null is NOT success, tombstone KEPT ---
@@ -269,11 +255,12 @@ class DeleteNodesApiIT {
     // Given
     String file1Id = "00000000-0000-0000-0000-100000000012";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(file1Id, OWNER_ID, "file1.txt"));
 
     // {"ids":null} / "{}" — SDK may return null or throw NPE; BOTH are treated as connection failure.
-    storagesMockHelper.bulkDeleteNullResponse();
+    app.mocks().storagesBulkDeleteReturnsNullResponse();
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(file1Id);
@@ -287,10 +274,10 @@ class DeleteNodesApiIT {
     Assertions.assertThat(deletedIds).containsExactly(file1Id);
 
     // Node deleted from DB (DB-first design).
-    Assertions.assertThat(nodeRepository.getNode(file1Id)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(file1Id)).isFalse();
     // CORRECTED: tombstone must REMAIN — null/empty response is NOT a success signal.
-    Assertions.assertThat(tombstoneRepository.getTombstones())
+    Assertions.assertThat(app.backdoor().tombstoneCount())
         .as("Tombstone must remain when PowerStore returns null/empty response (NOT a success signal)")
-        .hasSize(1);
+        .isEqualTo(1);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteSharesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteSharesApiIT.java
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -26,15 +22,12 @@ import org.junit.jupiter.api.Test;
 
 class DeleteSharesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static ShareRepository shareRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -45,36 +38,29 @@ class DeleteSharesApiIT {
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
                     "fake-token-account-for-sharing-2",
                     "cccccccc-cccc-cccc-cccc-cccccccccccc"))
-            .build()
-            .start();
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFile(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addShare(nodeId, targetUserId, permission);
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
   }
 
   @Test
-  void
-      givenExistingSharesTheDeleteSharesShouldDeleteAllAndReturnTargetIds() {
+  void givenExistingSharesTheDeleteSharesShouldDeleteAllAndReturnTargetIds() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
@@ -102,8 +88,7 @@ class DeleteSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -119,21 +104,20 @@ class DeleteSharesApiIT {
             "cccccccc-cccc-cccc-cccc-cccccccccccc");
 
     Assertions.assertThat(
-        shareRepository.getShare(
+        app.backdoor().shareExists(
             "00000000-0000-0000-0000-000000000000",
             "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    ).isEmpty();
+    ).isFalse();
 
     Assertions.assertThat(
-        shareRepository.getShare(
+        app.backdoor().shareExists(
             "00000000-0000-0000-0000-000000000000",
             "cccccccc-cccc-cccc-cccc-cccccccccccc")
-    ).isEmpty();
+    ).isFalse();
   }
 
   @Test
-  void
-      givenOneNonExistingShareTheDeleteSharesShouldReturnPartialSuccessWithErrors() {
+  void givenOneNonExistingShareTheDeleteSharesShouldReturnPartialSuccessWithErrors() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
@@ -157,8 +141,7 @@ class DeleteSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -181,8 +164,7 @@ class DeleteSharesApiIT {
   }
 
   @Test
-  void
-      givenATargetUserTheDeleteSharesShouldAllowSelfDeletion() {
+  void givenATargetUserTheDeleteSharesShouldAllowSelfDeletion() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
@@ -204,8 +186,7 @@ class DeleteSharesApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -219,15 +200,14 @@ class DeleteSharesApiIT {
         .containsExactly("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 
     Assertions.assertThat(
-        shareRepository.getShare(
+        app.backdoor().shareExists(
             "00000000-0000-0000-0000-000000000000",
             "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    ).isEmpty();
+    ).isFalse();
   }
 
   @Test
-  void
-      givenAUserWithoutPermissionsTheDeleteSharesShouldReturnErrors() {
+  void givenAUserWithoutPermissionsTheDeleteSharesShouldReturnErrors() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
@@ -250,8 +230,7 @@ class DeleteSharesApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing-2", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -268,8 +247,7 @@ class DeleteSharesApiIT {
   }
 
   @Test
-  void
-      givenOwnerAsTargetTheDeleteSharesShouldReturnErrorForOwner() {
+  void givenOwnerAsTargetTheDeleteSharesShouldReturnErrorForOwner() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     createShare(
@@ -293,8 +271,7 @@ class DeleteSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteTrashCopyEdgeCasesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteTrashCopyEdgeCasesApiIT.java
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deepens {@code NodeDataFetcher} JaCoCo branch coverage for {@code trashNodes}, {@code
+ * flagNodes}, and {@code deleteAllNodesAndBlobs} beyond Waves 0-6, per the measurement loop. Picked
+ * from a line-by-line read of {@code core/target/jacoco-it-report/jacoco.xml}'s missed branches,
+ * cross-checked against {@code TrashNodesApiIT}/{@code FlagNodesApiIT}/{@code
+ * DeleteAllNodesAndBlobsApiIT} to avoid duplicating existing coverage.
+ *
+ * <ul>
+ *   <li>{@code trashNodes}: the truster ≠ the trashed node's CURRENT parent's owner — same shape
+ *       and same reachability trick as {@code MoveRestoreEdgeCasesApiIT}'s move-remove-notify
+ *       tests (a node's owner does not have to match its structural parent's owner) — both the
+ *       "owner not yet in the notify list" (fresh add) and "owner already there" (skip, avoid
+ *       duplicate) outcomes of {@code !usersToNotify.contains(parent.getOwnerId())}.
+ *   <li>{@code flagNodes}: a ROOT id in the request — the {@code getNodeType() != ROOT} filter
+ *       (every existing {@code FlagNodesApiIT} test uses a plain file, never a root).
+ *   <li>{@code deleteAllNodesAndBlobs}: PowerStore returns a null/empty bulk-delete response
+ *       (neither success nor a thrown exception) — {@code DeleteNodesApiIT} already covers this
+ *       exact shape for {@code deleteNodes}, but {@code deleteAllNodesAndBlobs} has its own,
+ *       separate copy of the same null-check that no existing test reaches.
+ * </ul>
+ *
+ * <p><b>Explicitly SKIPPED as unreachable (not attempted):</b> {@code createFolderFetcher}'s
+ * analogous {@code !usersToNotify.contains(parent.getOwnerId())} check (line ~617) can NEVER
+ * observe {@code true} (skip) — its notify list is seeded ONLY from {@code
+ * createIndirectShare(parentId, ...)}, i.e. shares whose TARGET is a user other than {@code
+ * parentId}'s own owner (a node's shares can never target its own owner — enforced by {@code
+ * ShareDataFetcher#createShareFetcher}'s {@code targetUserId.equals(ownerId)} rejection), so the
+ * parent's owner can never already be in that list by the time the check runs. This differs from
+ * {@code trashNodes}/{@code moveNodes} (asserted above), whose notify lists are seeded from the
+ * MOVED/TRASHED NODE's OWN shares — and a node's owner CAN differ from its current parent's owner
+ * (ownership does not follow structure on move), so a share targeting the parent's owner is a
+ * valid, constructible share on the child. A newly-confirmed dead branch, not previously
+ * documented by the plan's §9 findings list.
+ */
+class DeleteTrashCopyEdgeCasesApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withStorages()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private int notificationCountOf(String cookie, String onClause) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNotifications")
+            .withBoolean("update_last_seen", true)
+            .withWantedResultFormat("{ notifications { " + onClause + " } }")
+            .build();
+    HttpResponse httpResponse = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNotifications");
+    List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
+    return (int) notifications.stream().filter(n -> !n.isEmpty()).count();
+  }
+
+  private HttpResponse trashNodes(String nodeId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("trashNodes")
+            .withListOfStrings("node_ids", new String[] {nodeId})
+            .withWantedResultFormat("")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // trashNodes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void givenATrasherWhoIsNotTheNodesParentOwnerTrashNodesShouldNotifyTheParentOwnerFreshly() {
+    // Given — folder F owned by OWNER_ID, shared WRITE to OTHER_USER_ID; a node OWNED by
+    // OTHER_USER_ID but structurally parented under F, with no shares of its own
+    String parentFolderId = "b1000000-0000-0000-0000-000000000001";
+    String nodeId = "b1000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addShare(parentFolderId, OTHER_USER_ID, SharePermission.READ_AND_WRITE)
+        .addNode(
+            new PopulatorNode(
+                nodeId, OTHER_USER_ID, OTHER_USER_ID, parentFolderId, "child.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentFolderId, 1L, "text/plain"));
+
+    // When — the node's owner (not F's owner) trashes it
+    HttpResponse httpResponse = trashNodes(nodeId, OTHER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(notificationCountOf(OWNER_COOKIE, "... on RemovedNode { created_at }"))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void givenATrasherWhoIsNotTheNodesParentOwnerButTheOwnerIsAlreadyAShareTargetTrashNodesShouldNotDuplicateTheNotification() {
+    // Given — same shape, but the node ALSO has a DIRECT share to F's owner already
+    String parentFolderId = "b1000000-0000-0000-0000-000000000011";
+    String nodeId = "b1000000-0000-0000-0000-000000000012";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addShare(parentFolderId, OTHER_USER_ID, SharePermission.READ_AND_WRITE)
+        .addNode(
+            new PopulatorNode(
+                nodeId, OTHER_USER_ID, OTHER_USER_ID, parentFolderId, "child2.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentFolderId, 1L, "text/plain"))
+        .addShare(nodeId, OWNER_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = trashNodes(nodeId, OTHER_COOKIE);
+
+    // Then — F's owner still gets EXACTLY ONE notification
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(notificationCountOf(OWNER_COOKIE, "... on RemovedNode { created_at }"))
+        .isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // flagNodes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void givenARootIdFlagNodesShouldFilterItAsAnError() {
+    // When
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("flagNodes")
+            .withListOfStrings("node_ids", new String[] {"LOCAL_ROOT"})
+            .withBoolean("flag", true)
+            .withWantedResultFormat("")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: LOCAL_ROOT");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // deleteAllNodesAndBlobs
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void givenNullResponseFromPowerStoreDeleteAllNodesAndBlobsShouldStillReturnTrueButKeepTheTombstone() {
+    // Given
+    String fileId = "b1000000-0000-0000-0000-000000000021";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "file.txt"));
+    app.mocks().storagesBulkDeleteReturnsNullResponse();
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteAllNodesAndBlobs")
+            .withString("user_id", OWNER_ID)
+            .withWantedResultFormat("")
+            .build();
+    List<Map.Entry<String, String>> headers = List.of(Map.entry("Internal", ""));
+
+    // When
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, headers, bodyPayload));
+
+    // Then — DB-first: node deleted, mutation reports true, but a null/empty PowerStore response is
+    // NOT treated as a success signal so the tombstone is kept for the purge retry loop
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Optional<Object> result =
+        TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteAllNodesAndBlobs");
+    Assertions.assertThat(result).contains(true);
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
+    Assertions.assertThat(app.backdoor().tombstoneCount())
+        .as("null/empty PowerStore response must NOT be treated as success")
+        .isEqualTo(1);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteVersionsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteVersionsApiIT.java
@@ -2,20 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.FileVersionSort;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,45 +23,32 @@ import java.util.stream.Collectors;
 
 class DeleteVersionsApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static TombstoneRepository tombstoneRepository;
+  static FilesTestApp app;
 
   private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withStorages()
             .withUserManagement(Map.of("fake-token", OWNER_ID))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    tombstoneRepository = injector.getInstance(TombstoneRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
     // Tombstones are not FK-linked to NODE so resetDatabase() doesn't clean them.
-    tombstoneRepository.getTombstones().forEach(t ->
-        tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
-    simulator.reinitializeMocks();
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private HttpResponse executeDeleteVersions(String nodeId, int... versions) {
@@ -80,7 +60,7 @@ class DeleteVersionsApiIT {
             .build();
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", null, bodyPayload);
-    return TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    return app.send(httpRequest);
   }
 
   /**
@@ -89,17 +69,32 @@ class DeleteVersionsApiIT {
    * The node's currentVersion ends at 3.
    */
   private void createFileWithThreeVersions(String nodeId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
         .addVersion(nodeId)   // version 2
         .addVersion(nodeId);  // version 3
   }
 
+  /**
+   * Remaining version numbers, ascending, read back via the public {@code getVersions} GraphQL
+   * query (contract-observable) rather than the FileVersionRepository directly. Omitting the
+   * "versions" argument returns every version currently persisted for the node.
+   */
   private List<Integer> getRemainingVersionNumbers(String nodeId) {
-    return fileVersionRepository
-        .getFileVersions(nodeId, List.of(FileVersionSort.VERSION_ASC))
-        .stream()
-        .map(fv -> fv.getVersion())
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getVersions")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ version }")
+            .build();
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+    HttpResponse httpResponse = app.send(httpRequest);
+    List<Map<String, Object>> versions =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getVersions");
+    return versions.stream()
+        .map(v -> (Integer) v.get("version"))
+        .sorted()
         .collect(Collectors.toList());
   }
 
@@ -112,7 +107,7 @@ class DeleteVersionsApiIT {
     String nodeId = "00000000-0000-0000-0000-200000000001";
     createFileWithThreeVersions(nodeId);
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When — delete versions 1 and 2 (current=3 must stay)
     HttpResponse httpResponse = executeDeleteVersions(nodeId, 1, 2);
@@ -132,7 +127,7 @@ class DeleteVersionsApiIT {
     Assertions.assertThat(getRemainingVersionNumbers(nodeId)).containsExactly(3);
 
     // Tombstones cleaned up after confirmed blob delete.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 2: PowerStore fails (exception) — versions still deleted from DB, no error to user ---
@@ -145,7 +140,7 @@ class DeleteVersionsApiIT {
     createFileWithThreeVersions(nodeId);
 
     // PowerStore returns HTTP 500 — complete failure.
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     // When — delete versions 1 and 2
     HttpResponse httpResponse = executeDeleteVersions(nodeId, 1, 2);
@@ -165,7 +160,7 @@ class DeleteVersionsApiIT {
     Assertions.assertThat(getRemainingVersionNumbers(nodeId)).containsExactly(3);
 
     // Tombstones remain for PurgeService retry.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(2);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(2);
   }
 
   // --- Test 3: Protective filter — current version cannot be deleted ---
@@ -176,7 +171,7 @@ class DeleteVersionsApiIT {
     String nodeId = "00000000-0000-0000-0000-200000000004";
     createFileWithThreeVersions(nodeId); // current = 3
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When — try to delete current version (3)
     HttpResponse httpResponse = executeDeleteVersions(nodeId, 3);
@@ -196,7 +191,7 @@ class DeleteVersionsApiIT {
     Assertions.assertThat(getRemainingVersionNumbers(nodeId)).containsExactly(1, 2, 3);
 
     // No tombstones created (nothing eligible to delete).
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 4: Protective filter — keepForever version cannot be deleted ---
@@ -205,12 +200,12 @@ class DeleteVersionsApiIT {
   void givenFileWithKeepForeverVersionDeleteItThenKeepForeverVersionSkippedAndOnlyEligibleVersionDeleted() {
     // Given — version 2 is keepForever, version 3 is current
     String nodeId = "00000000-0000-0000-0000-200000000005";
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
         .addVersion(nodeId, true)   // version 2, keepForever=true
         .addVersion(nodeId);        // version 3 (current)
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When — try to delete v1 (eligible) and v2 (keepForever, ineligible)
     HttpResponse httpResponse = executeDeleteVersions(nodeId, 1, 2);
@@ -231,6 +226,6 @@ class DeleteVersionsApiIT {
     Assertions.assertThat(getRemainingVersionNumbers(nodeId)).containsExactly(2, 3);
 
     // Tombstone for v1 cleaned up.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteVersionsCompletenessApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DeleteVersionsCompletenessApiIT.java
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.6 (part 3) of the acceptance coverage-expansion plan: completeness companion to the
+ * already-existing {@code DeleteVersionsApiIT} (which covers the happy path, the PowerStore-fails
+ * DB-first invariant, current-version protection with only a bare error-count assertion, and
+ * keep-forever protection likewise). The user prefers duplication over gaps, so this class
+ * re-covers the two "protected version" branches with their EXACT message asserted, adds the
+ * genuinely-nonexistent-version case for direct comparison, and documents (rather than fakes) the
+ * one branch the current seam cannot reach.
+ *
+ * <p><b>FINDING — "protected" and "nonexistent" are indistinguishable to the caller:</b> reading
+ * {@code NodeDataFetcher#deleteVersionsFetcher} precisely, ALL THREE of the following collapse
+ * onto the exact SAME {@code fileVersionNotFound(nodeId, v, path)} error (message {@code "Could
+ * not find version: <v> for node with id <id>"}, extension {@code errorCode:
+ * FILE_VERSION_NOT_FOUND}):
+ *
+ * <ul>
+ *   <li>{@code v} IS the node's current version (filtered out by {@code
+ *       !node.getCurrentVersion().equals(fv.getVersion())});
+ *   <li>{@code v} is marked {@code keepForever} (filtered out by {@code !fv.isKeptForever()});
+ *   <li>{@code v} simply has no {@code FileVersion} row at all for this node.
+ * </ul>
+ *
+ * <p>The result-composition code only ever compares "was {@code v} requested?" against "is {@code
+ * v} in the final {@code versionsToDelete} list?" — it has no memory of WHY a version fell out of
+ * that list, so a client can never tell a protected version apart from a typo'd/nonexistent one.
+ * This is asserted directly below (all three scenarios produce the byte-identical message shape),
+ * not fixed (Phase 1 forbids {@code src/main} changes).
+ *
+ * <p><b>GAP — the transaction-rollback branch (STOP + report, per task instructions):</b> {@code
+ * deleteVersionsFetcher}'s {@code catch (RuntimeException e)} around the
+ * tombstone-write-then-delete transaction (returning a single {@code nodeWriteError}) has NO
+ * reachable trigger through the current seam. Verified by reading every DB call inside that
+ * transaction:
+ *
+ * <ul>
+ *   <li>{@code TombstoneRepositoryEbean#createNewTombstone} does a check-then-insert (SELECT for
+ *       an existing row with the same {@code (node_id, version)} PK, and returns {@code
+ *       Optional.empty()} WITHOUT inserting if one already exists) — it is deliberately
+ *       idempotent and cannot throw a PK-violation;
+ *   <li>{@code FileVersionRepositoryEbean#deleteFileVersions} is a plain bulk {@code DELETE ...
+ *       WHERE node_id = ? AND version IN (...)} with no FK referencing {@code file_version} from
+ *       any other table (grep of every {@code V*__*.sql} migration under {@code
+ *       core/src/main/resources/db/migration} shows every {@code REFERENCES} targets {@code node},
+ *       none targets {@code file_version});
+ *   <li>the only fault-injection this seam exposes is on the STORAGES side ({@code
+ *       Mocks#storagesBulkDeleteFails/ReturnsNullResponse}, already exercised by {@code
+ *       DeleteVersionsApiIT}'s Test 2) — Wave 0 did not add any DB-level fault injection (e.g.
+ *       pausing/killing the shared Testcontainers Postgres, which is also a singleton shared
+ *       across the whole suite and would be unsafe to disrupt from a single test).
+ * </ul>
+ *
+ * <p>No white-box unit test exercises this catch block either (confirmed by grepping the test
+ * tree for its log line), so it is untested altogether today, not merely untested black-box. Per
+ * the task's explicit instruction to "STOP + report if the seam lacks something" rather than
+ * force a workaround or weaken the assertion, this branch is documented here as a genuine
+ * seam gap instead of a test.
+ */
+class DeleteVersionsCompletenessApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withStorages()
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    // Tombstones are not FK-linked to NODE so resetDatabase() doesn't clean them.
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse deleteVersions(String nodeId, int... versions) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteVersions")
+            .withString("node_id", nodeId)
+            .withListOfIntegers("versions", versions)
+            .withWantedResultFormat("")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Integer> deletedVersions(HttpResponse httpResponse) {
+    return (List<Integer>)
+        TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "deleteVersions").orElse(List.of());
+  }
+
+  @Test
+  void givenTheCurrentVersionRequestedForDeletionItIsSkippedWithTheSameNotFoundShapeAsGenuinelyMissing() {
+    // Given — v1, v2 (current)
+    String nodeId = "70000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId); // v2, current
+
+    // When — try to delete the current version
+    HttpResponse httpResponse = deleteVersions(nodeId, 2);
+
+    // Then — skipped, and surfaced with the EXACT SAME message/shape as "doesn't exist"
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(deletedVersions(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find version: 2 for node with id " + nodeId);
+
+    // both versions remain; no tombstone was ever created (nothing was eligible)
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(nodeId)).isEqualTo(0);
+  }
+
+  @Test
+  void givenAKeptForeverVersionRequestedForDeletionItIsSkippedWithTheSameNotFoundShapeAsGenuinelyMissing() {
+    // Given — v2 is kept-forever (non-current), v3 is current
+    String nodeId = "70000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId, true) // v2, keepForever=true
+        .addVersion(nodeId); // v3, current
+
+    // When — try to delete the kept-forever version
+    HttpResponse httpResponse = deleteVersions(nodeId, 2);
+
+    // Then — skipped, and surfaced with the EXACT SAME message/shape as "doesn't exist"
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(deletedVersions(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find version: 2 for node with id " + nodeId);
+
+    // all three versions remain; no tombstone was ever created
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2, 3);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(nodeId)).isEqualTo(0);
+  }
+
+  @Test
+  void givenAVersionThatDoesNotExistItProducesTheIdenticalFileVersionNotFoundShape() {
+    // Given — only v1 (current) exists
+    String nodeId = "70000000-0000-0000-0000-000000000003";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When
+    HttpResponse httpResponse = deleteVersions(nodeId, 999);
+
+    // Then — byte-identical message shape to the two "protected" cases above
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(deletedVersions(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find version: 999 for node with id " + nodeId);
+
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DownloadByPublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DownloadByPublicLinkApiIT.java
@@ -2,22 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -27,46 +19,31 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockserver.model.HttpError;
-import org.mockserver.model.Parameter;
-import org.mockserver.verify.VerificationTimes;
 
 public class DownloadByPublicLinkApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(Map.of("fake-token", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
             .withStorages()
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.getStoragesMock().reset();
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @ParameterizedTest
@@ -84,7 +61,8 @@ public class DownloadByPublicLinkApiIT {
       givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedTheDownloadByPublicLinkShouldReturnTheBlob(
           String publicLinkId, String publicLinkEndpoint, String userToken) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -105,29 +83,18 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty(),
             Optional.empty());
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download")
-                .withQueryStringParameter(
-                    Parameter.param("node", "00000000-0000-0000-0000-000000000000"))
-                .withQueryStringParameter(Parameter.param("version", "1"))
-                .withQueryStringParameter(Parameter.param("type", "files")),
-            VerificationTimes.once());
+    app.mocks().verifyStoragesDownloaded("00000000-0000-0000-0000-000000000000", 1);
   }
 
   @ParameterizedTest
@@ -145,7 +112,8 @@ public class DownloadByPublicLinkApiIT {
       givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedWithAccessCodeTheDownloadByPublicLinkShouldRedirect(
           String publicLinkId, String publicLinkEndpoint, String userToken) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -166,14 +134,13 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty(),
             Optional.of("test"));
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(307);
@@ -185,7 +152,8 @@ public class DownloadByPublicLinkApiIT {
   @Test
   void givenAnExistingFileAndAnExpiredLinkTheDownloadByPublicLinkShouldReturnA404StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -210,26 +178,20 @@ public class DownloadByPublicLinkApiIT {
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
   void givenANotExistingLinkTheDownloadByPublicLinkShouldReturnA404StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -254,20 +216,13 @@ public class DownloadByPublicLinkApiIT {
         HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
@@ -277,27 +232,21 @@ public class DownloadByPublicLinkApiIT {
         HttpRequest.of("GET", "/public/link/download/1234abcd", null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
   void
       givenAnExistingFileAndAValidPublicLinkAssociatedAndAConnectionProblemToStoragesTheTheDownloadByPublicLinkShouldReturnA500StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -318,20 +267,17 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty(),
             Optional.empty());
 
-    simulator
-        .getStoragesMock()
-        .when(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"))
-        .error(HttpError.error().withDropConnection(true));
+    app.mocks().storagesDownloadConnectionDrops();
 
     final HttpRequest httpRequest =
-        HttpRequest.of("GET", "/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab", null, null);
+        HttpRequest.of(
+            "GET",
+            "/public/link/download/abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
+            null,
+            null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
@@ -353,7 +299,8 @@ public class DownloadByPublicLinkApiIT {
       givenAUserWithOrWithoutCookieAnExistingTrashedFileAndAnExistingPublicLinkAssociatedTheDownloadByPublicLinkShouldReturn404(
           String publicLinkId, String publicLinkEndpoint, String userToken) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -375,14 +322,13 @@ public class DownloadByPublicLinkApiIT {
             Optional.empty())
         .addNodeToTrash("00000000-0000-0000-0000-000000000000", "LOCAL_ROOT");
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicLinkUrl = publicLinkEndpoint + publicLinkId;
     final HttpRequest httpRequest = HttpRequest.of("GET", publicLinkUrl, userToken, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/DownloadMultipleApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/DownloadMultipleApiIT.java
@@ -2,32 +2,22 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.Injector;
 import com.zextras.carbonio.files.Constants;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockserver.model.Parameter;
-import org.mockserver.verify.VerificationTimes;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -36,40 +26,28 @@ import java.util.Map;
 
 public class DownloadMultipleApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
   static ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(Map.of("fake-token", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
             .withStorages()
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
@@ -80,7 +58,8 @@ public class DownloadMultipleApiIT {
     String fileId2 = "00000000-0000-0000-0000-000000000102";
     String fileId3 = "00000000-0000-0000-0000-000000000103";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -131,9 +110,9 @@ public class DownloadMultipleApiIT {
                 "image/jpeg"));
 
     // Mock storages responses for each file
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
-    storagesMockHelper.getBlob(fileId3, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId3, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2, fileId3);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -152,8 +131,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -170,16 +148,7 @@ public class DownloadMultipleApiIT {
         );
 
     // Verify storages was called for each file
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download")
-                .withQueryStringParameter(Parameter.param("node", fileId1))
-                .withQueryStringParameter(Parameter.param("version", "1"))
-                .withQueryStringParameter(Parameter.param("type", "files")),
-            VerificationTimes.once());
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
   }
 
   @Test
@@ -190,7 +159,8 @@ public class DownloadMultipleApiIT {
     String fileId1 = "00000000-0000-0000-0000-000000000201";
     String fileId2 = "00000000-0000-0000-0000-000000000202";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 parentFolderId,
@@ -241,8 +211,8 @@ public class DownloadMultipleApiIT {
                 "text/plain"));
 
     // Mock storages responses
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, subFolderId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -261,8 +231,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -275,7 +244,8 @@ public class DownloadMultipleApiIT {
     String fileId2 = "00000000-0000-0000-0000-000000000302";
     String folderId = "11111111-1111-1111-1111-111111111301";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 fileId1,
@@ -314,8 +284,8 @@ public class DownloadMultipleApiIT {
                 null));
 
     // Mock storages responses
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(Constants.Db.RootId.LOCAL_ROOT);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -334,8 +304,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -351,7 +320,8 @@ public class DownloadMultipleApiIT {
     // Given
     String fileId = "00000000-0000-0000-0000-000000000501";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 fileId,
@@ -382,8 +352,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
@@ -409,8 +378,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
@@ -432,8 +400,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
@@ -457,8 +424,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
@@ -482,8 +448,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
@@ -496,7 +461,8 @@ public class DownloadMultipleApiIT {
     String fileId = "00000000-0000-0000-0000-000000000901";
 
     // Create a folder owned by another user but shared with our user
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -525,7 +491,7 @@ public class DownloadMultipleApiIT {
         .addShare(fileId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", ACL.SharePermission.READ_ONLY);
 
     // Mock storages response
-    storagesMockHelper.getBlob(fileId, 1);
+    app.mocks().storagesServesBlob(fileId, 1);
 
     List<String> nodeIds = List.of(fileId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -544,8 +510,7 @@ public class DownloadMultipleApiIT {
     );
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ExceptionResidueApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ExceptionResidueApiIT.java
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 4.3 of the acceptance coverage-expansion plan: {@code ExceptionsHandler} branches not
+ * exercised by any other {@code *ApiIT} -- oversized-aggregated-request and
+ * {@code InvalidTokenSignException}.
+ *
+ * <p><b>Per-TEST (not per-class) {@link FilesTestApp} lifecycle -- deliberate, see FINDING #3
+ * on the first test below:</b> unlike every other {@code *ApiIT} in this suite (which shares one
+ * {@code @BeforeAll}/{@code @AfterAll} app for the whole class), this class rebuilds and fully
+ * closes the app around EACH test. The connection-abort this class's first scenario deliberately
+ * provokes is unsafe to share with any other test's connection pool (real-HTTP transport) or
+ * Simulator lifecycle (both transports) -- see FINDING #3.
+ */
+class ExceptionResidueApiIT {
+
+  FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+  @BeforeEach
+  void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build();
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.close();
+  }
+
+  /**
+   * {@code /upload-to}'s {@code HttpObjectAggregator(256 * 1024)} (see {@code
+   * HttpRoutingHandler#channelRead0}) sits FIRST in the pipeline, ahead of the auth-handler. So
+   * an over-limit request is rejected before authentication -- no cookie is required to reach
+   * this branch at all.
+   *
+   * <p><b>FINDING #1 (seam-usage correction -- required to even exercise this branch):</b> {@code
+   * FilesTestApp#sendForm} cannot reliably reproduce an oversized request on both transports.
+   * {@code java.net.http.HttpClient} treats {@code Content-Length} as a JDK-restricted header
+   * (verified empirically: setting it explicitly throws {@code IllegalArgumentException:
+   * restricted header name: "Content-Length"} from {@code RealHttpFilesTestApp#exchange}) and
+   * always computes it itself from the real body -- so the real-HTTP transport needs no trick.
+   * But {@code TestUtils#sendFormRequest} (the embedded transport) builds ONE single-shot {@code
+   * DefaultFullHttpRequest} that already carries the whole body; per Netty's own {@code
+   * MessageAggregator#decode} (traced from the actual 4.2.16.Final classes in this project's
+   * dependency tree), the accumulated-size recheck only runs for a message delivered as SEPARATE
+   * {@code HttpContent}/{@code LastHttpContent} objects after an initial headers-only {@code
+   * HttpRequest} -- never for an already-complete {@code FullHttpMessage}, and with no {@code
+   * Content-Length} header at all (which {@code sendFormRequest} never sets) the header-based
+   * check is skipped too. Empirically, sending a 300000-byte body via {@code sendForm} on the
+   * embedded transport sailed straight through the aggregator to the auth-handler (observed:
+   * HTTP 401 "Missing cookies", not 413) -- so {@code sendForm} cannot exercise this branch on
+   * the embedded transport at all. {@link FilesTestApp#upload} is the correct call instead: it
+   * writes a headers-only {@code DefaultHttpRequest} (with a real, byte-array-derived {@code
+   * Content-Length}) followed by a separate {@code DefaultLastHttpContent} on the embedded
+   * transport, and a real socket write with an accurate JDK-computed {@code Content-Length} on
+   * the real-HTTP transport -- both paths land on the SAME Netty header-based oversized check
+   * ({@code isContentLengthInvalid}), symmetrically, regardless of {@code /upload-to}'s body
+   * being JSON rather than a blob (the seam's {@code upload()} is transport-plumbing only, blind
+   * to content semantics).
+   *
+   * <p><b>FINDING #2 (the brief's "413 via ExceptionsHandler" assumption is WRONG):</b>
+   * decompiling the actual Netty 4.2.16.Final classes in use ({@code
+   * HttpObjectAggregator#handleOversizedMessage}) shows that once the declared {@code
+   * Content-Length} exceeds {@code maxContentLength}, Netty's aggregator itself writes a static
+   * {@code TOO_LARGE}/{@code TOO_LARGE_CLOSE} {@code DefaultFullHttpResponse(HTTP_1_1,
+   * REQUEST_ENTITY_TOO_LARGE, Unpooled.EMPTY_BUFFER)} DIRECTLY and closes the connection --
+   * BEFORE the request ever reaches {@code auth-handler}, {@code procedure-handler}, or {@code
+   * ExceptionsHandler}. So {@code ExceptionsHandler}'s own {@code RequestEntityTooLargeException}
+   * branch (whose payload would be the string {@code "413 Request Entity Too Large"}) is NEVER
+   * exercised by this path: the actual, observed body is EMPTY, not that string. Confirmed
+   * empirically below on both transports, not merely inferred from bytecode.
+   *
+   * <p><b>FINDING #3 (real-HTTP-transport harness bug -- worked around by per-test app isolation,
+   * not papered over):</b> initially this scenario ran against a class-shared, {@code
+   * @BeforeAll}-built {@code app} (the pattern every other {@code *ApiIT} uses). On the real-HTTP
+   * transport that corrupted whichever test ran AFTER it: {@code java.net.http.HttpClient}
+   * pools/reuses the underlying TCP connection across calls made through the same client
+   * instance, and {@code RealHttpFilesTestApp}'s comment ("every request closes its channel...
+   * so there is no HTTP keep-alive reuse and thus no per-request pipeline-mutation clash") does
+   * not hold for THIS branch: Netty's aggregator closes the connection asynchronously via a
+   * listener, and the client's pool can race ahead and reuse the not-yet-fully-closed connection
+   * for the next request; when it does, {@code HttpRoutingHandler#channelRead0} runs its
+   * route-matched {@code context.pipeline().addLast(...)} mutation a SECOND time on the SAME
+   * (stale) pipeline, which already has a handler at that name from the first request --
+   * observed empirically as {@code IllegalArgumentException: Duplicate handler name:
+   * exceptions-handler}, itself caught by the STALE exceptions-handler and mapped to a spurious
+   * 400 on the FOLLOWING test. This is a real test-harness limitation (not a src/main bug, and
+   * not something this task is scoped to fix in the shared seam). Worked around at the CLASS
+   * level (see this class's javadoc): every test in this file gets its own freshly-built,
+   * fully-closed-before-the-next-one {@link FilesTestApp} ({@code @BeforeEach}/{@code
+   * @AfterEach}, not {@code @BeforeAll}/{@code @AfterAll}) -- an in-process, single, per-test
+   * {@code FilesTestApp} (attempted first) is NOT safe either: {@code Simulator}'s database
+   * wiring registers a process-wide Ebean/HikariCP default that a second, concurrently-open
+   * Simulator's teardown tears down out from under the first (observed empirically as {@code
+   * HikariDataSource (files-db-pool) has been closed} on the OTHER test) -- so isolation must be
+   * temporal (never two {@code Simulator}s alive at once), not merely a second parallel instance.
+   */
+  @Test
+  void givenABodyOverTheAggregatorLimitUploadToShouldReturn413WithAnEmptyBodyNotExceptionsHandlersPayload() {
+    // Given -- a body genuinely larger than /upload-to's 256KB HttpObjectAggregator limit.
+    byte[] oversizedBody = new byte[300_000];
+    Arrays.fill(oversizedBody, (byte) 'x');
+
+    // When
+    HttpResponse httpResponse =
+        app.upload(HttpRequest.ofUpload("POST", "/upload-to", null, null, oversizedBody));
+
+    // Then -- 413, but the body is EMPTY: Netty's own aggregator short-circuit, not
+    // ExceptionsHandler's REQUEST_ENTITY_TOO_LARGE branch (which would read "413 Request Entity
+    // Too Large"). Document the divergence rather than asserting the naive expectation.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(413);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEmpty();
+  }
+
+  /**
+   * Reproduces the exact fixture/forged-token construction already used by {@code
+   * PublicFindNodesApiIT}'s "hacked page token without signature" test, but states the STATUS-code
+   * mapping explicitly (this class's stated purpose), rather than only the GraphQL error message.
+   *
+   * <p><b>FINDING (the brief's "InvalidTokenSignException -> 401" assumption is WRONG / this
+   * branch is UNREACHABLE from any traced HTTP path):</b> every throw site of {@code
+   * InvalidTokenSignException} is confined to {@code PageQuery} ({@code fromToken}/{@code
+   * computeHmac}/{@code toToken}), which is invoked ONLY from within the {@code findNodes} /
+   * public {@code findNodes} GraphQL data-fetchers (via {@code NodeRepositoryEbean}) -- plus one
+   * unrelated throw in {@code FilesConfig#generateHmacSha256Key} (only reachable if the JVM lacks
+   * {@code HmacSHA256}, a standard algorithm guaranteed by every conforming JDK, and only invoked
+   * at config-generation time, never per-request). Both authenticated and public {@code
+   * findNodes} run inside graphql-java's query-execution engine, which catches any {@link
+   * RuntimeException} thrown by a {@code DataFetcher} and converts it into a {@code
+   * GraphQLError} entry in the (still-200) response -- the exception NEVER propagates to the
+   * Netty pipeline's {@code exceptionCaught} chain, so {@code ExceptionsHandler}'s {@code
+   * InvalidTokenSignException -> 401} branch can never fire from any request this suite (or, as
+   * far as static analysis of the call graph shows, ANY HTTP request) can construct. This joins
+   * the plan's confirmed-unreachable residue (alongside {@code Permissions.equals()} etc.): it is
+   * a structurally dead {@code ExceptionsHandler} branch, not merely an untested one. The actual,
+   * empirically-observed status is 200 with a GraphQL execution error -- asserted explicitly here
+   * instead of the fictitious 401.
+   */
+  @Test
+  void givenATamperedPageTokenTheActualStatusIs200WithAGraphQLErrorNotExceptionsHandlers401Mapping() {
+    // Given -- identical fixture to PublicFindNodesApiIT's tampered-signature test: a public
+    // folder (the query target) plus an unrelated private folder tree whose node ids the forged
+    // token's fixed internal payload references.
+    String ownerId = REQUESTER_ID;
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000000",
+                ownerId,
+                ownerId,
+                "LOCAL_ROOT",
+                "public folder",
+                "",
+                NodeType.FOLDER,
+                "LOCAL_ROOT",
+                0L,
+                null))
+        .addLink(
+            "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
+            "00000000-0000-0000-0000-000000000000",
+            "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab",
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty())
+        .addNode(
+            new PopulatorNode(
+                "77777777-7777-7777-7777-777777777777",
+                ownerId,
+                ownerId,
+                "LOCAL_ROOT",
+                "not public folder",
+                "",
+                NodeType.FOLDER,
+                "LOCAL_ROOT",
+                0L,
+                null))
+        .addNode(
+            new PopulatorNode(
+                "88888888-8888-8888-8888-888888888888",
+                ownerId,
+                ownerId,
+                "77777777-7777-7777-7777-777777777777",
+                "folder child",
+                "",
+                NodeType.FOLDER,
+                "LOCAL_ROOT,77777777-7777-7777-7777-777777777777",
+                0L,
+                null))
+        .addNode(
+            new PopulatorNode(
+                "99999999-9999-9999-9999-999999999999",
+                ownerId,
+                ownerId,
+                "77777777-7777-7777-7777-777777777777",
+                "folder child 2",
+                "",
+                NodeType.FOLDER,
+                "LOCAL_ROOT,77777777-7777-7777-7777-777777777777",
+                0L,
+                null));
+
+    String pageTokenHacked = app.backdoor().forgeTamperedPageTokenMissingSignature();
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", "00000000-0000-0000-0000-000000000000")
+            .withInteger("limit", 1)
+            .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
+            .withString("page_token", pageTokenHacked)
+            .withWantedResultFormat("{ nodes { id name }, page_token }")
+            .build();
+
+    final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then -- the ACTUAL, observed behaviour: 200 with a GraphQL error, not a 401 HTTP status.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    final List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Exception while fetching data (/findNodes) : Invalid token signature");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ExceptionResidueApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ExceptionResidueApiIT.java
@@ -52,6 +52,14 @@ class ExceptionResidueApiIT {
 
   @AfterEach
   void cleanUp() {
+    // NOTE: reset BEFORE close, not skipped -- this class's @BeforeEach already resets at the
+    // start of every test (needed because of the per-test app lifecycle explained in the class
+    // javadoc), but relying on that alone leaks whatever the LAST test in this class wrote (e.g.
+    // the fixed-UUID folder in the tampered-page-token test below) into the shared Postgres
+    // container for the NEXT *ApiIT class in the suite, which does not expect pre-existing rows.
+    // Found via a reproducible cross-class DuplicateKey failure in GetCollaborationLinksApiIT
+    // (same shared-container "00000000-..." fixture id) while measuring acceptance coverage.
+    app.backdoor().resetDatabase();
     app.close();
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesApiIT.java
@@ -11,7 +11,6 @@ import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -93,7 +92,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_ASC)
+              .withEnumLiteral("sort", "NAME_ASC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -134,7 +133,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_DESC)
+              .withEnumLiteral("sort", "NAME_DESC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -175,7 +174,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withEnumLiteral("sort", "UPDATED_AT_ASC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -216,7 +215,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withEnumLiteral("sort", "UPDATED_AT_DESC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -257,7 +256,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_ASC)
+              .withEnumLiteral("sort", "NAME_ASC")
               .withInteger("limit", 5)
               .withListOfStrings("keywords", new String[] {"a"})
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -322,7 +321,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withEnumLiteral("sort", "SIZE_ASC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -363,7 +362,7 @@ class FindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withEnumLiteral("sort", "SIZE_DESC")
               .withInteger("limit", 5)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -426,7 +425,7 @@ class FindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "LOCAL_ROOT")
             .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
+            .withEnumLiteral("sort", "NAME_ASC")
             .withInteger("limit", 5)
             .withBoolean("flagged", true)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -474,7 +473,7 @@ class FindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "LOCAL_ROOT")
             .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
+            .withEnumLiteral("sort", "NAME_ASC")
             .withInteger("limit", 5)
             .withBoolean("shared_by_me", true)
             .withBoolean("direct_share", true)
@@ -523,7 +522,7 @@ class FindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "LOCAL_ROOT")
             .withBoolean("cascade", true)
-            .withEnum("sort", NodeSort.NAME_ASC)
+            .withEnumLiteral("sort", "NAME_ASC")
             .withInteger("limit", 5)
             .withBoolean("shared_with_me", true)
             .withBoolean("direct_share", true)
@@ -569,7 +568,7 @@ class FindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "TRASH_ROOT")
             .withBoolean("cascade", false)
-            .withEnum("sort", NodeSort.NAME_ASC)
+            .withEnumLiteral("sort", "NAME_ASC")
             .withInteger("limit", 5)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
@@ -617,7 +616,7 @@ class FindNodesApiIT {
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "TRASH_ROOT")
             .withBoolean("cascade", false)
-            .withEnum("sort", NodeSort.NAME_ASC)
+            .withEnumLiteral("sort", "NAME_ASC")
             .withInteger("limit", 5)
             .withBoolean("shared_with_me", true)
             .withWantedResultFormat("{ nodes { id name }, page_token }")

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesApiIT.java
@@ -2,21 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.search;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -31,16 +26,12 @@ import org.junit.jupiter.api.TestInstance;
 
 class FindNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
@@ -49,18 +40,12 @@ class FindNodesApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-account-for-sharing",
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Nested
@@ -69,7 +54,7 @@ class FindNodesApiIT {
 
     @BeforeAll
     void setUp() {
-      DatabasePopulator.aNodePopulator(simulator.getInjector())
+      app.backdoor().populator()
           .addNode(
               new SimplePopulatorFolder(
                   "10000000-0000-0000-0000-000000000001",
@@ -99,7 +84,7 @@ class FindNodesApiIT {
 
     @AfterAll
     void tearDown() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
@@ -116,8 +101,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -158,8 +142,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -200,8 +183,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -242,8 +224,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -285,8 +266,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -311,7 +291,7 @@ class FindNodesApiIT {
 
     @BeforeAll
     void setUp() {
-      DatabasePopulator.aNodePopulator(simulator.getInjector())
+      app.backdoor().populator()
           .addNode(
               new SimplePopulatorFolder(
                   "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
@@ -333,7 +313,7 @@ class FindNodesApiIT {
 
     @AfterAll
     void tearDown() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
@@ -350,8 +330,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -392,8 +371,7 @@ class FindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
@@ -426,13 +404,13 @@ class FindNodesApiIT {
 
     @AfterEach
     void cleanUp() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
     void givenFilesOnRootSearchWithFlaggedShouldReturnFlaggedNodes() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001",
@@ -458,8 +436,7 @@ class FindNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -478,7 +455,7 @@ class FindNodesApiIT {
   @Test
   void givenFilesOnRootSearchSharedByMeShouldReturnSharedByMeNodes() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001",
@@ -508,8 +485,7 @@ class FindNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -528,7 +504,7 @@ class FindNodesApiIT {
   @Test
   void givenFilesOnRootSearchSharedWithMeShouldReturnSharedWithMeNodes() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001",
@@ -558,8 +534,7 @@ class FindNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -578,7 +553,7 @@ class FindNodesApiIT {
   @Test
   void givenFilesOnTrashSearchTrashBinShouldReturnTrashedNodes() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001",
@@ -603,8 +578,7 @@ class FindNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -623,7 +597,7 @@ class FindNodesApiIT {
   @Test
   void givenExistingFilesTrashSearchSharedWithMeInTrashBinShouldReturnSharedTrashedNodes() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001",
@@ -653,8 +627,7 @@ class FindNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesSortApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/FindNodesSortApiIT.java
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.3 of the acceptance coverage-expansion plan: {@code findNodes} sorts that no existing
+ * acceptance test drives: {@code OWNER_ASC/DESC}, {@code TYPE_ASC/DESC}, {@code
+ * LAST_EDITOR_ASC/DESC}, plus one negative case for the plan-corrected {@code CREATED_AT_ASC}
+ * (present in the Java {@code NodeSort} enum but NOT in the GraphQL schema's {@code NodeSort}
+ * enum, so it can only ever fail GraphQL document validation).
+ *
+ * <p><b>FINDING (overrides the plan's prediction for {@code TYPE_ASC}/{@code TYPE_DESC}):</b>
+ * {@code NodeRepositoryEbean.getRealSortingsToApply} unconditionally prepends {@code TYPE_ASC} as
+ * the primary sort for ANY requested sort other than {@code SIZE_ASC}/{@code SIZE_DESC} (which
+ * prepend {@code TYPE_ASC}/{@code TYPE_DESC} respectively) — see the {@code else} branch, which
+ * always adds {@code TYPE_ASC} first and the requested sort second, even when the requested sort
+ * IS {@code TYPE_DESC}. Since both clauses order the exact same {@code node_category} column, the
+ * second (the actual request) is a no-op tie-breaker over rows already fully separated by the
+ * first: requesting {@code sort: TYPE_DESC} on {@code findNodes} produces the SAME
+ * folder-before-file order as {@code TYPE_ASC}, never the reverse. This test pins the actual
+ * (broken) behaviour rather than the plan's predicted reversal.
+ *
+ * <p><b>FINDING (overrides the plan's prediction of a reachable "Root" position):</b> {@code
+ * SearchBuilder}'s base query unconditionally excludes {@code node_category = 0} (=
+ * {@code NodeCategory.ROOT}) via {@code .not().eq("mNodeCategory", 0)}. {@code LOCAL_ROOT}/{@code
+ * TRASH_ROOT} are also owned by nobody ({@code owner_id IS NULL}) and can never satisfy the
+ * owner-or-shared visibility clause either. A {@code ROOT}-category node can therefore NEVER
+ * appear in a {@code findNodes} result set — the "Root" position of {@code TYPE_ASC/DESC}
+ * ("Root, Folder, File") is structurally unreachable through this query, exactly like the {@code
+ * Permissions.equals()} / dead-code residue documented in the plan's §0. Only the Folder/File
+ * ordering is exercised below.
+ */
+class FindNodesSortApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OWNER_B,
+                    "fake-token-c", OWNER_C))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse execute(String bodyPayload, String cookie) {
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> findNodesSortedBy(String sortLiteral, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", "LOCAL_ROOT")
+            .withBoolean("cascade", true)
+            .withEnumLiteral("sort", sortLiteral)
+            .withInteger("limit", 10)
+            .withWantedResultFormat("{ nodes { id name }, page_token }")
+            .build();
+
+    HttpResponse httpResponse = execute(bodyPayload, cookie);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+    return (List<Map<String, Object>>) page.get("nodes");
+  }
+
+  private List<Map<String, Object>> findNodesSortedBy(String sortLiteral) {
+    return findNodesSortedBy(sortLiteral, "ZM_AUTH_TOKEN=fake-token");
+  }
+
+  // --- OWNER_ASC / OWNER_DESC -------------------------------------------------------------
+
+  private void seedThreeFilesWithDistinctOwnersVisibleToRequester() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-00000000000a",
+                REQUESTER_ID,
+                REQUESTER_ID,
+                "LOCAL_ROOT",
+                "ownedByA.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                1L,
+                "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-00000000000b",
+                OWNER_B,
+                OWNER_B,
+                "LOCAL_ROOT",
+                "ownedByB.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                1L,
+                "text/plain"))
+        .addShare("00000000-0000-0000-0000-00000000000b", REQUESTER_ID, ACL.SharePermission.READ_ONLY)
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-00000000000c",
+                OWNER_C,
+                OWNER_C,
+                "LOCAL_ROOT",
+                "ownedByC.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                1L,
+                "text/plain"))
+        .addShare("00000000-0000-0000-0000-00000000000c", REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+  }
+
+  @Test
+  void givenNodesWithDistinctOwnersSortOwnerAscShouldOrderByOwnerIdAscending() {
+    // Given
+    seedThreeFilesWithDistinctOwnersVisibleToRequester();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("OWNER_ASC");
+
+    // Then
+    Assertions.assertThat(nodes).hasSize(3);
+    Assertions.assertThat(nodes)
+        .extracting(node -> node.get("id"))
+        .containsExactly(
+            "00000000-0000-0000-0000-00000000000a",
+            "00000000-0000-0000-0000-00000000000b",
+            "00000000-0000-0000-0000-00000000000c");
+  }
+
+  @Test
+  void givenNodesWithDistinctOwnersSortOwnerDescShouldOrderByOwnerIdDescending() {
+    // Given
+    seedThreeFilesWithDistinctOwnersVisibleToRequester();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("OWNER_DESC");
+
+    // Then
+    Assertions.assertThat(nodes).hasSize(3);
+    Assertions.assertThat(nodes)
+        .extracting(node -> node.get("id"))
+        .containsExactly(
+            "00000000-0000-0000-0000-00000000000c",
+            "00000000-0000-0000-0000-00000000000b",
+            "00000000-0000-0000-0000-00000000000a");
+  }
+
+  // --- LAST_EDITOR_ASC / LAST_EDITOR_DESC -------------------------------------------------
+
+  /**
+   * All three files are owned by the SAME user (the requester) so that {@code OWNER} plays no
+   * role in the ordering; only {@code editor_id} differs, set via the real {@code updateNode}
+   * mutation (which sets {@code Node#setLastEditorId(requesterId)}) run as three different
+   * requesters who each hold at least {@code READ_AND_WRITE} on the node.
+   */
+  private void seedThreeFilesWithDistinctLastEditors() {
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile("00000000-0000-0000-0000-00000000000d", REQUESTER_ID, "editedByA.txt"))
+        .addNode(new SimplePopulatorTextFile("00000000-0000-0000-0000-00000000000e", REQUESTER_ID, "editedByB.txt"))
+        .addShare("00000000-0000-0000-0000-00000000000e", OWNER_B, ACL.SharePermission.READ_AND_WRITE)
+        .addNode(new SimplePopulatorTextFile("00000000-0000-0000-0000-00000000000f", REQUESTER_ID, "editedByC.txt"))
+        .addShare("00000000-0000-0000-0000-00000000000f", OWNER_C, ACL.SharePermission.READ_AND_WRITE);
+
+    updateNodeDescription("00000000-0000-0000-0000-00000000000d", "ZM_AUTH_TOKEN=fake-token", "edited by A");
+    updateNodeDescription("00000000-0000-0000-0000-00000000000e", "ZM_AUTH_TOKEN=fake-token-b", "edited by B");
+    updateNodeDescription("00000000-0000-0000-0000-00000000000f", "ZM_AUTH_TOKEN=fake-token-c", "edited by C");
+  }
+
+  private void updateNodeDescription(String nodeId, String cookie, String description) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode")
+            .withString("node_id", nodeId)
+            .withString("description", description)
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse response = execute(bodyPayload, cookie);
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(response.getBodyPayload())).isEmpty();
+  }
+
+  @Test
+  void givenNodesWithDistinctLastEditorsSortLastEditorAscShouldOrderByEditorIdAscending() {
+    // Given
+    seedThreeFilesWithDistinctLastEditors();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("LAST_EDITOR_ASC");
+
+    // Then
+    Assertions.assertThat(nodes).hasSize(3);
+    Assertions.assertThat(nodes)
+        .extracting(node -> node.get("id"))
+        .containsExactly(
+            "00000000-0000-0000-0000-00000000000d",
+            "00000000-0000-0000-0000-00000000000e",
+            "00000000-0000-0000-0000-00000000000f");
+  }
+
+  @Test
+  void givenNodesWithDistinctLastEditorsSortLastEditorDescShouldOrderByEditorIdDescending() {
+    // Given
+    seedThreeFilesWithDistinctLastEditors();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("LAST_EDITOR_DESC");
+
+    // Then
+    Assertions.assertThat(nodes).hasSize(3);
+    Assertions.assertThat(nodes)
+        .extracting(node -> node.get("id"))
+        .containsExactly(
+            "00000000-0000-0000-0000-00000000000f",
+            "00000000-0000-0000-0000-00000000000e",
+            "00000000-0000-0000-0000-00000000000d");
+  }
+
+  // --- TYPE_ASC / TYPE_DESC ----------------------------------------------------------------
+
+  private void seedOneFolderAndOneFile() {
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder("10000000-0000-0000-0000-000000000001", REQUESTER_ID, "aFolder"))
+        .addNode(new SimplePopulatorTextFile("00000000-0000-0000-0000-000000000001", REQUESTER_ID, "aFile.txt"));
+  }
+
+  @Test
+  void givenAFolderAndAFileSortTypeAscShouldReturnFolderBeforeFile() {
+    // Given
+    seedOneFolderAndOneFile();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("TYPE_ASC");
+
+    // Then
+    Assertions.assertThat(nodes).hasSize(2);
+    Assertions.assertThat(nodes.get(0)).containsEntry("id", "10000000-0000-0000-0000-000000000001");
+    Assertions.assertThat(nodes.get(1)).containsEntry("id", "00000000-0000-0000-0000-000000000001");
+  }
+
+  /**
+   * FINDING: see the class-level Javadoc. {@code sort: TYPE_DESC} does NOT reverse the
+   * folder/file grouping — {@code getRealSortingsToApply} always prepends {@code TYPE_ASC} first,
+   * making the requested {@code TYPE_DESC} a no-op secondary clause on the same already-resolved
+   * column. The observed order is identical to {@code TYPE_ASC}: folder still before file.
+   */
+  @Test
+  void givenAFolderAndAFileSortTypeDescStillReturnsFolderBeforeFileDueToHardcodedTypeAscPrepend() {
+    // Given
+    seedOneFolderAndOneFile();
+
+    // When
+    List<Map<String, Object>> nodes = findNodesSortedBy("TYPE_DESC");
+
+    // Then — NOT reversed, despite the DESC request (documented bug, not fixed per Phase-1 scope)
+    Assertions.assertThat(nodes).hasSize(2);
+    Assertions.assertThat(nodes.get(0)).containsEntry("id", "10000000-0000-0000-0000-000000000001");
+    Assertions.assertThat(nodes.get(1)).containsEntry("id", "00000000-0000-0000-0000-000000000001");
+  }
+
+  // --- CREATED_AT_ASC negative case (plan-corrected) --------------------------------------
+
+  /**
+   * {@code CREATED_AT_ASC} exists on the Java {@code NodeSort} enum but was never added to the
+   * GraphQL schema's {@code NodeSort} enum (only {@code LAST_EDITOR}, {@code NAME}, {@code
+   * OWNER}, {@code TYPE}, {@code UPDATED_AT}, {@code SIZE} are declared). Selecting it over the
+   * API can therefore only ever fail GraphQL document validation — it is not a reachable sort.
+   */
+  @Test
+  void givenSortCreatedAtAscWhichIsNotInTheGraphQLSchemaThenValidationErrorNotASort() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", "LOCAL_ROOT")
+            .withBoolean("cascade", true)
+            .withEnumLiteral("sort", "CREATED_AT_ASC")
+            .withInteger("limit", 5)
+            .withWantedResultFormat("{ nodes { id }, page_token }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1);
+    Assertions.assertThat(errors.get(0)).contains("Validation error");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/FlagNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/FlagNodesApiIT.java
@@ -2,18 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -27,45 +22,36 @@ import java.util.Map;
 
 class FlagNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
                 Map.of(
                     "fake-token",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
   void givenANodeFlagNodesShouldFlagIt() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
@@ -81,8 +67,7 @@ class FlagNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -110,8 +95,7 @@ class FlagNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -128,7 +112,8 @@ class FlagNodesApiIT {
   @Test
   void givenANodeAndAUserWithoutPermissionsFlagNodesShouldReturn200WithAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"));
@@ -144,8 +129,7 @@ class FlagNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -162,7 +146,8 @@ class FlagNodesApiIT {
   @Test
   void givenTwoNodesWithOneNotExistingNodeFlagNodesShouldReturn200WithAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000003", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
@@ -178,8 +163,7 @@ class FlagNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/FolderChildrenApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/FolderChildrenApiIT.java
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.6 (part 3) of the acceptance coverage-expansion plan: direct coverage of {@code
+ * Folder.children} (bound to {@code NodeDataFetcher#getChildNodesFetcherFast}).
+ *
+ * <p>Reading the source: the fetcher calls {@code nodeRepository.findNodes(...)} scoped to {@code
+ * folder_id = <this folder>, cascade = false}, with ONE special case on the {@code
+ * shared_with_me} parameter:
+ *
+ * <ul>
+ *   <li>if the folder is {@code LOCAL_ROOT}: {@code sharedWithMe = Optional.of(false)}, which
+ *       {@code SearchBuilder#setSharedWithMe} turns into a hard {@code owner_id = requester}
+ *       filter — REPLACING the base query's normal {@code (owner OR direct-share)} clause
+ *       entirely. So even a node directly shared with the requester at the top level is excluded;
+ *   <li>for any other folder: {@code sharedWithMe = Optional.empty()}, so {@code
+ *       SearchBuilder}'s BASE constructor filter applies unmodified: {@code owner_id = requester
+ *       OR mShares.target_user_id = requester}. A child individually shared with the requester
+ *       (a direct {@code Share} row on that exact child, independent of whatever share exists — or
+ *       doesn't — on the folder itself) IS included, alongside owned children.
+ * </ul>
+ *
+ * <p>Pagination reuses the same {@code page_token} mechanism as {@code findNodes} (both route
+ * through {@code nodePageFetcher} for the {@code nodes} field), confirmed reachable via the {@code
+ * children(limit, sort, page_token)} schema arguments.
+ */
+class FolderChildrenApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private HttpResponse getChildren(String folderId, int limit, String pageToken, String cookie) {
+    String childrenArgs =
+        pageToken == null
+            ? "limit: " + limit + ", sort: NAME_ASC"
+            : "limit: " + limit + ", sort: NAME_ASC, page_token: \\\"" + pageToken + "\\\"";
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", folderId)
+            .withWantedResultFormat(
+                "{ ... on Folder { children(" + childrenArgs + ") { nodes { id name }, page_token } } }")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> childrenPage(String folderId, int limit, String pageToken, String cookie) {
+    HttpResponse httpResponse = getChildren(folderId, limit, pageToken, cookie);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    return (Map<String, Object>) node.get("children");
+  }
+
+  private List<String> childIds(Map<String, Object> page) {
+    List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+    return nodes.stream().map(n -> (String) n.get("id")).toList();
+  }
+
+  @Test
+  void
+      givenLocalRootWithAnOwnedNodeAndASharedNodeChildrenShouldReturnOnlyTheOwnedNodeNoSharedWithMeLeakage() {
+    // Given — one node owned by the requester, and one node owned by OTHER_USER_ID but directly
+    // shared with the requester, both sitting at LOCAL_ROOT
+    String ownedId = "00000000-0000-0000-0000-000000000001";
+    String sharedId = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                ownedId, REQUESTER_ID, REQUESTER_ID, "LOCAL_ROOT", "owned.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                sharedId, OTHER_USER_ID, OTHER_USER_ID, "LOCAL_ROOT", "sharedWithMe.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"))
+        .addShare(sharedId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    Map<String, Object> page = childrenPage("LOCAL_ROOT", 10, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — only the owned node; the shared one does NOT leak into LOCAL_ROOT's children
+    Assertions.assertThat(childIds(page)).containsExactly(ownedId);
+  }
+
+  @Test
+  void givenANormalFolderChildrenShouldReturnBothOwnedAndIndividuallySharedNodes() {
+    // Given — folder F owned by the requester; C1 owned by the requester, C2 owned by
+    // OTHER_USER_ID but directly shared with the requester — both structurally parented under F
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    String c1Id = "00000000-0000-0000-0000-000000000001";
+    String c2Id = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID, "F"))
+        .addNode(
+            new PopulatorNode(
+                c1Id, REQUESTER_ID, REQUESTER_ID, folderId, "c1.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                c2Id, OTHER_USER_ID, OTHER_USER_ID, folderId, "c2.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"))
+        .addShare(c2Id, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    Map<String, Object> page = childrenPage(folderId, 10, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — unlike LOCAL_ROOT, a normal folder shows BOTH the owned and the individually-shared
+    // child
+    Assertions.assertThat(childIds(page)).containsExactlyInAnyOrder(c1Id, c2Id);
+  }
+
+  @Test
+  void givenMoreChildrenThanTheLimitChildrenShouldPaginateViaPageToken() {
+    // Given — folder F2 owned by the requester, with 3 children, page size 2
+    String folderId = "10000000-0000-0000-0000-000000000002";
+    String aId = "00000000-0000-0000-0000-000000000003";
+    String bId = "00000000-0000-0000-0000-000000000004";
+    String cId = "00000000-0000-0000-0000-000000000005";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID, "F2"))
+        .addNode(
+            new PopulatorNode(
+                aId, REQUESTER_ID, REQUESTER_ID, folderId, "aaa.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                bId, REQUESTER_ID, REQUESTER_ID, folderId, "bbb.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"))
+        .addNode(
+            new PopulatorNode(
+                cId, REQUESTER_ID, REQUESTER_ID, folderId, "ccc.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + folderId, 1L, "text/plain"));
+
+    // When — first page
+    Map<String, Object> firstPage = childrenPage(folderId, 2, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — exactly 2 nodes and a non-null continuation token
+    Assertions.assertThat(childIds(firstPage)).containsExactly(aId, bId);
+    Assertions.assertThat(firstPage.get("page_token")).isNotNull();
+
+    // When — second page, using the returned token
+    String pageToken = (String) firstPage.get("page_token");
+    Map<String, Object> secondPage =
+        childrenPage(folderId, 2, pageToken, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — the remaining single child, and no further page
+    Assertions.assertThat(childIds(secondPage)).containsExactly(cId);
+    Assertions.assertThat(secondPage.get("page_token")).isNull();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetCollaborationLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetCollaborationLinksApiIT.java
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 3.2 of the acceptance coverage-expansion plan: {@code getCollaborationLinks} top-level
+ * query AND the {@code File.collaboration_links}/{@code Folder.collaboration_links} field
+ * resolvers — both are backed by the SAME {@code
+ * CollaborationLinkDataFetcher#getCollaborationLinksByNodeId} lambda instance (the top-level query
+ * reads the {@code node_id} argument, the field resolvers read the node id from local context).
+ *
+ * <p><b>Visibility rule:</b> {@code getCollaborationLinksByNodeId} requires the requester to hold
+ * at least {@code READ_AND_SHARE} or {@code READ_WRITE_AND_SHARE}; once past that gate, the
+ * returned links are further filtered to only those whose permission tier the requester's own ACL
+ * is a bitwise superset of ({@code permissions.has(collaborationLink.getPermissions())}) — a
+ * {@code READ_AND_SHARE} sharer sees ONLY the {@code READ_AND_SHARE}-tier link even when a {@code
+ * READ_WRITE_AND_SHARE}-tier link also exists on the same node, while a {@code
+ * READ_WRITE_AND_SHARE} sharer (a bitwise superset of both) sees both.
+ *
+ * <p><b>Permission-denied shape:</b> the fetcher returns {@code
+ * Collections.singletonList(DataFetcherResult.error(nodeWriteError))} — i.e. the GraphQL response
+ * has data {@code [null]} (a one-element list whose only element is {@code null}) PLUS a top-level
+ * {@code nodeWriteError} in {@code errors}, mirroring the identical pattern already documented for
+ * {@code getLinks} in {@code GetPublicLinksApiIT}.
+ */
+class GetCollaborationLinksApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String READ_SHARE_TARGET_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String READ_WRITE_SHARE_TARGET_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  private static final String NODE_ID = "00000000-0000-0000-0000-000000000000";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", READ_SHARE_TARGET_ID,
+                    "fake-token-c", READ_WRITE_SHARE_TARGET_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void createFile(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+  }
+
+  private void createFolder(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(nodeId, ownerId));
+  }
+
+  private void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
+  }
+
+  private void createCollaborationLink(String nodeId, SharePermission permission) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createCollaborationLink")
+            .withString("node_id", nodeId)
+            .withEnumLiteral("permission", permission.name())
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse response =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  private HttpResponse getCollaborationLinks(String cookie, String nodeId) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getCollaborationLinks")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id permission }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @Test
+  void givenAnOwnerAndBothPermissionTierLinksTheGetCollaborationLinksShouldReturnBoth() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createCollaborationLink(NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+
+    // When — the owner's ACL is a superset of every tier
+    HttpResponse httpResponse = getCollaborationLinks("ZM_AUTH_TOKEN=fake-token", NODE_ID);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> links =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getCollaborationLinks");
+    Assertions.assertThat(links)
+        .hasSize(2)
+        .extracting(link -> link.get("permission"))
+        .containsExactlyInAnyOrder("READ_AND_SHARE", "READ_WRITE_AND_SHARE");
+  }
+
+  @Test
+  void givenAShareTargetWithReadAndShareOnlyTheGetCollaborationLinksShouldReturnOnlyThatTier() {
+    // Given — both tiers exist, but the requester's own ACL only covers READ_AND_SHARE
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createCollaborationLink(NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+    createShare(NODE_ID, READ_SHARE_TARGET_ID, SharePermission.READ_AND_SHARE);
+
+    // When
+    HttpResponse httpResponse = getCollaborationLinks("ZM_AUTH_TOKEN=fake-token-b", NODE_ID);
+
+    // Then — the READ_WRITE_AND_SHARE-tier link is invisible to this requester
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> links =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getCollaborationLinks");
+    Assertions.assertThat(links).hasSize(1);
+    Assertions.assertThat(links.get(0)).containsEntry("permission", "READ_AND_SHARE");
+  }
+
+  @Test
+  void givenAShareTargetWithReadWriteAndShareTheGetCollaborationLinksShouldReturnBothTiers() {
+    // Given — a READ_WRITE_AND_SHARE ACL is a bitwise superset of both existing links' tiers
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createCollaborationLink(NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+    createShare(NODE_ID, READ_WRITE_SHARE_TARGET_ID, SharePermission.READ_WRITE_AND_SHARE);
+
+    // When
+    HttpResponse httpResponse = getCollaborationLinks("ZM_AUTH_TOKEN=fake-token-c", NODE_ID);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> links =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getCollaborationLinks");
+    Assertions.assertThat(links)
+        .hasSize(2)
+        .extracting(link -> link.get("permission"))
+        .containsExactlyInAnyOrder("READ_AND_SHARE", "READ_WRITE_AND_SHARE");
+  }
+
+  @Test
+  void givenAShareTargetWithoutShareRightsTheGetCollaborationLinksShouldReturnAPermissionDeniedError() {
+    // Given — READ_ONLY carries no SHARE bit, so the requester never passes the top-level gate
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createShare(NODE_ID, READ_SHARE_TARGET_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = getCollaborationLinks("ZM_AUTH_TOKEN=fake-token-b", NODE_ID);
+
+    // Then — data is a one-element list whose only element is null, plus one top-level error
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> links =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getCollaborationLinks");
+    Assertions.assertThat(links).hasSize(1);
+    Assertions.assertThat(links.get(0)).isNull();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + NODE_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenAnOwnerTheFileCollaborationLinksFieldShouldResolveBothLinks() {
+    // Given — the File.collaboration_links field-resolver path (getNode -> collaboration_links)
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createCollaborationLink(NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", NODE_ID)
+            .withWantedResultFormat("{ id collaboration_links { id permission } }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    List<Map<String, Object>> links = (List<Map<String, Object>>) node.get("collaboration_links");
+    Assertions.assertThat(links)
+        .hasSize(2)
+        .extracting(link -> link.get("permission"))
+        .containsExactlyInAnyOrder("READ_AND_SHARE", "READ_WRITE_AND_SHARE");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenAnOwnerTheFolderCollaborationLinksFieldShouldResolveTheExistingLink() {
+    // Given — the Folder.collaboration_links field-resolver path (distinct type-wiring entry from
+    // File, same underlying fetcher instance)
+    createFolder(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", NODE_ID)
+            .withWantedResultFormat("{ id collaboration_links { id permission } }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    List<Map<String, Object>> links = (List<Map<String, Object>>) node.get("collaboration_links");
+    Assertions.assertThat(links).hasSize(1);
+    Assertions.assertThat(links.get(0)).containsEntry("permission", "READ_AND_SHARE");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenAShareTargetWithoutShareRightsTheFileCollaborationLinksFieldShouldReturnAScopedError() {
+    // Given — the requester passes getNode's own top-level READ_ONLY gate (see
+    // NodePermissionsFieldApiIT's finding) but fails the collaboration_links sub-field's own
+    // READ_AND_SHARE/READ_WRITE_AND_SHARE gate
+    createFile(NODE_ID, OWNER_ID);
+    createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    createShare(NODE_ID, READ_SHARE_TARGET_ID, SharePermission.READ_ONLY);
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", NODE_ID)
+            .withWantedResultFormat("{ id collaboration_links { id permission } }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-b", bodyPayload));
+
+    // Then — the node itself resolves (id present), only the sub-field errors
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).containsEntry("id", NODE_ID);
+    List<Map<String, Object>> links = (List<Map<String, Object>>) node.get("collaboration_links");
+    Assertions.assertThat(links).hasSize(1);
+    Assertions.assertThat(links.get(0)).isNull();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "There was a problem while executing requested operation on node: " + NODE_ID);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetConfigsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetConfigsApiIT.java
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 5.1 of the acceptance coverage-expansion plan: {@code ConfigDataFetcher#getConfigs} (bound
+ * to the {@code getConfigs} query).
+ *
+ * <p><b>Why this class does NOT use the usual static-app/{@code @BeforeAll} skeleton:</b> the two
+ * scenarios below differ ONLY in the ServiceDiscover mock's BUILD-TIME state (whether {@code
+ * max-number-of-versions} is stubbed at all, and to what value). {@code ConfigDataFetcher} re-hits
+ * ServiceDiscover on every {@code getConfigs} call, but the only seam knob able to shape that
+ * mock's KV response at all is {@code GuiceNettyFilesTestAppBuilder#withMaxNumberOfVersions(int)},
+ * which must run BEFORE {@code build()} (see its own javadoc and {@code
+ * Simulator#setMaxNumberOfVersions}). A single shared class-level app cannot host both the "happy"
+ * and the "ServiceDiscover-down" scenario at once. This follows the existing precedent of {@code
+ * HealthApiIT}/{@code MetricsApiIT}: a fresh, disposable {@code FilesTestApp} per test via
+ * try-with-resources; no {@code @BeforeAll}/{@code @AfterEach}/{@code @AfterAll} is needed since
+ * {@code getConfigs} touches no node/file/share state at all (nothing to reset between tests).
+ *
+ * <p><b>MISSING SEAM CAPABILITY for the plan's third scenario (reported, NOT built — see the task
+ * instructions and plan §2.5):</b> a non-numeric {@code max-number-of-versions} value from
+ * ServiceDiscover, which would make {@code ConfigDataFetcher#updateMaxKeepVersionsValue}'s uncaught
+ * {@code Integer.parseInt(...)} throw, CANNOT be constructed with the seam as it exists today:
+ *
+ * <ul>
+ *   <li>{@code GuiceNettyFilesTestAppBuilder#withMaxNumberOfVersions(int)} takes an {@code int} —
+ *       there is no overload accepting an arbitrary/non-numeric {@code String};
+ *   <li>{@code Simulator#serviceDiscoverMock} (the MockServer client that actually answers the KV
+ *       GETs) has NO getter — unlike {@code getStoragesMock()}/{@code getPreviewMock()}/{@code
+ *       getDocsConnectorMock()}/{@code getMailboxMock()}, there is no {@code
+ *       getServiceDiscoverMock()}, so {@code GuiceNettyMocks} has no way to reach it at all;
+ *   <li>consequently {@code Mocks} has no method to stub an arbitrary KV response (a raw string
+ *       value, a non-200 status, or a deliberately-missing key) for ANY ServiceDiscover key — only
+ *       the one hardwired "{@code max-number-of-versions} as a valid integer" path that {@code
+ *       withMaxNumberOfVersions(int)} exposes.
+ * </ul>
+ *
+ * <p><b>Recommended central addition</b> (per the task instructions, NOT added here without
+ * approval): a general {@code Mocks#serviceDiscoverReturns(String key, String rawValue)}
+ * (arbitrary/non-numeric string) and/or {@code Mocks#serviceDiscoverConfigDown(String key)} (force
+ * a non-200/error response for one key), ideally backed by exposing {@code
+ * Simulator#getServiceDiscoverMock()} the same way the other four dependency mocks already are.
+ * With either in place, the expected assertion is already known from reading {@code
+ * GraphQLProvider}'s unhandled-exception wrapping (the same mechanism verified empirically
+ * elsewhere in this suite, e.g. {@code CloneVersionApiIT}'s {@code "Exception while fetching data
+ * (/cloneVersion) : ..."}): a single GraphQL error, {@code "Exception while fetching data
+ * (/getConfigs) : For input string: \"<value>\""}, with {@code data.getConfigs} absent — NOT
+ * asserted below since it cannot be constructed honestly today.
+ *
+ * <p>Also documents a related, narrower finding: with the CURRENT seam, {@code
+ * max-uploadable-size-in-mb}/{@code max-downloadable-size-in-mb} can NEVER be observed as anything
+ * other than {@code null} — there is no builder knob or {@code Mocks} method that stubs either key
+ * to a real ServiceDiscover value, so the "happy" and "ServiceDiscover-down" scenarios are
+ * indistinguishable for these two keys specifically (both assert {@code null} below, honestly).
+ */
+class GetConfigsApiIT {
+
+  private static final String GET_CONFIGS_QUERY = "query { getConfigs { name value } }";
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+  private static Map<String, String> toConfigMap(List<Map<String, Object>> configs) {
+    Map<String, String> map = new HashMap<>();
+    configs.forEach(config -> map.put((String) config.get("name"), (String) config.get("value")));
+    return map;
+  }
+
+  private HttpResponse getConfigs(FilesTestApp app) {
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", GET_CONFIGS_QUERY);
+    return app.send(httpRequest);
+  }
+
+  @Test
+  void givenAConfiguredMaxNumberOfVersionsGetConfigsShouldReturnItAndTheDerivedKeepCap() {
+    // Given — max-number-of-versions stubbed at BUILD TIME to a value distinct from the hardcoded
+    // 30 default, so a passing assertion actually proves the value came from ServiceDiscover and
+    // not from the fallback default asserted in the sibling test below.
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withMaxNumberOfVersions(12)
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build()) {
+
+      // When
+      HttpResponse httpResponse = getConfigs(app);
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Map<String, String> configs =
+          toConfigMap(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getConfigs"));
+
+      Assertions.assertThat(configs)
+          .containsEntry("max-number-of-versions", "12")
+          // derived = configured - 2 (Constants.ServiceDiscover.Config.DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION)
+          .containsEntry("max-number-of-keep-versions", "10");
+
+      // Documents the actual, ONLY achievable behaviour of these two keys with the current seam
+      // (see class javadoc): every buildable configuration shows them as null.
+      Assertions.assertThat(configs.get("max-uploadable-size-in-mb")).isNull();
+      Assertions.assertThat(configs.get("max-downloadable-size-in-mb")).isNull();
+    }
+  }
+
+  @Test
+  void givenServiceDiscoverDoesNotServeTheseKeysGetConfigsShouldFallBackToDefaults() {
+    // Given — ServiceDiscover mock started, but max-number-of-versions/size keys deliberately NOT
+    // stubbed (withMaxNumberOfVersions is never called here): MockServer answers any unmatched GET
+    // with its default 404, so ServiceDiscoverHttpClient#getConfig fails (Try.failure) for every
+    // one of these keys — from this client's point of view this is indistinguishable from a real
+    // ServiceDiscover outage or a genuinely-missing key.
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build()) {
+
+      // When
+      HttpResponse httpResponse = getConfigs(app);
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Map<String, String> configs =
+          toConfigMap(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getConfigs"));
+
+      Assertions.assertThat(configs)
+          .containsEntry("max-number-of-versions", "30")
+          .containsEntry("max-number-of-keep-versions", "28");
+      Assertions.assertThat(configs.get("max-uploadable-size-in-mb")).isNull();
+      Assertions.assertThat(configs.get("max-downloadable-size-in-mb")).isNull();
+    }
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetConfigsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetConfigsApiIT.java
@@ -31,35 +31,16 @@ import org.junit.jupiter.api.Test;
  * try-with-resources; no {@code @BeforeAll}/{@code @AfterEach}/{@code @AfterAll} is needed since
  * {@code getConfigs} touches no node/file/share state at all (nothing to reset between tests).
  *
- * <p><b>MISSING SEAM CAPABILITY for the plan's third scenario (reported, NOT built — see the task
- * instructions and plan §2.5):</b> a non-numeric {@code max-number-of-versions} value from
- * ServiceDiscover, which would make {@code ConfigDataFetcher#updateMaxKeepVersionsValue}'s uncaught
- * {@code Integer.parseInt(...)} throw, CANNOT be constructed with the seam as it exists today:
- *
- * <ul>
- *   <li>{@code GuiceNettyFilesTestAppBuilder#withMaxNumberOfVersions(int)} takes an {@code int} —
- *       there is no overload accepting an arbitrary/non-numeric {@code String};
- *   <li>{@code Simulator#serviceDiscoverMock} (the MockServer client that actually answers the KV
- *       GETs) has NO getter — unlike {@code getStoragesMock()}/{@code getPreviewMock()}/{@code
- *       getDocsConnectorMock()}/{@code getMailboxMock()}, there is no {@code
- *       getServiceDiscoverMock()}, so {@code GuiceNettyMocks} has no way to reach it at all;
- *   <li>consequently {@code Mocks} has no method to stub an arbitrary KV response (a raw string
- *       value, a non-200 status, or a deliberately-missing key) for ANY ServiceDiscover key — only
- *       the one hardwired "{@code max-number-of-versions} as a valid integer" path that {@code
- *       withMaxNumberOfVersions(int)} exposes.
- * </ul>
- *
- * <p><b>Recommended central addition</b> (per the task instructions, NOT added here without
- * approval): a general {@code Mocks#serviceDiscoverReturns(String key, String rawValue)}
- * (arbitrary/non-numeric string) and/or {@code Mocks#serviceDiscoverConfigDown(String key)} (force
- * a non-200/error response for one key), ideally backed by exposing {@code
- * Simulator#getServiceDiscoverMock()} the same way the other four dependency mocks already are.
- * With either in place, the expected assertion is already known from reading {@code
- * GraphQLProvider}'s unhandled-exception wrapping (the same mechanism verified empirically
- * elsewhere in this suite, e.g. {@code CloneVersionApiIT}'s {@code "Exception while fetching data
- * (/cloneVersion) : ..."}): a single GraphQL error, {@code "Exception while fetching data
- * (/getConfigs) : For input string: \"<value>\""}, with {@code data.getConfigs} absent — NOT
- * asserted below since it cannot be constructed honestly today.
+ * <p><b>Gap-closing pass addition:</b> the plan's third scenario (a non-numeric {@code
+ * max-number-of-versions} value from ServiceDiscover, which makes {@code
+ * ConfigDataFetcher#updateMaxKeepVersionsValue}'s uncaught {@code Integer.parseInt(...)} throw)
+ * previously could not be constructed — {@code Simulator} exposed no {@code
+ * getServiceDiscoverMock()} and {@code Mocks} had no way to stub an arbitrary KV value. Both gaps
+ * are now closed: {@code Simulator#getServiceDiscoverMock()} mirrors the other four dependency
+ * mock getters, and {@code Mocks#serviceDiscoverReturns(String, String)}/{@code
+ * #serviceDiscoverConfigDown(String)} stub an arbitrary raw KV value / a connection-level outage
+ * for any key. See {@link #givenNonNumericMaxNumberOfVersionsGetConfigsShouldSurfaceAnExecutionError()}
+ * and {@link #givenServiceDiscoverConnectionDropsGetConfigsShouldStillFallBackToDefaults()} below.
  *
  * <p>Also documents a related, narrower finding: with the CURRENT seam, {@code
  * max-uploadable-size-in-mb}/{@code max-downloadable-size-in-mb} can NEVER be observed as anything
@@ -146,6 +127,111 @@ class GetConfigsApiIT {
           .containsEntry("max-number-of-keep-versions", "28");
       Assertions.assertThat(configs.get("max-uploadable-size-in-mb")).isNull();
       Assertions.assertThat(configs.get("max-downloadable-size-in-mb")).isNull();
+    }
+  }
+
+  /**
+   * Closes {@code ConfigDataFetcher#updateMaxKeepVersionsValue}'s missing branch: both scenarios
+   * above only ever exercise {@code maxVersions > DIFF_MAX_VERSION_AND_MAX_KEEP_VERSION} (12-2=10
+   * and 30-2=28). At-or-below the diff (2), the derived cap must clamp to {@code "0"} instead of
+   * going negative.
+   */
+  @Test
+  void givenMaxNumberOfVersionsAtTheDiffThenDerivedKeepCapClampsToZero() {
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withMaxNumberOfVersions(2)
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build()) {
+
+      HttpResponse httpResponse = getConfigs(app);
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Map<String, String> configs =
+          toConfigMap(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getConfigs"));
+
+      Assertions.assertThat(configs)
+          .containsEntry("max-number-of-versions", "2")
+          .containsEntry("max-number-of-keep-versions", "0");
+    }
+  }
+
+  /**
+   * Closes {@code ConfigDataFetcher.getConfigs}'s uncaught-{@code NumberFormatException} finding
+   * (§9): a non-numeric ServiceDiscover value for {@code max-number-of-versions} is never caught,
+   * so the whole {@code getConfigs} data fetcher fails and surfaces as a single generic GraphQL
+   * execution error (the same wrapping mechanism verified elsewhere in this suite, e.g. {@code
+   * CloneVersionApiIT}'s {@code "Exception while fetching data (/cloneVersion) : ..."}), NOT a 500
+   * or a per-field error.
+   *
+   * <p><b>Ordering finding:</b> the bad value must be stubbed AFTER a warm-up {@code getConfigs}
+   * call, not before. {@code NodeDataFetcher}'s constructor ALSO does an eager, unguarded {@code
+   * Integer.parseInt} on this exact same key (see plan §2.4/Task 0.3) — but only once, the first
+   * time Guice lazily instantiates it for this {@code FilesTestApp}. Stubbing the bad value before
+   * the very first request makes NodeDataFetcher's OWN construction crash instead (a {@code
+   * ProvisionException} out of {@code injector.getInstance(...)}, not a graceful GraphQL error) —
+   * empirically confirmed, and a more severe sibling finding than the one this test targets. The
+   * warm-up forces NodeDataFetcher to construct first (with a valid/default value), isolating the
+   * one behaviour this test documents: {@code ConfigDataFetcher} re-reads this key LIVE on every
+   * call and has no such guard.
+   */
+  @Test
+  void givenNonNumericMaxNumberOfVersionsGetConfigsShouldSurfaceAnExecutionError() {
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build()) {
+      // Warm-up: forces NodeDataFetcher's construction now, while the key is still unstubbed
+      // (ServiceDiscover mock answers 404 -> the safe default).
+      Assertions.assertThat(getConfigs(app).getStatus()).isEqualTo(200);
+
+      app.mocks().serviceDiscoverReturns("max-number-of-versions", "not-a-number");
+
+      HttpResponse httpResponse = getConfigs(app);
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+      Assertions.assertThat(errors)
+          .hasSize(1)
+          .containsExactly(
+              "Exception while fetching data (/getConfigs) : For input string: \"not-a-number\"");
+      Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "getConfigs"))
+          .isEmpty();
+    }
+  }
+
+  /**
+   * Closes {@code ServiceDiscoverHttpClient#getConfig}'s {@code catch (IOException)} branch: a
+   * connection-level outage (distinct from the "key never stubbed" scenario above, which only
+   * ever exercises the "non-200 status" branch since MockServer answers unmatched paths with a
+   * plain 404) is caught and wrapped into a {@code Try.failure}, which {@code ConfigDataFetcher}
+   * treats identically to any other failure — falling back to the same default.
+   */
+  @Test
+  void givenServiceDiscoverConnectionDropsGetConfigsShouldStillFallBackToDefaults() {
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build()) {
+      app.mocks().serviceDiscoverConfigDown("max-number-of-versions");
+
+      HttpResponse httpResponse = getConfigs(app);
+
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+      Map<String, String> configs =
+          toConfigMap(TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getConfigs"));
+
+      Assertions.assertThat(configs)
+          .containsEntry("max-number-of-versions", "30")
+          .containsEntry("max-number-of-keep-versions", "28");
     }
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNodeEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNodeEdgeApiIT.java
@@ -197,6 +197,26 @@ class GetNodeEdgeApiIT {
         .containsExactly("Could not find node with id " + nodeId);
   }
 
+  /**
+   * Closes {@code GenericControllerEvaluator#validateNodeId}'s missing branch: {@code
+   * RootId.TRASH_ROOT} is a special-cased valid id (alongside {@code LOCAL_ROOT}, already
+   * exercised elsewhere in the suite e.g. via {@code createFolder(parent_id: "LOCAL_ROOT")}), but
+   * no test ever passed {@code "TRASH_ROOT"} itself as a {@code getNode} argument, so that
+   * specific {@code || nodeId.equals(RootId.TRASH_ROOT)} branch direction was never taken.
+   */
+  @Test
+  void givenTrashRootAsNodeIdDirectGetNodeShouldPassValidationAndResolve() {
+    // When
+    HttpResponse httpResponse =
+        getNode("TRASH_ROOT", null, "{ id }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — no "Invalid node ID" validation error; TRASH_ROOT resolves like any other root id.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).containsEntry("id", "TRASH_ROOT");
+  }
+
   @Test
   void givenARequestedVersionThatDoesNotExistGetNodeReturnsBaseDataPlusAnError() {
     // Given — a file that only has version 1

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNodeEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNodeEdgeApiIT.java
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.6 (part 2) of the acceptance coverage-expansion plan: edge branches of {@code
+ * NodeDataFetcher#getNodeFetcher}, which is bound BOTH to the top-level {@code getNode} query AND
+ * to the {@code parent} field on {@code File}/{@code Folder} (source: reading {@code
+ * getNodeFetcher}'s body, which special-cases {@code environment.getField().getName().equals(
+ * "parent")} into an {@code isParent} flag).
+ *
+ * <p>Both call sites share the SAME permission gate ({@code
+ * permissionsChecker.getPermissions(nodeId, requesterId).has(READ_ONLY)}), but they react
+ * DIFFERENTLY when it fails:
+ *
+ * <ul>
+ *   <li>direct {@code getNode(node_id: ...)} (not-found OR permission-denied — the gate cannot
+ *       distinguish the two, per the existing {@code NodePermissionsFieldApiIT} finding): returns
+ *       a {@code nodeNotFound} GraphQL ERROR — {@code "Could not find node with id <id>"};
+ *   <li>{@code parent} field resolution: returns an EMPTY {@code DataFetcherResult} (no data, NO
+ *       error) — the field is simply {@code null}, completely silently.
+ * </ul>
+ *
+ * <p>To observe the silent {@code parent: null} path for real (as opposed to the gate failing on
+ * the child itself, which would fail the whole {@code getNode} call before {@code parent} is even
+ * reached), the child node must be one the requester CAN read while its PARENT is one the
+ * requester CANNOT — constructed here via the raw backdoor with an owner/parent-owner mismatch
+ * that the real API's owner-inheritance-on-creation would never produce naturally (same
+ * technique as {@code CreateFolderApiIT}'s and {@code GetPathApiIT}'s deliberately-inconsistent
+ * fixtures).
+ *
+ * <p>Also covers the missing-version partial-result branch of {@code
+ * convertNodeToDataFetcherResult}: when a requested {@code version} doesn't match any {@code
+ * FileVersion} row, the base Node fields (id/name/type/...) are still populated in {@code data}
+ * (the {@code DataFetcherResult.Builder} already carries {@code .data(result)} before the version
+ * check ever runs) while a {@code fileVersionNotFound} error is ALSO attached to the SAME result —
+ * both appear together in the response, not one instead of the other.
+ */
+class GetNodeEdgeApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private HttpResponse getNode(String nodeId, Integer version, String resultFormat, String cookie) {
+    GraphqlCommandBuilder builder =
+        GraphqlCommandBuilder.aQueryBuilder("getNode").withString("node_id", nodeId);
+    if (version != null) {
+      builder.withInteger("version", version);
+    }
+    String bodyPayload = builder.withWantedResultFormat(resultFormat).build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @Test
+  void givenAReadableChildWithAnUnreadableParentTheParentFieldIsSilentlyNull() {
+    // Given — folder P owned by OTHER_USER_ID, never shared with the requester (unreadable to
+    // them); child C is owned by the REQUESTER (so the requester CAN read C directly) but is
+    // structurally parented under P. This owner/parent-owner mismatch is not producible through
+    // the real createFolder/upload mutations (which always inherit the parent's owner), but is a
+    // valid raw DB state and is exactly what isolates the "parent unreadable" branch from the
+    // "child unreadable" branch (which would fail before ever reaching `parent`).
+    String parentId = "10000000-0000-0000-0000-000000000001";
+    String childId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                parentId, OTHER_USER_ID, OTHER_USER_ID, "LOCAL_ROOT", "privateParent", "",
+                NodeType.FOLDER, "LOCAL_ROOT", 0L, null))
+        .addNode(
+            new PopulatorNode(
+                childId, REQUESTER_ID, REQUESTER_ID, parentId, "child.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentId, 1L, "text/plain"));
+
+    // When
+    HttpResponse httpResponse =
+        getNode(childId, null, "{ id parent { id } }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — getNode itself succeeds (the requester owns the child), but parent is silently null
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).containsEntry("id", childId);
+    Assertions.assertThat(node.get("parent")).isNull();
+  }
+
+  @Test
+  void givenAReadableParentTheParentFieldResolvesNormally() {
+    // Given — contrast case: same shape, but the parent IS owned by the requester, so it IS
+    // readable and the field resolves to real data instead of silently going null.
+    String parentId = "10000000-0000-0000-0000-000000000002";
+    String childId = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                parentId, REQUESTER_ID, REQUESTER_ID, "LOCAL_ROOT", "myParent", "",
+                NodeType.FOLDER, "LOCAL_ROOT", 0L, null))
+        .addNode(
+            new PopulatorNode(
+                childId, REQUESTER_ID, REQUESTER_ID, parentId, "child2.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentId, 1L, "text/plain"));
+
+    // When
+    HttpResponse httpResponse =
+        getNode(childId, null, "{ id parent { id } }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat((Map<String, Object>) node.get("parent")).containsEntry("id", parentId);
+  }
+
+  @Test
+  void givenANonExistentNodeDirectGetNodeShouldReturnNodeNotFoundError() {
+    // Given
+    String nonExistentId = "00000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse =
+        getNode(nonExistentId, null, "{ id }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — unlike the `parent` field, direct getNode surfaces a real error
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id " + nonExistentId);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).isEmpty();
+  }
+
+  @Test
+  void givenNoPermissionOnAnExistingNodeDirectGetNodeShouldReturnNodeNotFoundError() {
+    // Given — exists, owned by someone else, never shared
+    String nodeId = "00000000-0000-0000-0000-000000000003";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId, OTHER_USER_ID, OTHER_USER_ID, "LOCAL_ROOT", "notMine.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"));
+
+    // When
+    HttpResponse httpResponse = getNode(nodeId, null, "{ id }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — same nodeNotFound-shaped error as the not-found case; the gate cannot distinguish them
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id " + nodeId);
+  }
+
+  @Test
+  void givenARequestedVersionThatDoesNotExistGetNodeReturnsBaseDataPlusAnError() {
+    // Given — a file that only has version 1
+    String nodeId = "00000000-0000-0000-0000-000000000004";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId, REQUESTER_ID, REQUESTER_ID, "LOCAL_ROOT", "versioned.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"));
+
+    // When — request a version that was never created
+    HttpResponse httpResponse =
+        getNode(nodeId, 999, "{ id name type }", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — base node data IS present...
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node)
+        .containsEntry("id", nodeId)
+        .containsEntry("name", "versioned")
+        .containsEntry("type", NodeType.TEXT.toString());
+
+    // ...alongside (not instead of) the version-not-found error
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find version: 999 for node with id " + nodeId);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNotificationsVariantsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetNotificationsVariantsApiIT.java
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.5 (part 3) of the acceptance coverage-expansion plan: direct coverage of {@code
+ * getNotifications} itself (as opposed to the existing notification ITs, which only assert that a
+ * notification was created as a side effect of some other mutation).
+ *
+ * <p><b>FINDING (overrides the plan's brief):</b> the plan asked for "not-found/permission/
+ * validation variants (none exist today)". {@code NotificationDataFetcher#getNotificationsFetcher}
+ * has NONE of these three kinds of branches at all:
+ *
+ * <ul>
+ *   <li>no permission concept — the query is entirely scoped to the requester's own notifications,
+ *       there is no target id to be denied access to;
+ *   <li>no schema field-validator is bound to {@code getNotifications} in {@code
+ *       GraphQLProvider#buildValidationInstrumentation} (unlike {@code findNodes}/{@code
+ *       getNode.children}), so no custom validation error can ever fire;
+ *   <li>an invalid/unknown {@code page_token} is NOT a not-found error: {@code
+ *       NotificationRepositoryEbean#doFind} looks up the token's {@code UserNotificationInterest}
+ *       row and, when absent, silently falls back to an empty notification id list — {@code
+ *       getNotifications} returns 200 with an empty {@code notifications} array, never an error.
+ * </ul>
+ *
+ * <p>Given there is no error surface to exercise, this file instead pins the real reachable
+ * "variant" behaviour: first-time-user fallback, the {@code update_last_seen} unread/last_seen
+ * side effects (including the not-entirely-obvious fact that the CURRENT call's response reports
+ * the counters as they were BEFORE this call's own reset), pagination via {@code page_token}
+ * (including the exactly-at-the-limit case), and the silently-empty garbage-token case above.
+ */
+class GetNotificationsVariantsApiIT {
+
+  static FilesTestApp app;
+
+  private static final String RECEIVER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String SHARER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String FRESH_USER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", RECEIVER_ID,
+                    "fake-token-sharer", SHARER_ID,
+                    "fake-token-fresh", FRESH_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  /** Shares a fresh node from {@code SHARER_ID} to {@code RECEIVER_ID}, creating one NewShare notification. */
+  private void shareANewNodeWithReceiver(String nodeId) {
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, SHARER_ID, nodeId.substring(0, 8) + ".txt"));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createShare")
+            .withString("node_id", nodeId)
+            .withString("share_target_id", RECEIVER_ID)
+            .withEnum("permission", ACL.SharePermission.READ_ONLY)
+            .withWantedResultFormat("{ created_at }")
+            .build();
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-sharer", bodyPayload);
+    HttpResponse httpResponse = app.send(httpRequest);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getNotifications(
+      boolean updateLastSeen, Integer limit, String pageToken, String cookie) {
+    GraphqlCommandBuilder builder =
+        GraphqlCommandBuilder.aQueryBuilder("getNotifications")
+            .withBoolean("update_last_seen", updateLastSeen);
+    if (limit != null) {
+      builder.withInteger("limit", limit);
+    }
+    if (pageToken != null) {
+      builder.withString("page_token", pageToken);
+    }
+    String bodyPayload =
+        builder
+            .withWantedResultFormat(
+                "{ notifications { ... on NewShare { id } }, unread, last_seen, page_token }")
+            .build();
+
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    HttpResponse httpResponse = app.send(httpRequest);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+
+    return TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNotifications");
+  }
+
+  @Test
+  void givenAUserWithNoPriorNotificationsInfoGetNotificationsFallsBackToZeroUnreadAndZeroLastSeen() {
+    // When — FRESH_USER_ID has never received a notification and has no UserNotificationsInfo row
+    Map<String, Object> page = getNotifications(false, null, null, "ZM_AUTH_TOKEN=fake-token-fresh");
+
+    // Then
+    Assertions.assertThat((List<Object>) page.get("notifications")).isEmpty();
+    Assertions.assertThat(page).containsEntry("unread", 0).containsEntry("last_seen", 0);
+    Assertions.assertThat(page.get("page_token")).isNull();
+  }
+
+  @Test
+  void givenUnreadNotificationsUpdateLastSeenTrueReturnsThePreResetCountThenResetsForTheNextCall() {
+    // Given — two notifications waiting, unread counter is 2
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000001");
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000002");
+
+    // When — first call with update_last_seen: true
+    Map<String, Object> firstCall = getNotifications(true, null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — THIS response reports the counter as it was BEFORE this call's own reset
+    Assertions.assertThat((List<Object>) firstCall.get("notifications")).hasSize(2);
+    Assertions.assertThat(firstCall).containsEntry("unread", 2);
+
+    // When — a second call, with no new notifications in between
+    Map<String, Object> secondCall = getNotifications(true, null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — now the counter reflects the reset performed by the first call
+    Assertions.assertThat(secondCall).containsEntry("unread", 0);
+  }
+
+  @Test
+  void givenUpdateLastSeenFalseTheUnreadCounterIsNeverReset() {
+    // Given
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000001");
+
+    // When
+    Map<String, Object> firstCall = getNotifications(false, null, null, "ZM_AUTH_TOKEN=fake-token");
+    Map<String, Object> secondCall = getNotifications(false, null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — unread stays at 1 across repeated update_last_seen: false calls
+    Assertions.assertThat(firstCall).containsEntry("unread", 1);
+    Assertions.assertThat(secondCall).containsEntry("unread", 1);
+  }
+
+  @Test
+  void givenMoreNotificationsThanTheLimitPaginationReturnsAPageTokenThenTheRemainder() {
+    // Given — 3 notifications, page size 2
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000001");
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000002");
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000003");
+
+    // When — first page
+    Map<String, Object> firstPage = getNotifications(false, 2, null, "ZM_AUTH_TOKEN=fake-token");
+    List<Map<String, Object>> firstPageNotifications =
+        (List<Map<String, Object>>) firstPage.get("notifications");
+
+    // Then — exactly at the limit still returns a (possibly "useless") page_token
+    Assertions.assertThat(firstPageNotifications).hasSize(2);
+    Assertions.assertThat(firstPage.get("page_token")).isNotNull();
+
+    // When — second page, using the returned token
+    String pageToken = (String) firstPage.get("page_token");
+    Map<String, Object> secondPage = getNotifications(false, 2, pageToken, "ZM_AUTH_TOKEN=fake-token");
+    List<Map<String, Object>> secondPageNotifications =
+        (List<Map<String, Object>>) secondPage.get("notifications");
+
+    // Then — the remaining single notification, and no further page
+    Assertions.assertThat(secondPageNotifications).hasSize(1);
+    Assertions.assertThat(secondPage.get("page_token")).isNull();
+
+    // and no notification id is repeated across the two pages
+    List<String> firstIds = firstPageNotifications.stream().map(n -> (String) n.get("id")).toList();
+    List<String> secondIds = secondPageNotifications.stream().map(n -> (String) n.get("id")).toList();
+    Assertions.assertThat(firstIds).doesNotContainAnyElementsOf(secondIds);
+  }
+
+  /**
+   * See the class-level FINDING: an unrecognised {@code page_token} is swallowed silently rather
+   * than surfaced as an error.
+   */
+  @Test
+  void givenAGarbagePageTokenGetNotificationsSilentlyReturnsAnEmptyPageInsteadOfAnError() {
+    // Given
+    shareANewNodeWithReceiver("00000000-0000-0000-0000-000000000001");
+
+    // When
+    Map<String, Object> page =
+        getNotifications(false, null, "not-a-real-page-token", "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat((List<Object>) page.get("notifications")).isEmpty();
+    Assertions.assertThat(page.get("page_token")).isNull();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPathApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPathApiIT.java
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.6 (part 1) of the acceptance coverage-expansion plan: direct coverage of {@code
+ * NodeDataFetcher#getPathFetcher}, which no existing acceptance test exercises at all.
+ *
+ * <p>{@code getPathFetcher} gates entry with the exact same per-node {@code
+ * permissionsChecker.getPermissions(nodeId, requesterId).has(READ_ONLY)} check used by {@code
+ * getNode} (confirmed by reading the source): if the requester has no relationship (not owner, no
+ * {@code Share} row) with the REQUESTED node itself, it returns a single-element list carrying a
+ * {@code nodeNotFound} error — {@code "Could not find node with id <id>"} — exactly like {@code
+ * getNode} (see {@code NodePermissionsFieldApiIT}'s prior finding). Once past that gate, the
+ * behaviour bifurcates on {@code node.getOwnerId().equals(requesterId)} (or {@code node.getType()
+ * == ROOT}):
+ *
+ * <ul>
+ *   <li>owner branch: the FULL ancestor chain is returned, from {@code LOCAL_ROOT} to the node,
+ *       with NO per-ancestor permission check at all (it trusts that owning a node implies the
+ *       whole chain above it is "yours" to see);
+ *   <li>non-owner branch: it collects {@code Share} rows for the requester across the WHOLE
+ *       ancestor chain (a single {@code shareRepository.getShares(treeNodeIds, requesterId)} call,
+ *       no recursion), then returns the sub-list starting at the FIRST (topmost, root-to-leaf
+ *       order) node that has a matching {@code Share} row, through the requested node itself.
+ * </ul>
+ *
+ * <p><b>FINDING (the plan's "assert current behaviour and file a finding if it throws" hedge on
+ * the inconsistent-share edge):</b> it does NOT throw. Since the initial gate already guarantees
+ * the requested node itself has a matching {@code Share} row (that IS what let it pass the gate in
+ * the non-owner case), {@code sharedNodes} in the non-owner branch is NEVER empty — at minimum it
+ * contains the requested node itself — so {@code sharedNodes.get(0)} never throws {@code
+ * IndexOutOfBoundsException}. When NO ancestor above the requested node has its own {@code Share}
+ * row (the "inconsistent share" edge: a leaf shared directly with no share anywhere on its
+ * ancestor chain — which cannot happen via the real {@code createShare} mutation, since that
+ * cascades share rows DOWN to descendants, but IS directly constructible via the test backdoor's
+ * non-cascading {@code addShare}), the method silently degrades to a ONE-ELEMENT path containing
+ * ONLY the requested node itself — no ancestors, no error. This is a real, silent product
+ * oddity worth flagging: a "path" response of length 1 for a file nested three folders deep gives
+ * the caller zero indication of that nesting.
+ */
+class GetPathApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private PopulatorNode folder(String id, String ownerId, String parentId, String ancestorIds, String name) {
+    return new PopulatorNode(
+        id, ownerId, ownerId, parentId, name, "", NodeType.FOLDER, ancestorIds, 0L, null);
+  }
+
+  private PopulatorNode file(String id, String ownerId, String parentId, String ancestorIds, String name) {
+    return new PopulatorNode(
+        id, ownerId, ownerId, parentId, name, "", NodeType.TEXT, ancestorIds, 1L, "text/plain");
+  }
+
+  private HttpResponse getPathRaw(String nodeId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getPath")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id name }")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  private List<Map<String, Object>> getPath(String nodeId, String cookie) {
+    HttpResponse httpResponse = getPathRaw(nodeId, cookie);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    return TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getPath");
+  }
+
+  @Test
+  void givenOwnedNodeGetPathShouldReturnTheFullChainFromRoot() {
+    // Given — a 3-level chain, fully owned by the requester
+    String folderAId = "10000000-0000-0000-0000-000000000001";
+    String folderBId = "10000000-0000-0000-0000-000000000002";
+    String fileCId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(folder(folderAId, REQUESTER_ID, "LOCAL_ROOT", "LOCAL_ROOT", "folderA"))
+        .addNode(folder(folderBId, REQUESTER_ID, folderAId, "LOCAL_ROOT," + folderAId, "folderB"))
+        .addNode(file(fileCId, REQUESTER_ID, folderBId, "LOCAL_ROOT," + folderAId + "," + folderBId, "fileC.txt"));
+
+    // When
+    List<Map<String, Object>> path = getPath(fileCId, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — the full chain, starting at LOCAL_ROOT itself
+    Assertions.assertThat(path).hasSize(4);
+    Assertions.assertThat(path.get(0)).containsEntry("id", "LOCAL_ROOT").containsEntry("name", "ROOT");
+    Assertions.assertThat(path.get(1)).containsEntry("id", folderAId).containsEntry("name", "folderA");
+    Assertions.assertThat(path.get(2)).containsEntry("id", folderBId).containsEntry("name", "folderB");
+    Assertions.assertThat(path.get(3)).containsEntry("id", fileCId).containsEntry("name", "fileC");
+  }
+
+  @Test
+  void givenASharedSubtreeGetPathShouldStartAtTheHighestSharedAncestorNotAtRoot() {
+    // Given — a 3-level chain owned by OTHER_USER_ID; only folderB and the leaf are individually
+    // shared with the requester (mirrors what the real createShare mutation's cascade would leave
+    // behind if only folderB, not folderA, had ever been shared)
+    String folderAId = "10000000-0000-0000-0000-000000000001";
+    String folderBId = "10000000-0000-0000-0000-000000000002";
+    String fileCId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(folder(folderAId, OTHER_USER_ID, "LOCAL_ROOT", "LOCAL_ROOT", "folderA"))
+        .addNode(folder(folderBId, OTHER_USER_ID, folderAId, "LOCAL_ROOT," + folderAId, "folderB"))
+        .addNode(file(fileCId, OTHER_USER_ID, folderBId, "LOCAL_ROOT," + folderAId + "," + folderBId, "fileC.txt"))
+        .addShare(folderBId, REQUESTER_ID, ACL.SharePermission.READ_ONLY)
+        .addShare(fileCId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    List<Map<String, Object>> path = getPath(fileCId, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — starts at folderB (the highest node with an explicit share), NOT at LOCAL_ROOT nor
+    // at the unshared folderA
+    Assertions.assertThat(path).hasSize(2);
+    Assertions.assertThat(path.get(0)).containsEntry("id", folderBId).containsEntry("name", "folderB");
+    Assertions.assertThat(path.get(1)).containsEntry("id", fileCId).containsEntry("name", "fileC");
+  }
+
+  /**
+   * See the class-level FINDING: this is the "inconsistent share" edge — a leaf shared directly
+   * with no share anywhere on its ancestor chain. It does NOT throw; it silently returns a
+   * one-element path containing only the leaf itself.
+   */
+  @Test
+  void givenALeafSharedWithNoAncestorShareGetPathSilentlyReturnsOnlyTheLeafItself() {
+    // Given — 3-level chain owned by OTHER_USER_ID; ONLY the leaf has a Share row, no ancestor does
+    String folderAId = "10000000-0000-0000-0000-000000000001";
+    String folderBId = "10000000-0000-0000-0000-000000000002";
+    String fileCId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(folder(folderAId, OTHER_USER_ID, "LOCAL_ROOT", "LOCAL_ROOT", "folderA"))
+        .addNode(folder(folderBId, OTHER_USER_ID, folderAId, "LOCAL_ROOT," + folderAId, "folderB"))
+        .addNode(file(fileCId, OTHER_USER_ID, folderBId, "LOCAL_ROOT," + folderAId + "," + folderBId, "fileC.txt"))
+        .addShare(fileCId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = getPathRaw(fileCId, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — silently degrades to a singleton path; no ancestors, no error
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> path =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getPath");
+    Assertions.assertThat(path).hasSize(1);
+    Assertions.assertThat(path.get(0)).containsEntry("id", fileCId).containsEntry("name", "fileC");
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+  }
+
+  @Test
+  void givenNoRelationshipToTheRequestedNodeGetPathShouldReturnNodeNotFound() {
+    // Given — a node owned by OTHER_USER_ID, never shared with the requester at all
+    String fileDId = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(file(fileDId, OTHER_USER_ID, "LOCAL_ROOT", "LOCAL_ROOT", "fileD.txt"));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getPath")
+            .withString("node_id", fileDId)
+            .withWantedResultFormat("{ id name }")
+            .build();
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id " + fileDId);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPublicLinksApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPublicLinksApiIT.java
@@ -2,21 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 
@@ -32,17 +26,12 @@ import org.junit.jupiter.api.Test;
 
 class GetPublicLinksApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static ShareRepository shareRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -51,39 +40,29 @@ class GetPublicLinksApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-account-for-sharing",
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFile(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
   }
 
   void createFolder(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorFolder(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(nodeId, ownerId));
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addShare(nodeId, targetUserId, permission);
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
   }
 
   @Test
@@ -92,7 +71,8 @@ class GetPublicLinksApiIT {
           throws InterruptedException {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
@@ -106,7 +86,8 @@ class GetPublicLinksApiIT {
     // injected clock in the LinkRepository, then we will have a better solution for this ugly trick
     Thread.sleep(500);
 
-    DatabasePopulator.aNodePopulator((simulator.getInjector()))
+    app.backdoor()
+        .populator()
         .addLink(
             "0c04783b-bdfb-446f-870c-625f5ae02a0a",
             "00000000-0000-0000-0000-000000000000",
@@ -125,8 +106,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -162,7 +142,8 @@ class GetPublicLinksApiIT {
   givenAnExistingFolderWithOneExistingLinkTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
@@ -181,8 +162,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -207,7 +187,8 @@ class GetPublicLinksApiIT {
   givenAnExistingFolderWithOneExistingLinkWithAccessCodeTheGetLinksShouldReturnAListContainingTheAssociatedLink() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "06e0f2ae-b128-4d25-9b3b-df84eb7948a9",
             "00000000-0000-0000-0000-000000000000",
@@ -226,8 +207,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -263,8 +243,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -286,8 +265,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -302,7 +280,8 @@ class GetPublicLinksApiIT {
   givenAnExistingNodeALinkAssociatedAndAUserWithoutPermissionsTheGetLinksShouldReturn200StatusCodeAndNull() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "0c04783b-bdfb-446f-870c-625f5ae02a0a",
             "00000000-0000-0000-0000-000000000000",
@@ -322,8 +301,7 @@ class GetPublicLinksApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -338,7 +316,8 @@ class GetPublicLinksApiIT {
   givenAnExistingNodeSharedToAUserWithoutShareRightsAndAnExistingLinkTheGetLinksShouldReturn200CodeAndNull() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addShare(
             "00000000-0000-0000-0000-000000000000",
             "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -362,8 +341,7 @@ class GetPublicLinksApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -377,7 +355,8 @@ class GetPublicLinksApiIT {
   givenAnExistingNodeSharedToAUserWithShareRightsAndAnExistingLinkTheGetLinksShouldReturnAListOfAssociatedLinks() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addShare(
             "00000000-0000-0000-0000-000000000000",
             "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -401,8 +380,7 @@ class GetPublicLinksApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -419,7 +397,8 @@ class GetPublicLinksApiIT {
   givenAnExistingFileAndAnAssociatedLegacyPublicLinkWithAn8CharsPublicIdentifierTheGetLinksShouldReturnItCorrectly() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addShare(
             "00000000-0000-0000-0000-000000000000",
             "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -442,8 +421,7 @@ class GetPublicLinksApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPublicNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/GetPublicNodeApiIT.java
@@ -2,19 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -28,37 +23,33 @@ import org.junit.jupiter.api.Test;
 
 public class GetPublicNodeApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static LinkRepository linkRepository;
-  static FileVersionRepository fileVersionRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover().build().start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
   void givenAPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturnThePublicFolder() {
     // Given
     long now = System.currentTimeMillis();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -88,7 +79,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -107,7 +98,8 @@ public class GetPublicNodeApiIT {
   void givenAPublicLinkIdAndAnExistingFileTheGetPublicNodeShouldReturnThePublicFile() {
     // Given
     long now = System.currentTimeMillis();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -138,7 +130,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -160,7 +152,8 @@ public class GetPublicNodeApiIT {
   void
       givenANotExistingPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -183,7 +176,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -200,7 +193,8 @@ public class GetPublicNodeApiIT {
   void
       givenAnExpiredPublicLinkIdAndAnExistingFolderTheGetPublicNodeShouldReturn200StatusCodeWithAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -230,7 +224,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -247,7 +241,8 @@ public class GetPublicNodeApiIT {
   void givenAPublicLinkIdWithAccessCodeAndAnExistingFolderTheGetPublicNodeWithCorrectCodeShouldReturnThePublicFolder() {
     // Given
     long now = System.currentTimeMillis();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -278,7 +273,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -297,7 +292,8 @@ public class GetPublicNodeApiIT {
   void givenAPublicLinkIdWithAccessCodeAndAnExistingFolderTheGetPublicNodeWithWrongCodeShouldReturnAnErrorMessage() {
     // Given
     long now = System.currentTimeMillis();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -328,7 +324,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -345,7 +341,8 @@ public class GetPublicNodeApiIT {
   void givenAPublicLinkIdWithAccessCodeAndAnExistingFolderTheGetPublicNodeWithNoCodeShouldReturnAnErrorMessage() {
     // Given
     long now = System.currentTimeMillis();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -375,7 +372,7 @@ public class GetPublicNodeApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/HealthApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/HealthApiIT.java
@@ -2,40 +2,35 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.rest.types.health.DependencyType;
 import com.zextras.carbonio.files.rest.types.health.HealthResponse;
 import com.zextras.carbonio.files.rest.types.health.ServiceHealth;
-import io.netty.handler.codec.http.HttpMethod;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockserver.client.MockServerClient;
-import org.mockserver.model.HttpRequest;
-import org.mockserver.model.HttpResponse;
 
 class HealthApiIT {
 
   @Test
   void givenAnHealthServiceTheHealthLiveShouldReturn204StatusCode() {
     // Given
-    SimulatorBuilder simulatorBUilder =
-        SimulatorBuilder.aSimulator().init().withDatabase().withServiceDiscover();
-
-    try (Simulator simulator = simulatorBUilder.build().start()) {
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/live/", null, null);
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .build()) {
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/live/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
@@ -47,55 +42,28 @@ class HealthApiIT {
   void givenAllDependenciesHealthyTheHealthShouldReturn200CodeWithTheHealthStatusOfEachDependency()
       throws Exception {
     // Given
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withMessageBroker()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
             .withStorages()
             .withPreview()
-            .withDocsConnector();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withDocsConnector()
+            .build()) {
 
       // UserManagement health: the InProcess gRPC server is running, so the channel
       // will be in READY/IDLE state and isUserManagementLive() returns true.
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesLive();
+      app.mocks().previewReady();
+      app.mocks().docsConnectorLive();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      // Preview
-      MockServerClient previewServiceMock = simulator.getPreviewMock();
-
-      previewServiceMock
-          .when(
-              HttpRequest.request()
-                  .withMethod(HttpMethod.GET.toString())
-                  .withPath("/health/ready/"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      // DocsConnector
-      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorMock();
-
-      docsConnectorServiceMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/q/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -147,56 +115,29 @@ class HealthApiIT {
       givenUserManagementUnreachableAndOtherDependenciesHealthyTheHealthShouldReturn500CodeWithTheHealthStatusOfEachDependency()
           throws Exception {
     // Given: UM gRPC InProcess server is started then shut down to simulate UM being unreachable
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withMessageBroker()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
             .withStorages()
             .withPreview()
-            .withDocsConnector();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withDocsConnector()
+            .build()) {
 
       // Shut down the UM gRPC server to simulate UM being unreachable.
       // The channel will transition to TRANSIENT_FAILURE state.
-      simulator.shutdownUserManagementServer();
+      app.mocks().userManagementDown();
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesLive();
+      app.mocks().previewReady();
+      app.mocks().docsConnectorLive();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      // Preview
-      MockServerClient previewServiceMock = simulator.getPreviewMock();
-
-      previewServiceMock
-          .when(
-              HttpRequest.request()
-                  .withMethod(HttpMethod.GET.toString())
-                  .withPath("/health/ready/"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      // DocsConnector
-      MockServerClient docsConnectorServiceMock = simulator.getDocsConnectorMock();
-
-      docsConnectorServiceMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/q/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
@@ -246,35 +187,24 @@ class HealthApiIT {
   @Test
   void givenAllMandatoryDependenciesHealthyTheHealthReadyShouldReturn204StatusCode() {
     // Given
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withMessageBroker()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
-            .withStorages();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withStorages()
+            .build()) {
 
       // UserManagement health: the InProcess gRPC server is running, so the channel
       // will be in READY/IDLE state and isUserManagementLive() returns true.
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesLive();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/ready/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/ready/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
@@ -286,35 +216,24 @@ class HealthApiIT {
   void
       givenUserManagementUnreachableAndOtherMandatoryDependenciesReachableTheHealthReadyShouldReturn500StatusCode() {
     // Given: UM gRPC InProcess server is started then shut down to simulate UM being unreachable
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withMessageBroker()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
-            .withStorages();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withStorages()
+            .build()) {
 
       // Shut down the UM gRPC server to simulate UM being unreachable
-      simulator.shutdownUserManagementServer();
+      app.mocks().userManagementDown();
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesLive();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/ready/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/ready/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
@@ -326,35 +245,24 @@ class HealthApiIT {
   void
       givenStoragesUnreachableAndOtherMandatoryDependenciesReachableTheHealthReadyShouldReturn502StatusCode() {
     // Given
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withMessageBroker()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
-            .withStorages();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withStorages()
+            .build()) {
 
       // UserManagement health: the InProcess gRPC server is running, so the channel
       // will be in READY/IDLE state and isUserManagementLive() returns true.
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesUnreachable();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(502));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/ready/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/ready/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
@@ -366,34 +274,23 @@ class HealthApiIT {
   void
   givenMessageBrokerUnreachableAndOtherMandatoryDependenciesReachableTheHealthReadyShouldReturn204StatusCode() {
     // Given
-    SimulatorBuilder simulatorBuilder =
-        SimulatorBuilder.aSimulator()
-            .init()
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(Collections.emptyMap())
-            .withStorages();
-
-    try (Simulator simulator = simulatorBuilder.build().start()) {
+            .withStorages()
+            .build()) {
 
       // UserManagement health: the InProcess gRPC server is running, so the channel
       // will be in READY/IDLE state and isUserManagementLive() returns true.
 
-      // Storages
-      MockServerClient storagesMock = simulator.getStoragesMock();
+      app.mocks().storagesLive();
 
-      storagesMock
-          .when(
-              HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
-          .respond(HttpResponse.response().withStatusCode(200));
-
-      com.zextras.carbonio.files.utilities.http.HttpRequest httpRequest =
-          com.zextras.carbonio.files.utilities.http.HttpRequest.of(
-              HttpMethod.GET.toString(), "/health/ready/", null, null);
+      HttpRequest httpRequest = HttpRequest.of("GET", "/health/ready/", null, null);
 
       // When
-      com.zextras.carbonio.files.utilities.http.HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      HttpResponse httpResponse = app.send(httpRequest);
 
       // Then
       Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/InternalUploadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/InternalUploadApiIT.java
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.3 of the acceptance coverage-expansion plan: {@code POST /internal/upload}. Per {@code
+ * HttpRoutingHandler#channelRead0} ("No auth for internal calls") this route has NO {@code
+ * auth-handler} in its pipeline at all — the {@code AccountId} header is the ONLY thing that
+ * determines ownership, there is no size cap ({@code BlobController#uploadFileInternal} never
+ * calls {@code isRequestSizeOverLimit}, unlike {@code uploadFile}/{@code uploadFileVersion}), and
+ * no notification is ever fired ({@code doUploadFile} passes {@code Optional.empty()} as the
+ * requester entity, which gates {@code BlobService.uploadFile}'s notification branch off
+ * regardless of who else is shared on the destination folder).
+ */
+class InternalUploadApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_USER_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setMaxUploadableSizeMb(null);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String toBase64(String value) {
+    return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Deliberately takes NO cookie parameter: {@code /internal/upload} has no auth-handler. */
+  private HttpResponse internalUpload(String accountId, String parentId, String filenameB64, byte[] body) {
+    List<Map.Entry<String, String>> headers = new ArrayList<>();
+    headers.add(Map.entry("Filename", filenameB64));
+    headers.add(Map.entry("AccountId", accountId));
+    if (parentId != null) {
+      headers.add(Map.entry("ParentId", parentId));
+    }
+    HttpRequest httpRequest =
+        HttpRequest.ofUpload("POST", "/internal/upload", null, headers, body);
+    return app.upload(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getNode(String nodeId, String cookie) {
+    // NOTE: the GraphQL Node interface splits the stored filename into a base `name` (extension
+    // stripped) and a separate `extension` field -- see UploadFileApiIT's helper for detail.
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id name owner { id } ... on File { extension } }")
+            .build();
+    HttpResponse httpResponse = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    return TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+  }
+
+  @Test
+  void givenNoAuthenticationInternalUploadShouldSucceedAndTheAccountIdHeaderShouldDriveOwnership()
+      throws Exception {
+    // Given — deliberately NO cookie at all: this route has no auth-handler in its pipeline.
+    app.mocks().storagesUploadSucceeds();
+
+    // When
+    HttpResponse httpResponse =
+        internalUpload(REQUESTER_ID, null, toBase64("internal.txt"), "content".getBytes(StandardCharsets.UTF_8));
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    String nodeId = (String) json.get("nodeId");
+    Assertions.assertThat(nodeId).isNotBlank();
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+
+    // The AccountId header alone determined the node's owner/creator, with no authenticated
+    // session in play at all.
+    Map<String, Object> node = getNode(nodeId, REQUESTER_COOKIE);
+    Assertions.assertThat(node).containsEntry("name", "internal").containsEntry("extension", "txt");
+    Assertions.assertThat(((Map<String, Object>) node.get("owner"))).containsEntry("id", REQUESTER_ID);
+  }
+
+  @Test
+  void givenABodyOverTheConfiguredSizeCapInternalUploadShouldStillSucceed() throws Exception {
+    // Given — a strict 1MB cap is configured, but /internal/upload never checks it
+    app.mocks().setMaxUploadableSizeMb(1);
+    app.mocks().storagesUploadSucceeds();
+    byte[] oversizedBody = new byte[2 * 1024 * 1024]; // 2MB > the configured 1MB cap
+
+    // When
+    HttpResponse httpResponse =
+        internalUpload(REQUESTER_ID, null, toBase64("big-internal.bin"), oversizedBody);
+
+    // Then — no 413: the size cap is bypassed entirely for the internal route
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsKey("nodeId");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void givenASharedDestinationFolderInternalUploadShouldFireNoAddedNodeNotification() throws Exception {
+    // Given — folder owned by REQUESTER_ID, shared with OTHER_USER_ID (who would normally be
+    // notified of a new node landing in a folder shared with them).
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID, "sharedFolder"));
+
+    String createSharePayload =
+        GraphqlCommandBuilder.aMutationBuilder("createShare")
+            .withString("node_id", folderId)
+            .withString("share_target_id", OTHER_USER_ID)
+            .withEnum("permission", ACL.SharePermission.READ_AND_SHARE)
+            .withWantedResultFormat("{ created_at }")
+            .build();
+    HttpResponse createShareResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", REQUESTER_COOKIE, createSharePayload));
+    Assertions.assertThat(createShareResponse.getStatus()).isEqualTo(200);
+
+    app.mocks().storagesUploadSucceeds();
+
+    // When — internal upload into the shared folder, owned by the folder owner (AccountId)
+    HttpResponse httpResponse =
+        internalUpload(REQUESTER_ID, folderId, toBase64("internal-in-shared.txt"), "content".getBytes(StandardCharsets.UTF_8));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    // Then — OTHER_USER_ID only sees the NewShare notification from createShare; NO AddedNode
+    // notification was created for the internal upload (requesterEntity is Optional.empty(),
+    // which gates BlobService#uploadFile's notification branch off regardless of the share).
+    String getNotificationsPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNotifications")
+            .withBoolean("update_last_seen", true)
+            .withWantedResultFormat(
+                "{ notifications { ... on AddedNode { created_at }, ... on NewShare { created_at } } }")
+            .build();
+    HttpResponse notificationsResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OTHER_USER_COOKIE, getNotificationsPayload));
+    Assertions.assertThat(notificationsResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> page =
+        TestUtils.jsonResponseToMap(notificationsResponse.getBodyPayload(), "getNotifications");
+    List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
+    Assertions.assertThat(notifications).hasSize(1);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/IntrospectionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/IntrospectionApiIT.java
@@ -2,15 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -24,39 +20,29 @@ import java.util.Map;
 
 class IntrospectionApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
                 Map.of(
                     "fake-token",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
@@ -68,8 +54,7 @@ class IntrospectionApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", introspectionQuery);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/InviteRedirectApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/InviteRedirectApiIT.java
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 3.4 of the acceptance coverage-expansion plan: {@code GET /invite/{id}} —
+ * {@code CollaborationLinkController} consuming the 8-char invitation id produced by {@code
+ * createCollaborationLink} (see {@code CreateCollaborationLinkApiIT}) to auto-create/update a
+ * share and 307-redirect. Run on BOTH transports (default embedded + {@code
+ * -Dfiles.test.transport=http}) since this is a redirect route with no aggregator in its pipeline
+ * ({@code HttpRoutingHandler}'s {@code COLLABORATION_LINK} branch is {@code auth-handler ->
+ * collaboration-link-handler -> exceptions-handler}, no {@code HttpObjectAggregator}) — exactly
+ * the kind of route the plan flags as transport-sensitive.
+ *
+ * <p><b>FINDING analysed and verified NOT to cause a transport divergence:</b> {@code
+ * CollaborationLinkController#channelRead0} calls {@code
+ * context.fireChannelRead(new NoSuchElementException())} UNCONDITIONALLY after handling the
+ * request — including on the 307-success path, where it runs right after the {@code
+ * DefaultFullHttpResponse} has already been queued via {@code writeAndFlush(...)
+ * .addListener(ChannelFutureListener.CLOSE)}. This looks alarming but is inert on both transports:
+ * {@code fireChannelRead} propagates an INBOUND pipeline event (a "message was read" signal), not
+ * an outbound write — it never puts another byte on the wire. The next handler in the pipeline,
+ * {@code exceptions-handler} ({@code ExceptionsHandler}), overrides only {@code exceptionCaught}
+ * and not {@code channelRead}, so {@code ChannelInboundHandlerAdapter}'s default implementation
+ * just forwards the object to the pipeline tail, which silently discards a non-{@code ByteBuf}
+ * inbound message (a `DEBUG`-level "discarded message" log, nothing else). The tests below assert
+ * the real, correct 307/404 status/headers/body on both transports to confirm this — a genuine
+ * divergence would show up as a wrong status, an extra response, or a hung/reset connection, none
+ * of which occurs.
+ */
+class InviteRedirectApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String INVITEE_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String NODE_ID = "00000000-0000-0000-0000-000000000000";
+  private static final String EXPECTED_DOMAIN = "example.com";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withStorages()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", INVITEE_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void createFile(String nodeId, String ownerId) {
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+  }
+
+  private void createShare(String nodeId, String targetUserId, SharePermission permission) {
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
+  }
+
+  /** Creates a collaboration link via the mutation and returns its 8-char invitation id. */
+  private String createCollaborationLink(String nodeId, SharePermission permission) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createCollaborationLink")
+            .withString("node_id", nodeId)
+            .withEnumLiteral("permission", permission.name())
+            .withWantedResultFormat("{ url }")
+            .build();
+    HttpResponse response =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    String url =
+        (String)
+            TestUtils.jsonResponseToMap(response.getBodyPayload(), "createCollaborationLink")
+                .get("url");
+    return url.substring(url.length() - 8);
+  }
+
+  private HttpResponse clickInvite(String invitationId, String cookie) {
+    return app.send(HttpRequest.of("GET", "/invite/" + invitationId, cookie, null));
+  }
+
+  private String headerValue(HttpResponse response, String name) {
+    return response.getHeaders().stream()
+        .filter(header -> header.getKey().equalsIgnoreCase(name))
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private String expectedLocation(String nodeId) {
+    return EXPECTED_DOMAIN + "/carbonio/files/?file=" + nodeId + "&node=" + nodeId + "&tab=sharing";
+  }
+
+  /** Reads back a share's permission tier via the API — requires the caller to hold READ_ONLY. */
+  private String getSharePermission(String cookie, String nodeId, String targetUserId) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getShare")
+            .withString("node_id", nodeId)
+            .withString("share_target_id", targetUserId)
+            .withWantedResultFormat("{ permission }")
+            .build();
+    HttpResponse response = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    Map<String, Object> share = TestUtils.jsonResponseToMap(response.getBodyPayload(), "getShare");
+    return (String) share.get("permission");
+  }
+
+  private void deleteNode(String nodeId) {
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteNodes")
+            .withListOfStrings("node_ids", new String[] {nodeId})
+            .withWantedResultFormat("")
+            .build();
+    HttpResponse response =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload));
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void givenAValidInvitationAndANonOwnerTheInviteShouldRedirectAndAutoCreateTheShare() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+    String invitationId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    Assertions.assertThat(app.backdoor().shareExists(NODE_ID, INVITEE_ID)).isFalse();
+
+    // When
+    HttpResponse httpResponse = clickInvite(invitationId, "ZM_AUTH_TOKEN=fake-token-b");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(307);
+    Assertions.assertThat(headerValue(httpResponse, "location")).isEqualTo(expectedLocation(NODE_ID));
+    Assertions.assertThat(headerValue(httpResponse, "content-length")).isEqualTo("0");
+
+    Assertions.assertThat(app.backdoor().shareExists(NODE_ID, INVITEE_ID)).isTrue();
+    Assertions.assertThat(getSharePermission("ZM_AUTH_TOKEN=fake-token-b", NODE_ID, INVITEE_ID))
+        .isEqualTo("READ_AND_SHARE");
+  }
+
+  @Test
+  void givenAnExistingShareTheInviteShouldUpdateItInPlace() {
+    // Given — a pre-existing direct READ_ONLY share, then a READ_WRITE_AND_SHARE collaboration link
+    createFile(NODE_ID, OWNER_ID);
+    createShare(NODE_ID, INVITEE_ID, SharePermission.READ_ONLY);
+    Assertions.assertThat(getSharePermission("ZM_AUTH_TOKEN=fake-token-b", NODE_ID, INVITEE_ID))
+        .isEqualTo("READ_ONLY");
+    String invitationId = createCollaborationLink(NODE_ID, SharePermission.READ_WRITE_AND_SHARE);
+
+    // When
+    HttpResponse httpResponse = clickInvite(invitationId, "ZM_AUTH_TOKEN=fake-token-b");
+
+    // Then — same share row, but its permission tier is now updated, not duplicated
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(307);
+    Assertions.assertThat(headerValue(httpResponse, "location")).isEqualTo(expectedLocation(NODE_ID));
+    Assertions.assertThat(app.backdoor().shareExists(NODE_ID, INVITEE_ID)).isTrue();
+    Assertions.assertThat(getSharePermission("ZM_AUTH_TOKEN=fake-token-b", NODE_ID, INVITEE_ID))
+        .isEqualTo("READ_WRITE_AND_SHARE");
+  }
+
+  @Test
+  void givenTheOwnerClickingItsOwnLinkTheInviteShouldRedirectWithoutAnyShareMutation() {
+    // Given
+    createFile(NODE_ID, OWNER_ID);
+    String invitationId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    Assertions.assertThat(app.backdoor().shareExists(NODE_ID, OWNER_ID)).isFalse();
+
+    // When
+    HttpResponse httpResponse = clickInvite(invitationId, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — same 307 success shape as a non-owner, but the owner never gets an explicit share row
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(307);
+    Assertions.assertThat(headerValue(httpResponse, "location")).isEqualTo(expectedLocation(NODE_ID));
+    Assertions.assertThat(headerValue(httpResponse, "content-length")).isEqualTo("0");
+    Assertions.assertThat(app.backdoor().shareExists(NODE_ID, OWNER_ID)).isFalse();
+  }
+
+  @Test
+  void givenABadInvitationIdTheInviteShouldReturn404() {
+    // Given — syntactically valid (8 word chars, matches the routing regex) but not tied to any
+    // collaboration link
+    String badInvitationId = "aaaaaaaa";
+
+    // When
+    HttpResponse httpResponse = clickInvite(badInvitationId, "ZM_AUTH_TOKEN=fake-token-b");
+
+    // Then — NoSuchElementException -> ExceptionsHandler's generic 404 shape
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+
+  @Test
+  void givenAnInvitationWhoseNodeWasDeletedTheInviteShouldReturn404() {
+    // Given — the collaboration link outlives the node it points to: nothing in this codebase
+    // cleans up a CollaborationLink row when its node is hard-deleted
+    createFile(NODE_ID, OWNER_ID);
+    String invitationId = createCollaborationLink(NODE_ID, SharePermission.READ_AND_SHARE);
+    deleteNode(NODE_ID);
+    Assertions.assertThat(app.backdoor().nodeExists(NODE_ID)).isFalse();
+
+    // When
+    HttpResponse httpResponse = clickInvite(invitationId, "ZM_AUTH_TOKEN=fake-token-b");
+
+    // Then — same generic 404 shape as a bad invitation id (both are NoSuchElementException)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/KeepVersionsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/KeepVersionsApiIT.java
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 2.6 (part 1) of the acceptance coverage-expansion plan: the {@code keepVersions} mutation
+ * (bound to {@code NodeDataFetcher#keepVersionsFetcher}).
+ *
+ * <p><b>Cap plumbing:</b> {@code keepVersionsFetcher}'s cap ({@code maxNumberOfKeepVersions}) is
+ * derived ONCE at {@code NodeDataFetcher} CONSTRUCTION from {@code maxNumberOfVersions - 2}
+ * (floored at 0), which itself is read directly from Service-Discover, bypassing {@code
+ * FilesConfig} entirely. This class therefore sets the cap via the builder's {@code
+ * withMaxNumberOfVersions(3)} (giving {@code maxNumberOfKeepVersions == 1}) BEFORE {@code build()}
+ * for the whole class — a post-build {@code Mocks#setMaxNumberOfVersions} call would be too late
+ * to affect this fetcher (see that method's own javadoc). A keep-cap of 1 is generous enough to
+ * let the mark/unmark/missing-version tests (which each mark at most one NEW version while no
+ * other version is already kept-forever) succeed normally, while still letting the dedicated cap
+ * test trip it by pre-seeding one already-kept-forever version.
+ *
+ * <p><b>FINDING (confirmed dead code — see plan §1/§9):</b> the missing-version error composition
+ * at the end of {@code keepVersionsFetcher} filters {@code List<FileVersion>} against {@code
+ * List<GraphQLError>} via {@code .contains(...)} — a {@code FileVersion} can never {@code .equals}
+ * a {@code GraphQLError}, so that filter's predicate is always {@code false} and the branch that
+ * would emit a {@code fileVersionNotFound} for a missing/non-existent requested version can NEVER
+ * execute. In addition, {@code fileVersionRepository.getFileVersions(nodeId, versions)} is a plain
+ * SQL {@code WHERE node_id = ? AND version IN (...)} query (see {@code
+ * FileVersionRepositoryEbean#getFileVersions(String, Collection)}) — a version number with no
+ * matching row is simply absent from the result list, not represented by a null placeholder. The
+ * combined, observable effect: requesting a version that doesn't exist produces NEITHER a data
+ * entry NOR any error for it — it vanishes without a trace. This is asserted below (not fixed —
+ * Phase 1 forbids {@code src/main} changes).
+ */
+class KeepVersionsApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withMaxNumberOfVersions(3) // maxNumberOfKeepVersions == 1 (see class javadoc)
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse keepVersions(String nodeId, boolean keepForever, int... versions) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("keepVersions")
+            .withString("node_id", nodeId)
+            .withListOfIntegers("versions", versions)
+            .withBoolean("keep_forever", keepForever)
+            .withWantedResultFormat("")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Integer> keptVersions(HttpResponse httpResponse) {
+    return (List<Integer>)
+        TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "keepVersions").orElse(List.of());
+  }
+
+  /** Raw {@code errors[].extensions.errorCode} values, in response order. */
+  private List<String> errorCodes(String bodyPayload) throws Exception {
+    JsonNode root = OBJECT_MAPPER.readTree(bodyPayload);
+    List<String> codes = new ArrayList<>();
+    if (root.has("errors")) {
+      for (JsonNode error : root.get("errors")) {
+        JsonNode extensions = error.get("extensions");
+        codes.add(extensions != null && extensions.has("errorCode")
+            ? extensions.get("errorCode").asText()
+            : null);
+      }
+    }
+    return codes;
+  }
+
+  private boolean keepForeverFlagOf(String nodeId, int version) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getVersions")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ version keep_forever }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, bodyPayload));
+    List<Map<String, Object>> versions =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getVersions");
+    return versions.stream()
+        .filter(v -> version == (Integer) v.get("version"))
+        .findFirst()
+        .map(v -> (Boolean) v.get("keep_forever"))
+        .orElseThrow();
+  }
+
+  @Test
+  void givenANonKeptVersionMarkingItKeepForeverShouldSuceedAndPersistTheFlag() {
+    // Given — v1 (non-current), v2 (current); no version is kept-forever yet
+    String nodeId = "50000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId); // v2, current
+
+    // When
+    HttpResponse httpResponse = keepVersions(nodeId, true, 1);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(keptVersions(httpResponse)).containsExactly(1);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(keepForeverFlagOf(nodeId, 1)).isTrue();
+    Assertions.assertThat(keepForeverFlagOf(nodeId, 2)).isFalse();
+  }
+
+  @Test
+  void givenAKeptForeverVersionUnmarkingItShouldSucceedAndClearTheFlag() {
+    // Given — v2 is kept-forever (non-current), v3 is current
+    String nodeId = "50000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId, true) // v2, keepForever=true
+        .addVersion(nodeId); // v3, current
+
+    // When — unmark v2 (keep_forever:false is never cap-checked, see keepVersionsFetcher's
+    // `!keepForever || counter < cap` condition)
+    HttpResponse httpResponse = keepVersions(nodeId, false, 2);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(keptVersions(httpResponse)).containsExactly(2);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(keepForeverFlagOf(nodeId, 2)).isFalse();
+  }
+
+  @Test
+  void givenTheKeepCapAlreadyReachedMarkingAnotherVersionShouldReturnTooManyVersionsError()
+      throws Exception {
+    // Given — cap is 1 (maxNumberOfKeepVersions, from withMaxNumberOfVersions(3)); v2 is ALREADY
+    // kept-forever (keepForeverCounter starts at 1, which is NOT < cap(1))
+    String nodeId = "50000000-0000-0000-0000-000000000003";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"))
+        .addVersion(nodeId, true) // v2, keepForever=true (fills the cap)
+        .addVersion(nodeId); // v3, current
+
+    // When — try to ALSO mark v1 as keep-forever
+    HttpResponse httpResponse = keepVersions(nodeId, true, 1);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(keptVersions(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + nodeId);
+    Assertions.assertThat(errorCodes(httpResponse.getBodyPayload()))
+        .containsExactly("VERSIONS_LIMIT_REACHED");
+
+    // v1 was NOT marked
+    Assertions.assertThat(keepForeverFlagOf(nodeId, 1)).isFalse();
+  }
+
+  @Test
+  void givenARequestedVersionThatDoesNotExistItVanishesWithNoDataAndNoError() {
+    // Given — only v1 (current) exists; per the class javadoc's dead-filter finding, version 999
+    // will produce NEITHER a data entry NOR a fileVersionNotFound error
+    String nodeId = "50000000-0000-0000-0000-000000000004";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When — mix one real, existing version with one that does not exist
+    HttpResponse httpResponse = keepVersions(nodeId, true, 1, 999);
+
+    // Then — the real version IS processed normally...
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(keptVersions(httpResponse)).containsExactly(1);
+    Assertions.assertThat(keepForeverFlagOf(nodeId, 1)).isTrue();
+
+    // ...while the missing version 999 produces NO error at all (confirmed dead code — NOT a
+    // fileVersionNotFound, despite `deleteVersions`' analogous but reachable check for the same
+    // scenario).
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/MetricsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/MetricsApiIT.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@code GET /metrics} (Task 1.7 of the acceptance coverage-expansion plan): an
+ * unauthenticated route (no {@code auth-handler} in its pipeline, see {@code
+ * HttpRoutingHandler#channelRead0}) that returns the Prometheus text-exposition scrape of the
+ * in-process {@code PrometheusMeterRegistry}.
+ */
+class MetricsApiIT {
+
+  @Test
+  void givenNoAuthenticationTheMetricsEndpointShouldReturn200WithPrometheusTextExposition() {
+    // Given — deliberately no withUserManagement()/cookie: /metrics has no auth-handler.
+    try (FilesTestApp app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .build()) {
+      HttpRequest httpRequest = HttpRequest.of("GET", "/metrics", null, null);
+
+      // When
+      HttpResponse httpResponse = app.send(httpRequest);
+
+      // Then
+      Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+      Assertions.assertThat(httpResponse.getHeaders())
+          .anyMatch(
+              header ->
+                  header.getKey().equalsIgnoreCase("content-type")
+                      && header.getValue().contains("text/plain"));
+
+      // The "files.upload" counter registered by PrometheusService is Prometheus-sanitized
+      // (dots -> underscores); its presence proves this is the real scrape, not an empty body.
+      Assertions.assertThat(httpResponse.getBodyPayload()).contains("files_upload");
+    }
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/MoveNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/MoveNodesApiIT.java
@@ -2,21 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -27,45 +22,36 @@ import java.util.Map;
 
 class MoveNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
                 Map.of(
                     "fake-token",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
   void givenANodeInRootAndANodeInAnotherFolderWithSameNameMovingThemInTheSameFolderShouldRenameTheMovedOne() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "name.txt"))
@@ -98,8 +84,7 @@ class MoveNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -119,7 +104,8 @@ class MoveNodesApiIT {
   @Test
   void givenANodeInAFolderMovingItInTheSameFolderShouldNotRenameTheNode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000003", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "second.txt"));
@@ -135,8 +121,7 @@ class MoveNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/MoveRestoreEdgeCasesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/MoveRestoreEdgeCasesApiIT.java
@@ -1,0 +1,538 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deepens {@code NodeDataFetcher#moveNodesFetcher}/{@code #restoreNodes} JaCoCo branch coverage
+ * beyond Waves 0-6, per the acceptance-coverage-expansion measurement loop. Every scenario below
+ * was picked from a line-by-line read of {@code core/target/jacoco-it-report/jacoco.xml}'s missed
+ * branches for {@code NodeDataFetcher.java}, cross-checked against {@code MoveNodesApiIT}/{@code
+ * RestoreNodesApiIT}/the notification {@code *ApiIT}s to avoid duplicating existing coverage.
+ *
+ * <h2>moveNodes</h2>
+ *
+ * <ul>
+ *   <li>Permission-denied on the destination (no existing {@code MoveNodesApiIT} test covers
+ *       this at all).
+ *   <li>Destination that exists, and the requester has {@code READ_AND_WRITE} on it, but it is a
+ *       FILE, not a FOLDER/ROOT — falls through {@code moveNodesFetcher}'s
+ *       {@code FOLDER-or-ROOT} check. <b>FINDING:</b> a genuinely non-existent destination is
+ *       NOT a separate reachable branch here — {@link
+ *       com.zextras.carbonio.files.utilities.PermissionsChecker#getPermissions} does its own
+ *       {@code nodeRepository.getNode(...)} lookup and returns {@code ACL.NONE} for any missing
+ *       id, so it always fails the OUTER permission gate first (identical to the {@code
+ *       CreateFolderApiIT} class-level finding for {@code createFolder}, not previously documented
+ *       for {@code moveNodes}/{@code copyNodes}); the subsequent {@code
+ *       optDestinationFolder.isPresent()} check can therefore never observe {@code false} and is
+ *       dead code — not attempted here.
+ *   <li>Every requested node filtered out (no permission on the sole one) with an otherwise-valid
+ *       destination — the {@code nodeIdsToMove.isEmpty()} branch, never hit by any existing test
+ *       (which always move at least one node successfully).
+ *   <li>A ROOT id and a self-move (destination == the node itself) in the same request — the
+ *       {@code rootIds.contains(nodeId)} and {@code destinationFolderId.equals(nodeId)} filters.
+ *   <li>Mover ≠ destination-folder-owner, moving a node that has NO existing shares into a folder
+ *       shared with a third party — closes the {@code sourceShare} "absent" branch of the
+ *       inherited-share-recompute loop AND the destination-owner remove-notify gate (previously
+ *       always false, since every existing move-notification test moves as the folder's owner).
+ *   <li>Mover ≠ the moved node's CURRENT parent's owner, on the REMOVE-notification side, with
+ *       both the "owner not yet in the notify list" (fresh add) and "owner already in the notify
+ *       list" (skip, avoid duplicate) outcomes of the {@code
+ *       !usersToNotifyRemoveNode.contains(parent.getOwnerId())} check — reachable ONLY because a
+ *       node's ownership does not change on move, so a node can retain an owner different from
+ *       its new parent's owner (every existing move-notification test moves as the parent's own
+ *       owner, so this line is 0% covered).
+ * </ul>
+ *
+ * <h2>restoreNodes</h2>
+ *
+ * <ul>
+ *   <li>A node that is not actually in the trash (never trashed) — the {@code
+ *       nodeRepository.getTrashedNode(nodeId).isPresent()} filter.
+ *   <li>A ROOT id in the request — the {@code getNodeType() != ROOT} filter.
+ *   <li>The node's recorded original parent no longer resolves to any row at all (hard-gone) —
+ *       promotes to {@code LOCAL_ROOT} and promotes the node's INDIRECT share(s) to DIRECT
+ *       (proved behaviourally: a direct share survives a subsequent move away, an indirect one
+ *       would not).
+ *   <li>The node's recorded original parent still exists as a row but is ITSELF also trashed
+ *       (the other reachable half of the same {@code !isPresent() || ancestors.contains(TRASH)}
+ *       check) — same fatherless treatment.
+ *   <li>Restoring a FOLDER into a valid, still-existing, NON-ROOT parent that has shares —
+ *       exercises the {@code FOLDER}-vs-{@code ROOT} ancestor-string ternary AND {@code
+ *       ShareDataFetcher#cascadeUpsertShare}'s recursive share-cascade to the restored folder's
+ *       OWN child (proved by asserting the grandchild inherits the share too).
+ * </ul>
+ */
+class MoveRestoreEdgeCasesApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String THIRD_USER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_COOKIE = "ZM_AUTH_TOKEN=fake-token-b";
+  private static final String THIRD_COOKIE = "ZM_AUTH_TOKEN=fake-token-c";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-b", OTHER_USER_ID,
+                    "fake-token-c", THIRD_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse moveNodes(String[] nodeIds, String destinationId, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("moveNodes")
+            .withListOfStrings("node_ids", nodeIds)
+            .withString("destination_id", destinationId)
+            .withWantedResultFormat("{ id }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> movedNodes(HttpResponse httpResponse) {
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "moveNodes");
+    Object data = page.get("data");
+    return data == null ? List.of() : (List<Map<String, Object>>) data;
+  }
+
+  private HttpResponse restoreNodes(String[] nodeIds, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("restoreNodes")
+            .withListOfStrings("node_ids", nodeIds)
+            .withWantedResultFormat("{ id }")
+            .build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @SuppressWarnings("unchecked")
+  private int notificationCountOf(String cookie, String onClause) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNotifications")
+            .withBoolean("update_last_seen", true)
+            .withWantedResultFormat("{ notifications { " + onClause + " } }")
+            .build();
+    HttpResponse httpResponse = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNotifications");
+    List<Map<String, Object>> notifications = (List<Map<String, Object>>) page.get("notifications");
+    return (int) notifications.stream().filter(n -> !n.isEmpty()).count();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // moveNodes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void givenNoWritePermissionOnDestinationMoveNodesShouldReturnNodeWriteError() {
+    // Given — destination owned by someone else, never shared
+    String destFolderId = "a1000000-0000-0000-0000-000000000001";
+    String nodeId = "a1000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, OTHER_USER_ID, "privateDest"))
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, destFolderId, OWNER_COOKIE);
+
+    // Then — the single blocked node bubbles TWO errors: the app's own nodeWriteError, PLUS a
+    // graphql-java-generated null-propagation error (schema declares `moveNodes: [Node!]`, a
+    // non-null list item resolving to null propagates as a second error — same divergence already
+    // documented by CopyNodesApiIT for the equivalent copyNodes shape).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + destFolderId);
+    Assertions.assertThat(movedNodes(httpResponse)).isEmpty();
+  }
+
+  @Test
+  void givenADestinationThatIsAFileNotAFolderMoveNodesShouldReturnNodeWriteError() {
+    // Given — destination exists and is owned by the requester (permission gate passes), but it
+    // is a FILE, not a FOLDER/ROOT
+    String destFileId = "a1000000-0000-0000-0000-000000000011";
+    String nodeId = "a1000000-0000-0000-0000-000000000012";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(destFileId, OWNER_ID, "notAFolder.txt"))
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "file.txt"));
+
+    // When
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, destFileId, OWNER_COOKIE);
+
+    // Then — see the destination-permission test above for why this is 2 errors, not 1
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + destFileId);
+  }
+
+  @Test
+  void givenTheOnlyRequestedNodeHasNoPermissionMoveNodesShouldReturnEmptyDataAndOneError() {
+    // Given — destination valid, but the sole requested node is owned by someone else, unshared
+    String destFolderId = "a1000000-0000-0000-0000-000000000021";
+    String nodeId = "a1000000-0000-0000-0000-000000000022";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, OWNER_ID, "dest"))
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "notMine.txt"));
+
+    // When
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, destFolderId, OWNER_COOKIE);
+
+    // Then — nodeIdsToMove ends up empty: the whole "movedNodesResult" building block is skipped;
+    // see the destination-permission test above for why this is 2 errors, not 1
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(movedNodes(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .contains("There was a problem while executing requested operation on node: " + nodeId);
+  }
+
+  @Test
+  void givenARootIdAndASelfMoveMoveNodesShouldFilterBothAsErrors() {
+    // Given — a valid destination owned by the requester
+    String destFolderId = "a1000000-0000-0000-0000-000000000031";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(destFolderId, OWNER_ID, "dest"));
+
+    // When — one root id (always filtered) + a self-move (destination moved into itself)
+    HttpResponse httpResponse =
+        moveNodes(new String[] {"LOCAL_ROOT", destFolderId}, destFolderId, OWNER_COOKIE);
+
+    // Then — TWO blocked nodes, each bubbling its own app error PLUS its own null-propagation
+    // error (see the destination-permission test above) -> 4 errors total
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(movedNodes(httpResponse)).isEmpty();
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(4)
+        .contains(
+            "There was a problem while executing requested operation on node: LOCAL_ROOT",
+            "There was a problem while executing requested operation on node: " + destFolderId);
+  }
+
+  @Test
+  void givenAMoverWhoIsNotTheDestinationOwnerMoveNodesShouldNotifyTheOwnerAndUpsertInheritedShares() {
+    // Given — folder F owned by OWNER_ID, shared WRITE to OTHER_USER_ID (mover) and shared to
+    // THIRD_USER_ID (an unrelated share target on the destination); a FRESH, completely unshared
+    // node owned by the mover, sitting at LOCAL_ROOT
+    String destFolderId = "a1000000-0000-0000-0000-000000000041";
+    String nodeId = "a1000000-0000-0000-0000-000000000042";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, OWNER_ID, "sharedDest"))
+        .addShare(destFolderId, OTHER_USER_ID, SharePermission.READ_AND_WRITE)
+        .addShare(destFolderId, THIRD_USER_ID, SharePermission.READ_ONLY)
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "fresh.txt"));
+
+    // When — OTHER_USER_ID (not the destination's owner) moves their own fresh node into it
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, destFolderId, OTHER_COOKIE);
+
+    // Then — the move succeeds...
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(movedNodes(httpResponse)).hasSize(1);
+
+    // ...the node inherited THIRD_USER_ID's share from the destination (sourceShare absent -> upsert)...
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, THIRD_USER_ID)).isTrue();
+
+    // ...and the destination's OWNER (who did not perform the move) got an AddedNode notification
+    Assertions.assertThat(notificationCountOf(OWNER_COOKIE, "... on AddedNode { created_at }"))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void givenTheMovedNodeAlreadyHasADirectShareToADestinationTargetMoveNodesShouldLeaveItUntouched() {
+    // Given — node X owned by OTHER_USER_ID already has a DIRECT (not inherited) share to
+    // THIRD_USER_ID; the destination folder is ALSO shared to THIRD_USER_ID. Unlike an INHERITED
+    // share (deleted by the same move's own remove-phase before this check ever runs — see
+    // moveNodesFetcher's `!share.isDirect()` remove-loop, which always runs first), a DIRECT share
+    // survives into the add-phase's `sourceShare` lookup, so the recompute loop must find it
+    // PRESENT and DIRECT and skip re-upserting it.
+    String destFolderId = "a1000000-0000-0000-0000-000000000071";
+    String nodeId = "a1000000-0000-0000-0000-000000000072";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(destFolderId, OTHER_USER_ID, "dest"))
+        .addShare(destFolderId, THIRD_USER_ID, SharePermission.READ_ONLY)
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "shared.txt"))
+        .addShare(nodeId, THIRD_USER_ID, SharePermission.READ_AND_WRITE);
+
+    // When — the node's own owner moves it into the (also-shared-to-the-same-user) destination
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, destFolderId, OTHER_COOKIE);
+
+    // Then — the move succeeds and the pre-existing direct share is untouched (still present,
+    // still whatever permission it already had — not overwritten with the destination's own tier)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, THIRD_USER_ID)).isTrue();
+  }
+
+  @Test
+  void givenAMoverWhoIsNotTheNodesParentOwnerMoveNodesShouldNotifyTheParentOwnerFreshly() {
+    // Given — folder F owned by OWNER_ID, shared WRITE to OTHER_USER_ID; a node OWNED by
+    // OTHER_USER_ID but structurally parented under F (ownership does not follow structure on a
+    // raw fixture, exactly like GetNodeEdgeApiIT's deliberately-inconsistent parent trick), with NO
+    // shares of its own at all
+    String parentFolderId = "a1000000-0000-0000-0000-000000000051";
+    String nodeId = "a1000000-0000-0000-0000-000000000052";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addShare(parentFolderId, OTHER_USER_ID, SharePermission.READ_AND_WRITE)
+        .addNode(
+            new PopulatorNode(
+                nodeId, OTHER_USER_ID, OTHER_USER_ID, parentFolderId, "child.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentFolderId, 1L, "text/plain"));
+
+    // When — the node's owner (not F's owner) moves it away to LOCAL_ROOT
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, "LOCAL_ROOT", OTHER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+
+    // F's owner (fresh add: was not already in the notify list) gets exactly one RemovedNode notification
+    Assertions.assertThat(notificationCountOf(OWNER_COOKIE, "... on RemovedNode { created_at }"))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void givenAMoverWhoIsNotTheNodesParentOwnerButTheOwnerIsAlreadyAShareTargetMoveNodesShouldNotDuplicateTheNotification() {
+    // Given — same shape as above, but the node ALSO has a DIRECT share to F's owner already (so
+    // the owner is already in the remove-notify list before the "add if absent" check runs)
+    String parentFolderId = "a1000000-0000-0000-0000-000000000061";
+    String nodeId = "a1000000-0000-0000-0000-000000000062";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addShare(parentFolderId, OTHER_USER_ID, SharePermission.READ_AND_WRITE)
+        .addNode(
+            new PopulatorNode(
+                nodeId, OTHER_USER_ID, OTHER_USER_ID, parentFolderId, "child2.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + parentFolderId, 1L, "text/plain"))
+        .addShare(nodeId, OWNER_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = moveNodes(new String[] {nodeId}, "LOCAL_ROOT", OTHER_COOKIE);
+
+    // Then — F's owner still gets EXACTLY ONE notification, not two (the contains-check prevented
+    // a duplicate add to the notify list)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(notificationCountOf(OWNER_COOKIE, "... on RemovedNode { created_at }"))
+        .isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // restoreNodes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void givenANodeThatWasNeverTrashedRestoreNodesShouldReturnNodeWriteError() {
+    // Given — exists, owned by the requester, but never trashed
+    String nodeId = "a2000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "notTrashed.txt"));
+
+    // When
+    HttpResponse httpResponse = restoreNodes(new String[] {nodeId}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + nodeId);
+  }
+
+  @Test
+  void givenARootIdRestoreNodesShouldFilterItAsAnError() {
+    // When
+    HttpResponse httpResponse = restoreNodes(new String[] {"LOCAL_ROOT"}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: LOCAL_ROOT");
+  }
+
+  @Test
+  void givenAFatherlessNodeWhoseOriginalParentRowNoLongerExistsRestoreNodesShouldRestoreToLocalRootAndPromoteIndirectSharesToDirect() {
+    // Given — folder F (shared to THIRD_USER_ID), a sub-folder X created via the REAL createFolder
+    // mutation (so X inherits an INDIRECT share to THIRD_USER_ID via cascade); X is then trashed
+    // with its RECORDED original parent set to an id that was NEVER a real node row at all
+    String parentFolderId = "a2000000-0000-0000-0000-000000000011";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addShare(parentFolderId, THIRD_USER_ID, SharePermission.READ_ONLY);
+
+    String createPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createFolder")
+            .withString("destination_id", parentFolderId)
+            .withString("name", "X")
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse createResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, createPayload));
+    Assertions.assertThat(createResponse.getStatus()).isEqualTo(200);
+    String nodeId = (String) TestUtils.jsonResponseToMap(createResponse.getBodyPayload(), "createFolder").get("id");
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, THIRD_USER_ID))
+        .as("X must have inherited an INDIRECT share before we can prove promotion to DIRECT")
+        .isTrue();
+
+    String neverExistedParentId = "a2000000-0000-0000-0000-00000000dead";
+    app.backdoor().populator().addNodeToTrash(nodeId, neverExistedParentId);
+
+    // When
+    HttpResponse httpResponse = restoreNodes(new String[] {nodeId}, OWNER_COOKIE);
+
+    // Then — restored to LOCAL_ROOT (not left dangling, not erroring on the missing parent)
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+
+    // The share survives the restore itself...
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, THIRD_USER_ID)).isTrue();
+
+    // ...and PROOF it is now DIRECT (not indirect): moving X away into a folder never shared with
+    // THIRD_USER_ID would strip any INDIRECT share (moveNodesFetcher's remove-phase), but a DIRECT
+    // one survives.
+    String privateFolderId = "a2000000-0000-0000-0000-000000000012";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(privateFolderId, OWNER_ID, "private"));
+    HttpResponse moveResponse = moveNodes(new String[] {nodeId}, privateFolderId, OWNER_COOKIE);
+    Assertions.assertThat(moveResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().shareExists(nodeId, THIRD_USER_ID))
+        .as("a DIRECT share must survive a move away from any granting ancestor")
+        .isTrue();
+  }
+
+  @Test
+  void givenAFatherlessNodeWhoseOriginalParentIsItselfTrashedRestoreNodesShouldRestoreToLocalRoot() {
+    // Given — folder F is trashed too (its OWN ancestor chain now contains TRASH_ROOT), so a child
+    // recorded as originally-parented-under F must ALSO be treated as fatherless, even though F's
+    // row still physically exists
+    String parentFolderId = "a2000000-0000-0000-0000-000000000021";
+    String nodeId = "a2000000-0000-0000-0000-000000000022";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(parentFolderId, OWNER_ID, "F"))
+        .addNode(new SimplePopulatorTextFile(nodeId, OWNER_ID, "child.txt"));
+    app.backdoor().populator().addNodeToTrash(parentFolderId, "LOCAL_ROOT");
+    app.backdoor().populator().addNodeToTrash(nodeId, parentFolderId);
+
+    // When
+    HttpResponse httpResponse = restoreNodes(new String[] {nodeId}, OWNER_COOKIE);
+
+    // Then — restored to LOCAL_ROOT, not left pointing at a still-trashed parent
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+
+    String getNodePayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id parent { id } }")
+            .build();
+    HttpResponse getNodeResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, getNodePayload));
+    Map<String, Object> node = TestUtils.jsonResponseToMap(getNodeResponse.getBodyPayload(), "getNode");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> parent = (Map<String, Object>) node.get("parent");
+    Assertions.assertThat(parent).containsEntry("id", "LOCAL_ROOT");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void givenAValidNonRootParentWithSharesRestoringAFolderShouldCascadeTheShareToItsOwnChild() {
+    // Given — P (a real, non-trashed FOLDER, shared to THIRD_USER_ID) is Q's recorded original
+    // parent; Q is itself a FOLDER with its own child R, so restoring Q must both (a) build its
+    // new ancestor string off a FOLDER (not ROOT) parent, and (b) cascade P's share down through Q
+    // to R (ShareDataFetcher#cascadeUpsertShare's recursive FOLDER branch)
+    String validParentId = "a2000000-0000-0000-0000-000000000031";
+    String folderId = "a2000000-0000-0000-0000-000000000032";
+    String grandchildId = "a2000000-0000-0000-0000-000000000033";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(validParentId, OWNER_ID, "P"))
+        .addShare(validParentId, THIRD_USER_ID, SharePermission.READ_ONLY)
+        .addNode(
+            new PopulatorNode(
+                folderId, OWNER_ID, OWNER_ID, validParentId, "Q", "",
+                NodeType.FOLDER, "LOCAL_ROOT," + validParentId, 0L, null))
+        .addNode(
+            new PopulatorNode(
+                grandchildId, OWNER_ID, OWNER_ID, folderId, "R.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT," + validParentId + "," + folderId, 1L, "text/plain"));
+    app.backdoor().populator().addNodeToTrash(folderId, validParentId);
+
+    // When
+    HttpResponse httpResponse = restoreNodes(new String[] {folderId}, OWNER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+
+    // Q itself is now (again) parented under P
+    String getNodePayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", folderId)
+            .withWantedResultFormat("{ id parent { id } }")
+            .build();
+    HttpResponse getNodeResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, getNodePayload));
+    Map<String, Object> node = TestUtils.jsonResponseToMap(getNodeResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat((Map<String, Object>) node.get("parent")).containsEntry("id", validParentId);
+
+    // P's share cascaded onto Q AND down to Q's own child R
+    Assertions.assertThat(app.backdoor().shareExists(folderId, THIRD_USER_ID)).isTrue();
+    Assertions.assertThat(app.backdoor().shareExists(grandchildId, THIRD_USER_ID))
+        .as("cascadeUpsertShare must reach the restored folder's own descendants")
+        .isTrue();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/MultiDownloadZipApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/MultiDownloadZipApiIT.java
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.Constants;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MEASURE-GUIDED coverage-deepening of the multi-download ZIP internals in {@code
+ * rest.services.BlobService} ({@code checkDownloadMultipleInternal}, {@code createZip}, {@code
+ * addNodeToZip}/{@code addFolderToZip}/{@code addFileToZip}, {@code getUniqueNameForZip}) and
+ * {@code rest.controllers.BlobController} ({@code checkDownloadMultiple}, {@code
+ * downloadMultiple}). {@link DownloadMultipleApiIT} already covers the happy-path/basic-validation
+ * surface of {@code /download-multiple}; this file targets branches that jacoco showed as
+ * genuinely uncovered: the {@code /download-multiple/check} endpoint (0% branch coverage before
+ * this file — no existing acceptance test hits it at all), and the ZIP-building internals
+ * (duplicate-name disambiguation, recursive folder zipping, single-vs-multi naming, silent
+ * skip-on-inaccessible-node).
+ *
+ * <p><b>Seam limitation (body content):</b> {@code BlobController#downloadMultiple}/{@code
+ * checkDownloadMultiple}'s success response streams its body in separate Netty frames (a
+ * headers-only {@code DefaultHttpResponse} then content chunks — see {@code
+ * NettyBufferWriter#writePipedStream}), never as one {@code DefaultFullHttpResponse}. The embedded
+ * transport's {@code EmbeddedChannel#readOutbound()} only ever captures the first frame, so {@code
+ * httpResponse.getBodyPayload()} is ALWAYS {@code null} for these two routes on the embedded
+ * transport (pre-existing gap, see {@code AuthenticatedDownloadApiIT}'s class-level FINDING — not
+ * introduced here). On the real-HTTP transport ({@code -Dfiles.test.transport=http}), {@code
+ * java.net.http.HttpClient} drains the full body over the socket and decodes it with {@code
+ * BodyHandlers.ofString(UTF_8)}. That decoding is lossy for the ZIP's compressed binary payload,
+ * but every byte {@code < 0x80} (i.e. every plain-ASCII byte, which is exactly what our ZIP entry
+ * names are) decodes to itself regardless of what invalid multi-byte sequences precede it — the
+ * UTF-8 "maximal subpart" replacement algorithm always resyncs at the next byte and can never
+ * mis-consume a low-ASCII byte as a continuation byte. So entry-name substrings survive the lossy
+ * decode intact and ARE reliably assertable on the real-HTTP transport; they are simply skipped
+ * (not asserted, not faked) whenever the body is unobservable (embedded transport). Every test
+ * additionally verifies via {@code Mocks#verifyStoragesDownloaded}/{@code
+ * verifyStoragesNeverDownloaded}, which is transport-invariant proof of which blobs the ZIP
+ * builder actually fetched.
+ */
+class MultiDownloadZipApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setMaxDownloadableSizeMb(null);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------------------
+
+  private HttpResponse checkMultiple(String jsonBody) {
+    List<Map.Entry<String, String>> headers = List.of(Map.entry("Content-Type", "application/json"));
+    return app.sendForm(HttpRequest.of("POST", "/download-multiple/check", REQUESTER_COOKIE, headers, jsonBody));
+  }
+
+  private String checkBodyOf(List<String> nodeIds) throws Exception {
+    return OBJECT_MAPPER.writeValueAsString(Map.of("nodeIds", nodeIds));
+  }
+
+  private HttpResponse downloadMultipleForm(String rawBodyPayload) {
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/x-www-form-urlencoded"));
+    return app.sendForm(HttpRequest.of("POST", "/download-multiple", REQUESTER_COOKIE, headers, rawBodyPayload));
+  }
+
+  private HttpResponse downloadMultiple(List<String> nodeIds) throws Exception {
+    String jsonArray = OBJECT_MAPPER.writeValueAsString(nodeIds);
+    String requestBody = "nodeIds=" + URLEncoder.encode(jsonArray, StandardCharsets.UTF_8);
+    return downloadMultipleForm(requestBody);
+  }
+
+  private void assertBodyContainsWhenObservable(HttpResponse response, String expectedSubstring) {
+    if (response.getBodyPayload() != null) {
+      Assertions.assertThat(response.getBodyPayload()).contains(expectedSubstring);
+    }
+  }
+
+  private void assertBodyDoesNotContainWhenObservable(HttpResponse response, String unexpectedSubstring) {
+    if (response.getBodyPayload() != null) {
+      Assertions.assertThat(response.getBodyPayload()).doesNotContain(unexpectedSubstring);
+    }
+  }
+
+  private void addFile(String id, String parentId, String ancestorIds, String name, long size) {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                id, REQUESTER_ID, REQUESTER_ID, parentId, name, "", NodeType.TEXT, ancestorIds, size,
+                "text/plain"));
+  }
+
+  private void addFolder(String id, String parentId, String ancestorIds, String name) {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                id, REQUESTER_ID, REQUESTER_ID, parentId, name, "", NodeType.FOLDER, ancestorIds, 0L, null));
+  }
+
+  // =========================================================================================
+  // Section A: /download-multiple/check (BlobController#checkDownloadMultiple) — was 0% covered
+  // =========================================================================================
+
+  @Test
+  void givenValidNodeIdsCheckDownloadMultipleShouldReturn204AndNeverTouchStorages() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000a001";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "file.txt", 10L);
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(fileId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+    // /download-multiple/check only validates access + size; it never fetches a blob.
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  @Test
+  void givenMissingBodyCheckDownloadMultipleShouldReturn400() {
+    HttpResponse response = checkMultiple(null);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  /**
+   * FINDING (real production behaviour, not a test-harness artifact): {@code
+   * BlobController#checkDownloadMultiple}'s JSON-parse-failure branch wraps the caught {@code
+   * JsonProcessingException} as the CAUSE of the {@code IllegalArgumentException} it fires
+   * (unlike every other {@code IllegalArgumentException} in this method, and unlike its sibling
+   * {@code downloadMultiple}'s equivalent form-parsing catch, neither of which set a cause).
+   * {@code ExceptionsHandler#exceptionCaught} unconditionally unwraps to {@code
+   * cause.getCause()} before classifying the status code, so it reclassifies based on the
+   * INNER {@code JsonProcessingException} — which maps to 500 — instead of the outer, intended
+   * {@code IllegalArgumentException} -> 400. Net effect: an invalid JSON body on {@code
+   * /download-multiple/check} returns 500 Internal Server Error, not the 400 the message text
+   * ("Can't parse JSON body...") implies. Verified reproducible in isolation (not test order/
+   * classloading). Not fixed here (src/main is out of scope) — asserted as the real behaviour.
+   */
+  @Test
+  void givenInvalidJsonBodyCheckDownloadMultipleActuallyReturns500NotTheIntended400() {
+    HttpResponse response = checkMultiple("this-is-not-json");
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(500);
+  }
+
+  @Test
+  void givenJsonBodyMissingNodeIdsFieldCheckDownloadMultipleShouldReturn400() {
+    HttpResponse response = checkMultiple("{\"foo\":\"bar\"}");
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void givenEmptyNodeIdsArrayCheckDownloadMultipleShouldReturn400() {
+    HttpResponse response = checkMultiple("{\"nodeIds\":[]}");
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void givenLocalRootWithOtherNodeCheckDownloadMultipleShouldReturn400() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000a002";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "file.txt", 10L);
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(Constants.Db.RootId.LOCAL_ROOT, fileId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  /**
+   * FINDING: {@code BlobService#checkDownloadMultipleInternal} silently {@code continue}s past
+   * node ids that do not exist (or are inaccessible) rather than failing the whole request — the
+   * method ALWAYS returns {@code Optional.of(nodes)} (possibly an empty list) once past the
+   * up-front validation, and never {@code Optional.empty()} for an authenticated caller (that
+   * outcome is reserved for the LOCAL_ROOT-alias-with-null-requester case, which cannot happen for
+   * an authenticated request). Consequently {@code BlobController#checkDownloadMultiple}'s {@code
+   * .orElseThrow(() -> new NoSuchElementException(...))} — whose message promises "some nodes do
+   * not exist or user lacks permission" — is DEAD CODE for the authenticated endpoint: requesting
+   * ONLY non-existent ids still returns 204, not 404.
+   */
+  @Test
+  void givenOnlyNonExistentNodeIdsCheckDownloadMultipleShouldReturn204NotFound() throws Exception {
+    String nonExistentId = "00000000-0000-0000-0000-0000dead0001";
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(nonExistentId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenMixOfValidAndNonExistentNodeIdsCheckDownloadMultipleShouldReturn204SkippingTheInvalidOne()
+      throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000a003";
+    String nonExistentId = "00000000-0000-0000-0000-0000dead0002";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "file.txt", 10L);
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(fileId, nonExistentId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenNodeWithoutPermissionMixedWithOwnedNodeCheckDownloadMultipleShouldReturn204SkippingTheDeniedOne()
+      throws Exception {
+    String ownedFileId = "00000000-0000-0000-0000-00000000a004";
+    String deniedFileId = "00000000-0000-0000-0000-00000000a005";
+    addFile(ownedFileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "mine.txt", 10L);
+    // Owned by another user, never shared with the requester -> PermissionsChecker yields NONE.
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                deniedFileId,
+                OTHER_USER_ID,
+                OTHER_USER_ID,
+                Constants.Db.RootId.LOCAL_ROOT,
+                "notMine.txt",
+                "",
+                NodeType.TEXT,
+                Constants.Db.RootId.LOCAL_ROOT,
+                10L,
+                "text/plain"));
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(ownedFileId, deniedFileId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenTotalSizeExceedingCapCheckDownloadMultipleShouldReturn413() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000a006";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "big.bin", 1024L);
+    app.mocks().setMaxDownloadableSizeMb(0);
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(fileId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(413);
+  }
+
+  @Test
+  void givenTotalSizeWithinAGenerousCapCheckDownloadMultipleShouldReturn204() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000a007";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "small.bin", 10L);
+    app.mocks().setMaxDownloadableSizeMb(100);
+
+    HttpResponse response = checkMultiple(checkBodyOf(List.of(fileId)));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  // =========================================================================================
+  // Section B: /download-multiple — ZIP-building internals (createZip / addNodeToZip /
+  // addFolderToZip / addFileToZip / getUniqueNameForZip)
+  // =========================================================================================
+
+  @Test
+  void givenDuplicateFileNamesTheDownloadMultipleShouldDisambiguateWithExtensionPreserved()
+      throws Exception {
+    String fileId1 = "00000000-0000-0000-0000-00000000b001";
+    String fileId2 = "00000000-0000-0000-0000-00000000b002";
+    // Both files requested DIRECTLY (not via their containing folder) -> createZip passes an
+    // empty parentPath for each top-level requested node regardless of the node's real DB
+    // parent, so the ZIP mirrors the REQUEST shape (flat here), not the node's absolute path.
+    addFile(fileId1, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dup.txt", 10L);
+    addFile(fileId2, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dup.txt", 10L);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId1, fileId2));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
+    app.mocks().verifyStoragesDownloaded(fileId2, 1);
+    assertBodyContainsWhenObservable(response, "dup.txt");
+    assertBodyContainsWhenObservable(response, "dup (1).txt");
+  }
+
+  @Test
+  void givenDuplicateFileNamesWithoutExtensionTheDownloadMultipleShouldDisambiguate() throws Exception {
+    String fileId1 = "00000000-0000-0000-0000-00000000b003";
+    String fileId2 = "00000000-0000-0000-0000-00000000b004";
+    addFile(fileId1, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dupfile", 10L);
+    addFile(fileId2, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dupfile", 10L);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId1, fileId2));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
+    app.mocks().verifyStoragesDownloaded(fileId2, 1);
+    assertBodyContainsWhenObservable(response, "dupfile (1)");
+  }
+
+  @Test
+  void givenDuplicateFileNamesEndingWithDotTheDownloadMultipleShouldDisambiguate() throws Exception {
+    String fileId1 = "00000000-0000-0000-0000-00000000b005";
+    String fileId2 = "00000000-0000-0000-0000-00000000b006";
+    addFile(fileId1, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dup.", 10L);
+    addFile(fileId2, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "dup.", 10L);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId1, fileId2));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
+    app.mocks().verifyStoragesDownloaded(fileId2, 1);
+    // lastDotIndex == originalName.length()-1 -> the "< length-1" half of the && is false, so no
+    // extension is split off: the counter is appended after the trailing dot itself.
+    assertBodyContainsWhenObservable(response, "dup. (1)");
+  }
+
+  @Test
+  void givenTripleDuplicateFileNamesTheDownloadMultipleShouldIncrementCounterPastOne() throws Exception {
+    String fileId1 = "00000000-0000-0000-0000-00000000b007";
+    String fileId2 = "00000000-0000-0000-0000-00000000b008";
+    String fileId3 = "00000000-0000-0000-0000-00000000b009";
+    addFile(fileId1, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "same.txt", 10L);
+    addFile(fileId2, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "same.txt", 10L);
+    addFile(fileId3, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "same.txt", 10L);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId3, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId1, fileId2, fileId3));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
+    app.mocks().verifyStoragesDownloaded(fileId2, 1);
+    app.mocks().verifyStoragesDownloaded(fileId3, 1);
+    assertBodyContainsWhenObservable(response, "same.txt");
+    assertBodyContainsWhenObservable(response, "same (1).txt");
+    // The 3rd collision must retry past "(1)" (already used) to "(2)" -> exercises the do-while
+    // loop actually looping more than once.
+    assertBodyContainsWhenObservable(response, "same (2).txt");
+  }
+
+  @Test
+  void givenDuplicateFolderNamesTheDownloadMultipleShouldDisambiguateFolderEntries() throws Exception {
+    String folderId1 = "11111111-1111-1111-1111-1111b0000010";
+    String folderId2 = "11111111-1111-1111-1111-1111b0000011";
+    addFolder(folderId1, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "docs");
+    addFolder(folderId2, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "docs");
+
+    HttpResponse response = downloadMultiple(List.of(folderId1, folderId2));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    assertBodyContainsWhenObservable(response, "docs/");
+    assertBodyContainsWhenObservable(response, "docs (1)/");
+  }
+
+  @Test
+  void givenDeeplyNestedFolderTheDownloadMultipleShouldRecurseThroughAllLevels() throws Exception {
+    String folderA = "11111111-1111-1111-1111-1111b0000020";
+    String folderB = "11111111-1111-1111-1111-1111b0000021";
+    String folderC = "11111111-1111-1111-1111-1111b0000022";
+    String fileId = "00000000-0000-0000-0000-00000000b020";
+    addFolder(folderA, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "A");
+    addFolder(folderB, folderA, Constants.Db.RootId.LOCAL_ROOT + "," + folderA, "B");
+    addFolder(folderC, folderB, Constants.Db.RootId.LOCAL_ROOT + "," + folderA + "," + folderB, "C");
+    addFile(
+        fileId,
+        folderC,
+        Constants.Db.RootId.LOCAL_ROOT + "," + folderA + "," + folderB + "," + folderC,
+        "leaf.txt",
+        10L);
+    app.mocks().storagesServesBlob(fileId, 1);
+
+    HttpResponse response = downloadMultiple(List.of(folderA));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId, 1);
+    assertBodyContainsWhenObservable(response, "A/B/C/leaf.txt");
+  }
+
+  /**
+   * {@code createZip}'s single-node branch names the ZIP after {@code nodes.get(0).getName()} —
+   * NOT {@code getFullName()}. {@code Node#getName()} strips the extension for non-folder types
+   * (see {@code Node#getName()}), so a single "report.pdf" download is named "report.zip", not
+   * "report.pdf.zip" — a real, slightly surprising quirk, asserted as observed.
+   */
+  @Test
+  void givenSingleFileRequestTheDownloadMultipleShouldNameZipAfterTheFile() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000b030";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "report.pdf", 10L);
+    app.mocks().storagesServesBlob(fileId, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    Assertions.assertThat(response.getHeaders())
+        .anyMatch(
+            header ->
+                header.getKey().equalsIgnoreCase("content-disposition")
+                    && header.getValue().contains("report.zip"));
+    app.mocks().verifyStoragesDownloaded(fileId, 1);
+  }
+
+  @Test
+  void givenEmptyFolderAlongsideAFileTheDownloadMultipleShouldIncludeBothEntries() throws Exception {
+    String emptyFolderId = "11111111-1111-1111-1111-1111b0000040";
+    String fileId = "00000000-0000-0000-0000-00000000b040";
+    addFolder(emptyFolderId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "empty");
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "alone.txt", 10L);
+    app.mocks().storagesServesBlob(fileId, 1);
+
+    HttpResponse response = downloadMultiple(List.of(emptyFolderId, fileId));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId, 1);
+    assertBodyContainsWhenObservable(response, "empty/");
+    assertBodyContainsWhenObservable(response, "alone.txt");
+  }
+
+  @Test
+  void givenNonExistentNodeIdMixedWithValidFileTheDownloadMultipleShouldSilentlySkipIt() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000b050";
+    String nonExistentId = "00000000-0000-0000-0000-0000dead0050";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "present.txt", 10L);
+    app.mocks().storagesServesBlob(fileId, 1);
+
+    HttpResponse response = downloadMultiple(List.of(fileId, nonExistentId));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(fileId, 1);
+    assertBodyContainsWhenObservable(response, "present.txt");
+  }
+
+  /**
+   * Authenticated-path exercise of {@code addNodeToZip}'s per-node {@code accessChecker.apply}
+   * during RECURSION (not just the top-level request list): the folder itself is shared
+   * READ_ONLY with the requester (so the top-level {@code checkDownloadMultipleInternal} gate
+   * passes for the folder), but its child file is owned by someone else and never individually
+   * shared. {@code PermissionsChecker#getPermissions} is a per-node lookup (owner-or-direct-share,
+   * NOT ancestor-cascading — see {@code PermissionsChecker#getPermissions}), so the child fails
+   * the same {@code accessChecker} the folder itself used to pass, and {@code addNodeToZip}
+   * silently excludes it while still zipping the (empty, from the requester's view) folder.
+   */
+  @Test
+  void givenSharedFolderWithUnsharedChildTheDownloadMultipleShouldExcludeTheChildFromTheZip()
+      throws Exception {
+    String folderId = "11111111-1111-1111-1111-1111b0000060";
+    String childFileId = "00000000-0000-0000-0000-00000000b060";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                folderId,
+                OTHER_USER_ID,
+                OTHER_USER_ID,
+                Constants.Db.RootId.LOCAL_ROOT,
+                "shared-folder",
+                "",
+                NodeType.FOLDER,
+                Constants.Db.RootId.LOCAL_ROOT,
+                0L,
+                null))
+        .addShare(folderId, REQUESTER_ID, ACL.SharePermission.READ_ONLY)
+        .addNode(
+            new PopulatorNode(
+                childFileId,
+                OTHER_USER_ID,
+                OTHER_USER_ID,
+                folderId,
+                "notShared.txt",
+                "",
+                NodeType.TEXT,
+                Constants.Db.RootId.LOCAL_ROOT + "," + folderId,
+                10L,
+                "text/plain"));
+    // childFileId is deliberately NOT shared with REQUESTER_ID.
+
+    HttpResponse response = downloadMultiple(List.of(folderId));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    // The only downloadable content in this test is the excluded child; if it were wrongly
+    // included, storages would have been hit.
+    app.mocks().verifyStoragesNeverDownloaded();
+    assertBodyContainsWhenObservable(response, "shared-folder/");
+    assertBodyDoesNotContainWhenObservable(response, "notShared.txt");
+  }
+
+  @Test
+  void givenTotalSizeExceedingCapTheDownloadMultipleShouldReturn413() throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000b070";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "big.bin", 1024L);
+    app.mocks().setMaxDownloadableSizeMb(0);
+
+    HttpResponse response = downloadMultiple(List.of(fileId));
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(413);
+    app.mocks().verifyStoragesNeverDownloaded();
+  }
+
+  /**
+   * FINDING: unlike the single-file download route (where a storages connection-drop is caught
+   * synchronously, BEFORE any response is written, and cleanly surfaces as 500 — see {@code
+   * DownloadByPublicLinkApiIT}'s equivalent 500 test), the multi-download ZIP route has ALREADY
+   * committed its 200-with-chunked-headers response (in {@code
+   * BlobController#downloadMultiple}, synchronously, before the async {@code
+   * CompletableFuture.runAsync} ZIP-building task in {@code BlobService#createZip} even starts).
+   * When a per-file storages fetch then fails mid-build ({@code addFileToZip}'s {@code
+   * fileStore.download(...)} throwing), the failure is caught, wrapped ({@code
+   * DependencyException} -> {@code ZipGenerationException}), logged, and the pipe is closed in the
+   * {@code finally} — but there is no way left to change the response status. The client
+   * (embedded and real-HTTP alike) sees a normal 200 with a truncated/incomplete ZIP body, not an
+   * error. This is a genuine robustness gap (silent partial-content delivery), not fixed here per
+   * the "no src/main changes" guardrail — only exercised and documented.
+   */
+  @Test
+  void givenStoragesConnectionDropsMidZipTheDownloadMultipleStillReturns200WithATruncatedBody()
+      throws Exception {
+    String fileId = "00000000-0000-0000-0000-00000000b080";
+    addFile(fileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "flaky.bin", 10L);
+    app.mocks().storagesDownloadConnectionDrops();
+
+    HttpResponse response = downloadMultiple(List.of(fileId));
+
+    // Headers are already committed by the time the async failure happens.
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void givenNodeIdsJsonNullFormEncodedTheDownloadMultipleShouldReturn400() {
+    // The literal JSON token "null" parses via ObjectMapper#readValue to an actual Java null,
+    // reaching BlobController#downloadMultiple's own "nodeIds == null" check (distinct from the
+    // "nodeIds.isEmpty()" case already covered by DownloadMultipleApiIT).
+    String requestBody = "nodeIds=" + URLEncoder.encode("null", StandardCharsets.UTF_8);
+
+    HttpResponse response = downloadMultipleForm(requestBody);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(400);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/NewShareNotificationApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/NewShareNotificationApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,17 +23,12 @@ import java.util.Map;
 
 class NewShareNotificationApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class NewShareNotificationApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create the node to be shared, owned by first user
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "name.txt"));
@@ -90,7 +72,7 @@ class NewShareNotificationApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
   }
 
   @Test
@@ -108,8 +90,7 @@ class NewShareNotificationApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -123,11 +104,7 @@ class NewShareNotificationApiIT {
   @Test
   void givenANodeCreatingAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -140,8 +117,7 @@ class NewShareNotificationApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -152,10 +128,6 @@ class NewShareNotificationApiIT {
     Assertions.assertThat(notifications).hasSize(0);
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/NodePermissionsFieldApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/NodePermissionsFieldApiIT.java
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.4 of the acceptance coverage-expansion plan: {@code getNode { permissions { ... } } }
+ * exercises {@code NodeDataFetcher#getPermissionsNodeFetcher}, which no existing acceptance test
+ * touches at all (0/9 lines covered before this file).
+ *
+ * <p><b>FINDING (overrides the plan's third scenario):</b> the plan asked for "a NONE user still
+ * gets an all-false Permissions object, not an error". This is NOT what happens for {@code
+ * getNode}. {@code NodeDataFetcher#getNodeFetcher} gates entry with the exact same {@code
+ * permissionsChecker.getPermissions(nodeId, requesterId).has(SharePermission.READ_ONLY)} check
+ * BEFORE any field (including {@code permissions}) is ever resolved: when the requester has zero
+ * relationship to the node (not owner, no share row at all), that top-level check fails and {@code
+ * getNode} returns a {@code nodeNotFound} GraphQL error — {@code getPermissionsNodeFetcher} is
+ * never invoked, so a "NONE" {@code Permissions} object can never be observed through {@code
+ * getNode}. Since {@code can_read}/{@code can_read_link}/{@code can_read_share} all map to {@code
+ * ACL#canRead()}, and the top-level gate requires exactly that bit, ANY node successfully returned
+ * by {@code getNode} is guaranteed to have those three fields {@code true} — an all-false {@code
+ * Permissions} is structurally unreachable via this query, similar to the other dead/defensive
+ * paths documented in the plan's §0. This test pins the ACTUAL behaviour (an error, not a
+ * Permissions object) instead of the plan's prediction.
+ */
+class NodePermissionsFieldApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String SHARE_TARGET_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String NO_RELATIONSHIP_USER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  private static final String NODE_ID = "00000000-0000-0000-0000-000000000001";
+
+  private static final String PERMISSIONS_RESULT_FORMAT =
+      "{ id permissions { can_read can_write_file can_write_folder can_delete can_add_version"
+          + " can_read_link can_change_link can_share can_read_share can_change_share } }";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", SHARE_TARGET_ID,
+                    "fake-token-c", NO_RELATIONSHIP_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getNodePermissions(String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", NODE_ID)
+            .withWantedResultFormat(PERMISSIONS_RESULT_FORMAT)
+            .build();
+
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    HttpResponse httpResponse = app.send(httpRequest);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    return (Map<String, Object>) node.get("permissions");
+  }
+
+  @Test
+  void givenOwnerGetNodePermissionsShouldReturnAllTruePermissions() {
+    // Given
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(NODE_ID, REQUESTER_ID, "owned.txt"));
+
+    // When
+    Map<String, Object> permissions = getNodePermissions("ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(permissions)
+        .containsEntry("can_read", true)
+        .containsEntry("can_write_file", true)
+        .containsEntry("can_write_folder", true)
+        .containsEntry("can_delete", true)
+        .containsEntry("can_add_version", true)
+        .containsEntry("can_read_link", true)
+        .containsEntry("can_change_link", true)
+        .containsEntry("can_share", true)
+        .containsEntry("can_read_share", true)
+        .containsEntry("can_change_share", true);
+  }
+
+  @Test
+  void givenReadOnlyShareTargetGetNodePermissionsShouldReturnOnlyReadPermissionsTrue() {
+    // Given
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(NODE_ID, REQUESTER_ID, "shared.txt"))
+        .addShare(NODE_ID, SHARE_TARGET_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    Map<String, Object> permissions = getNodePermissions("ZM_AUTH_TOKEN=fake-token-b");
+
+    // Then — READ_ONLY grants only the READ bit; write/share/delete all false
+    Assertions.assertThat(permissions)
+        .containsEntry("can_read", true)
+        .containsEntry("can_write_file", false)
+        .containsEntry("can_write_folder", false)
+        .containsEntry("can_delete", false)
+        .containsEntry("can_add_version", false)
+        .containsEntry("can_read_link", true)
+        .containsEntry("can_change_link", false)
+        .containsEntry("can_share", false)
+        .containsEntry("can_read_share", true)
+        .containsEntry("can_change_share", false);
+  }
+
+  /**
+   * See the class-level FINDING: a user with zero relationship to the node cannot reach the
+   * {@code permissions} field at all — {@code getNode} itself fails with {@code nodeNotFound}
+   * before any field resolver (including {@code getPermissionsNodeFetcher}) runs.
+   */
+  @Test
+  void givenUserWithNoRelationshipToNodeGetNodeFailsWithNodeNotFoundInsteadOfAllFalsePermissions() {
+    // Given
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(NODE_ID, REQUESTER_ID, "private.txt"));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", NODE_ID)
+            .withWantedResultFormat(PERMISSIONS_RESULT_FORMAT)
+            .build();
+
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-c", bodyPayload);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1).containsExactly("Could not find node with id " + NODE_ID);
+
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PaginationFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PaginationFindNodesApiIT.java
@@ -2,20 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.search;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -38,16 +33,12 @@ import org.junit.jupiter.api.TestInstance;
  */
 class PaginationFindNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
@@ -56,18 +47,12 @@ class PaginationFindNodesApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-account-for-sharing",
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Nested
@@ -76,7 +61,7 @@ class PaginationFindNodesApiIT {
 
     @BeforeAll
     void setUp() {
-      DatabasePopulator.aNodePopulator(simulator.getInjector())
+      app.backdoor().populator()
           .addNode(
               new SimplePopulatorFolder(
                   "10000000-0000-0000-0000-000000000001",
@@ -106,7 +91,7 @@ class PaginationFindNodesApiIT {
 
     @AfterAll
     void tearDown() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
@@ -123,8 +108,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -143,8 +127,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -173,8 +156,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -193,8 +175,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -223,8 +204,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -243,8 +223,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -274,8 +253,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -294,8 +272,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -317,7 +294,7 @@ class PaginationFindNodesApiIT {
 
     @BeforeAll
     void setUp() {
-      DatabasePopulator.aNodePopulator(simulator.getInjector())
+      app.backdoor().populator()
           .addNode(
               new SimplePopulatorFolder(
                   "10000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
@@ -339,7 +316,7 @@ class PaginationFindNodesApiIT {
 
     @AfterAll
     void tearDown() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
@@ -356,8 +333,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -376,8 +352,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -406,8 +381,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-          TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
           TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -426,8 +400,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
           HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-          TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -448,7 +421,7 @@ class PaginationFindNodesApiIT {
 
     @AfterEach
     void cleanUp() {
-      simulator.resetDatabase();
+      app.backdoor().resetDatabase();
     }
 
     @Test
@@ -459,8 +432,8 @@ class PaginationFindNodesApiIT {
       page_token
       """)
     void givenFilesOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
-      DatabasePopulator
-        .aNodePopulator(simulator.getInjector())
+      app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorFolder(
           "10000000-0000-0000-0000-000000000001",
           "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -493,8 +466,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -512,8 +484,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 
@@ -536,8 +507,8 @@ class PaginationFindNodesApiIT {
       """)
     @Test
     void givenFoldersOnRootHavingInjectedSQLInFilenameSearchWithSortNameAscShouldNotBeVulnerable() {
-      DatabasePopulator
-        .aNodePopulator(simulator.getInjector())
+      app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorFolder(
           "10000000-0000-0000-0000-000000000001",
           "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -570,8 +541,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-      final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+      final HttpResponse httpResponse = app.send(httpRequest);
 
       final Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
@@ -589,8 +559,7 @@ class PaginationFindNodesApiIT {
       final HttpRequest httpRequestPage =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayloadPage);
 
-      final HttpResponse httpResponsePage =
-        TestUtils.sendRequest(httpRequestPage, simulator.getNettyChannel());
+      final HttpResponse httpResponsePage = app.send(httpRequestPage);
 
       Assertions.assertThat(httpResponsePage.getStatus()).isEqualTo(200);
 

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PaginationFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PaginationFindNodesApiIT.java
@@ -10,7 +10,6 @@ import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBui
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSort;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -100,7 +99,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_ASC)
+              .withEnumLiteral("sort", "NAME_ASC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -118,7 +117,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_ASC)
+              .withEnumLiteral("sort", "NAME_ASC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -148,7 +147,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_DESC)
+              .withEnumLiteral("sort", "NAME_DESC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -166,7 +165,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.NAME_DESC)
+              .withEnumLiteral("sort", "NAME_DESC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -196,7 +195,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withEnumLiteral("sort", "UPDATED_AT_ASC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -214,7 +213,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_ASC)
+              .withEnumLiteral("sort", "UPDATED_AT_ASC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -245,7 +244,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withEnumLiteral("sort", "UPDATED_AT_DESC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -263,7 +262,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.UPDATED_AT_DESC)
+              .withEnumLiteral("sort", "UPDATED_AT_DESC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -325,7 +324,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withEnumLiteral("sort", "SIZE_ASC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -343,7 +342,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_ASC)
+              .withEnumLiteral("sort", "SIZE_ASC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -373,7 +372,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withEnumLiteral("sort", "SIZE_DESC")
               .withInteger("limit", 4)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
               .build();
@@ -391,7 +390,7 @@ class PaginationFindNodesApiIT {
           GraphqlCommandBuilder.aQueryBuilder("findNodes")
               .withString("folder_id", "LOCAL_ROOT")
               .withBoolean("cascade", true)
-              .withEnum("sort", NodeSort.SIZE_DESC)
+              .withEnumLiteral("sort", "SIZE_DESC")
               .withInteger("limit", 1)
               .withString("page_token", pageToken)
               .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -458,7 +457,7 @@ class PaginationFindNodesApiIT {
       String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
           .withString("folder_id", "LOCAL_ROOT")
-          .withEnum("sort", NodeSort.NAME_ASC)
+          .withEnumLiteral("sort", "NAME_ASC")
           .withInteger("limit", 2)
           .withWantedResultFormat("{ nodes { id name }, page_token }")
           .build();
@@ -475,7 +474,7 @@ class PaginationFindNodesApiIT {
       String bodyPayloadPage =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
           .withString("folder_id", "LOCAL_ROOT")
-          .withEnum("sort", NodeSort.NAME_ASC)
+          .withEnumLiteral("sort", "NAME_ASC")
           .withInteger("limit", 2)
           .withString("page_token", pageToken)
           .withWantedResultFormat("{ nodes { id name }, page_token }")
@@ -533,7 +532,7 @@ class PaginationFindNodesApiIT {
       String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
           .withString("folder_id", "LOCAL_ROOT")
-          .withEnum("sort", NodeSort.NAME_ASC)
+          .withEnumLiteral("sort", "NAME_ASC")
           .withInteger("limit", 2)
           .withWantedResultFormat("{ nodes { id name }, page_token }")
           .build();
@@ -550,7 +549,7 @@ class PaginationFindNodesApiIT {
       String bodyPayloadPage =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
           .withString("folder_id", "LOCAL_ROOT")
-          .withEnum("sort", NodeSort.NAME_ASC)
+          .withEnumLiteral("sort", "NAME_ASC")
           .withInteger("limit", 2)
           .withString("page_token", pageToken)
           .withWantedResultFormat("{ nodes { id name }, page_token }")

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewApiIT.java
@@ -2,19 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -22,80 +17,48 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockserver.client.MockServerClient;
-import org.mockserver.model.BinaryBody;
-import org.mockserver.model.MediaType;
-import org.mockserver.model.Parameter;
 
 import java.util.Map;
 
 class PreviewApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withPreview()
             .withUserManagement( // create a fake token to use in cookie for auth
-                Map.of(
-                    "fake-token",
-                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
+                Map.of("fake-token", OWNER_ID))
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.clearFileVersionCache();
+    app.backdoor().resetDatabase();
+    app.backdoor().clearFileVersionCache();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
-  }
-
-  static String mockSuccessPreviewResponse(String previewPathEndpoint, MediaType previewTypeResponse) {
-    org.mockserver.model.HttpRequest request = org.mockserver.model.HttpRequest.request()
-        .withMethod(HttpMethod.GET.toString())
-        .withPath(previewPathEndpoint)
-        .withQueryStringParameter(new Parameter("service_type", "files"))
-        .withHeader("FileOwnerId", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
-    if (previewPathEndpoint.contains("document")) {
-      request.withQueryStringParameter(new Parameter("lang_tag", "en"));
-    }
-
-    return simulator.getPreviewMock()
-        .when(request)
-        .respond(org.mockserver.model.HttpResponse.response()
-            .withStatusCode(200)
-            .withBody(new BinaryBody("0".getBytes())).withContentType(previewTypeResponse))[0].getId();
-  }
-
-  static void verifyAndClearExpectationInPreviewMockService(String expectationId) {
-    MockServerClient previewServiceMock = simulator.getPreviewMock();
-    previewServiceMock.verify(expectationId).clear(expectationId);
+    app.close();
   }
 
   @Test
   void givenAnExistingDocumentTheGetPreviewApiShouldGetAndReturnThePreviewWithLangTag() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "FILE.XLS",
                 "",
@@ -105,9 +68,11 @@ class PreviewApiIT {
                 "application/vnd.ms-excel")
         );
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/document/00000000-0000-0000-0000-000000000000/1/",
-        MediaType.PDF
+        OWNER_ID,
+        "0".getBytes(),
+        "application/pdf"
     );
 
     final HttpRequest httpRequest =
@@ -117,8 +82,7 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -126,7 +90,7 @@ class PreviewApiIT {
         .extracting(header -> header.getKey().equals("content-type") ? header.getValue() : null)
         .contains("application/pdf");
 
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @ParameterizedTest
@@ -135,12 +99,13 @@ class PreviewApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "pres.odp",
                 "",
@@ -150,9 +115,11 @@ class PreviewApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/document/00000000-0000-0000-0000-000000000000/2/",
-        MediaType.PDF
+        OWNER_ID,
+        "0".getBytes(),
+        "application/pdf"
     );
 
     final HttpRequest httpRequest =
@@ -162,22 +129,23 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @Test
   void givenTwoVersionsOfAnExistingDocumentTheGetPreviewApiShouldReturnThePdfOfTheFirstVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "pres.odp",
                 "",
@@ -187,9 +155,11 @@ class PreviewApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/document/00000000-0000-0000-0000-000000000000/1/",
-        MediaType.PDF
+        OWNER_ID,
+        "0".getBytes(),
+        "application/pdf"
     );
 
     final HttpRequest httpRequest =
@@ -199,11 +169,11 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @ParameterizedTest
@@ -212,12 +182,13 @@ class PreviewApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "buy_me.pdf",
                 "",
@@ -228,9 +199,11 @@ class PreviewApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/pdf/00000000-0000-0000-0000-000000000000/3/",
-        MediaType.PDF
+        OWNER_ID,
+        "0".getBytes(),
+        "application/pdf"
     );
 
     final HttpRequest httpRequest =
@@ -240,22 +213,23 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @Test
   void givenThreeVersionsOfAnExistingPdfTheGetPreviewApiShouldReturnThePdfOfTheSecondVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "buy_me.pdf",
                 "",
@@ -266,9 +240,11 @@ class PreviewApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/pdf/00000000-0000-0000-0000-000000000000/2/",
-        MediaType.PDF
+        OWNER_ID,
+        "0".getBytes(),
+        "application/pdf"
     );
 
     final HttpRequest httpRequest =
@@ -278,11 +254,11 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @ParameterizedTest
@@ -291,12 +267,13 @@ class PreviewApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "don't open.png",
                 "",
@@ -306,9 +283,11 @@ class PreviewApiIT {
                 "image/png")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",
-        MediaType.PNG
+        OWNER_ID,
+        "0".getBytes(),
+        "image/png"
     );
 
     final HttpRequest httpRequest =
@@ -318,22 +297,23 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 
   @Test
   void givenTwoVersionsOfAnExistingJpegImageTheGetPreviewApiShouldReturnTheJpegOfTheSecondVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "don't open.png",
                 "",
@@ -343,9 +323,11 @@ class PreviewApiIT {
                 "image/jpeg")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callPreviewExpectationId = mockSuccessPreviewResponse(
+    String callPreviewExpectationId = app.mocks().previewServes(
         "/preview/image/00000000-0000-0000-0000-000000000000/2/0x0/",
-        MediaType.JPEG
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -355,10 +337,10 @@ class PreviewApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInPreviewMockService(callPreviewExpectationId);
+    app.mocks().verifyPreviewServed(callPreviewExpectationId);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewEdgeApiIT.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Edge-branch coverage for {@code PreviewController} that {@code PreviewApiIT}/{@code
@@ -34,20 +36,22 @@ import org.junit.jupiter.api.Test;
  *       (exercised once, via the pdf family, since the branch is shared bytecode).
  * </ul>
  *
- * <p><b>NOT covered here (missing seam capability, reported rather than silently added — see the
- * wave-2D report):</b>
+ * <p><b>Gap-closing pass additions</b> (the wave-2D report flagged the preview-service-failure
+ * fallback as missing a seam capability; {@code Mocks#previewFails(String)} now closes it — see
+ * the {@code *ThePreviewServiceFailsTheApiShouldReturnA404StatusCode} tests below). Also closes:
+ * the {@code channelRead0} "matched path, wrong HTTP verb" fallback (6 identical {@code
+ * matcher.find() && method.equals(GET)} conditions, one per preview/thumbnail route, all
+ * previously untested since every existing test uses GET); the image-family ETag/304 case
+ * (previously only exercised for pdf/document); and {@code checkNodePermissionAndExistence}'s
+ * "permission granted but the requested version doesn't exist" branch (previously every
+ * not-found/permission-denied test hit the OTHER short-circuit of that {@code &&}, never this one).
  *
- * <ul>
- *   <li>The preview-service-failure fallback ({@code PreviewController#failureResponse} reached via
- *       {@code previewService.getXxx(...).onFailure(...)}) — {@code Mocks}/{@code GuiceNettyMocks}
- *       only expose {@code previewServes(...)} (always a 200); there is no {@code previewFails(...)}
- *       stub to make the Preview mock return an error.
- *   <li>The document-preview ETag's locale component (same node, different {@code Accept-Language}
- *       must NOT 304) — production does not read an {@code Accept-Language} header at all; the
- *       requester's {@code Locale} comes from the user-management profile
- *       ({@code UserRepositoryRest#parseLocale}), and {@code MockUserManagementService} hardcodes
- *       every registered user's locale to {@code "en"} with no seam knob to vary it.
- * </ul>
+ * <p><b>Still NOT covered here (a genuine seam gap, out of THIS pass's authorized scope):</b> the
+ * document-preview ETag's locale component (same node, different {@code Accept-Language} must NOT
+ * 304) — production does not read an {@code Accept-Language} header at all; the requester's
+ * {@code Locale} comes from the user-management profile ({@code UserRepositoryRest#parseLocale}),
+ * and {@code MockUserManagementService} hardcodes every registered user's locale to {@code "en"}
+ * with no seam knob to vary it.
  */
 class PreviewEdgeApiIT {
 
@@ -391,5 +395,299 @@ class PreviewEdgeApiIT {
     Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
 
     app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  // --- Image-family ETag / If-None-Match caching (previously only exercised for pdf/document) --
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedImagePreviewRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000208",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/image/00000000-0000-0000-0000-000000000208/1/0x0/",
+                OWNER_ID,
+                "content".getBytes(),
+                "image/png");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000208/0x0",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000208/0x0",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  // --- Preview-service failure fallback (PreviewController#failureResponse via onFailure) -------
+  // Closes the wave-2D-reported gap: Mocks#previewFails(String) stubs the Preview mock itself to
+  // fail (distinct from the permission/mime-type failures above, which never reach the Preview
+  // service at all). Production maps this (the SDK's PreviewException is not a
+  // BadRequestException) to a NoSuchElementException -> HTTP 404.
+
+  @Test
+  void givenThePreviewServiceFailsTheImagePreviewApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000209",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+
+    app.mocks().previewFails("/preview/image/00000000-0000-0000-0000-000000000209/1/0x0/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000209/0x0",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenThePreviewServiceFailsTheImageThumbnailApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000210",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken-thumb.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+
+    app.mocks()
+        .previewFails("/preview/image/00000000-0000-0000-0000-000000000210/1/5x5/thumbnail/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000210/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenThePreviewServiceFailsThePdfPreviewApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000211",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    app.mocks().previewFails("/preview/pdf/00000000-0000-0000-0000-000000000211/1/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET", "/preview/pdf/00000000-0000-0000-0000-000000000211/", OWNER_COOKIE, null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenThePreviewServiceFailsThePdfThumbnailApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000212",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken-thumb.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    app.mocks()
+        .previewFails("/preview/pdf/00000000-0000-0000-0000-000000000212/1/5x5/thumbnail/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000212/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenThePreviewServiceFailsTheDocumentPreviewApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000213",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken.xls",
+                "",
+                NodeType.SPREADSHEET,
+                "LOCAL_ROOT",
+                10L,
+                "application/vnd.ms-excel"));
+
+    app.mocks().previewFails("/preview/document/00000000-0000-0000-0000-000000000213/1/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET", "/preview/document/00000000-0000-0000-0000-000000000213", OWNER_COOKIE, null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenThePreviewServiceFailsTheDocumentThumbnailApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000214",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "broken-thumb.xls",
+                "",
+                NodeType.SPREADSHEET,
+                "LOCAL_ROOT",
+                10L,
+                "application/vnd.ms-excel"));
+
+    app.mocks()
+        .previewFails("/preview/document/00000000-0000-0000-0000-000000000214/1/5x5/thumbnail/");
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/document/00000000-0000-0000-0000-000000000214/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  // --- channelRead0 "matched path, wrong HTTP verb" fallback -----------------------------------
+  // Each of the 6 preview/thumbnail routes shares the identical `matcher.find() &&
+  // method.equals(GET)` guard; every existing test in the suite only ever sends GET, so the
+  // "matched but wrong verb" direction was never taken for ANY of the 6. No node needs to exist:
+  // the method check happens before any DB lookup, falling through to the generic 400.
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/preview/image/00000000-0000-0000-0000-000000000299/100x100",
+        "/preview/image/00000000-0000-0000-0000-000000000299/100x100/thumbnail",
+        "/preview/pdf/00000000-0000-0000-0000-000000000299/",
+        "/preview/pdf/00000000-0000-0000-0000-000000000299/100x100/thumbnail",
+        "/preview/document/00000000-0000-0000-0000-000000000299",
+        "/preview/document/00000000-0000-0000-0000-000000000299/100x100/thumbnail"
+      })
+  void givenAMatchingPreviewPathWithAWrongHttpVerbTheApiShouldReturnA400StatusCode(String uri) {
+    final HttpRequest httpRequest = HttpRequest.of("POST", uri, OWNER_COOKIE, null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  // --- checkNodePermissionAndExistence: permission granted but the requested version is absent --
+  // Distinct from the not-found/permission-denied tests above (which short-circuit the "&&" on
+  // permissionsChecker...has(READ_ONLY), never reaching optFileVersion.isPresent() at all): here
+  // permission IS granted, but the specific requested version number doesn't exist.
+
+  @Test
+  void givenAPermittedNodeWithANonExistentVersionThePreviewApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000215",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "onlyOneVersion.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000215/?version=999",
+            OWNER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PreviewEdgeApiIT.java
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Edge-branch coverage for {@code PreviewController} that {@code PreviewApiIT}/{@code
+ * ThumbnailApiIT} do not exercise (those two cover only the happy paths: successful preview/
+ * thumbnail retrieval and version resolution). This class targets:
+ *
+ * <ul>
+ *   <li>MIME-type mismatch per family (image/pdf/document) -&gt; 400 ({@code BadRequestException}).
+ *   <li>The generic {@code /preview/<unmatched>} fall-through -&gt; 400.
+ *   <li>The {@code IllegalArgumentException} catch branch (unparsable {@code ?version=} value)
+ *       -&gt; 400.
+ *   <li>ETag / {@code If-None-Match} caching: first request -&gt; 200 + ETag; matching If-None-Match
+ *       -&gt; 304; stale/mismatched If-None-Match -&gt; 200 again (same ETag).
+ *   <li>Permission-denied and not-found on the shared {@code checkNodePermissionAndExistence} path
+ *       (exercised once, via the pdf family, since the branch is shared bytecode).
+ * </ul>
+ *
+ * <p><b>NOT covered here (missing seam capability, reported rather than silently added — see the
+ * wave-2D report):</b>
+ *
+ * <ul>
+ *   <li>The preview-service-failure fallback ({@code PreviewController#failureResponse} reached via
+ *       {@code previewService.getXxx(...).onFailure(...)}) — {@code Mocks}/{@code GuiceNettyMocks}
+ *       only expose {@code previewServes(...)} (always a 200); there is no {@code previewFails(...)}
+ *       stub to make the Preview mock return an error.
+ *   <li>The document-preview ETag's locale component (same node, different {@code Accept-Language}
+ *       must NOT 304) — production does not read an {@code Accept-Language} header at all; the
+ *       requester's {@code Locale} comes from the user-management profile
+ *       ({@code UserRepositoryRest#parseLocale}), and {@code MockUserManagementService} hardcodes
+ *       every registered user's locale to {@code "en"} with no seam knob to vary it.
+ * </ul>
+ */
+class PreviewEdgeApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_USER_COOKIE = "ZM_AUTH_TOKEN=fake-token-other";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withPreview()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-other", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.backdoor().clearFileVersionCache();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String extractHeader(HttpResponse response, String name) {
+    return response.getHeaders().stream()
+        .filter(header -> header.getKey().equalsIgnoreCase(name))
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  // --- MIME-type mismatch, one per family --------------------------------------------------
+
+  @Test
+  void givenANonImageNodeThePreviewImageApiShouldReturnA400StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000201",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "not-an-image.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000201/100x100",
+            OWNER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void givenANonPdfNodeThePreviewPdfApiShouldReturnA400StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000202",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "not-a-pdf.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET", "/preview/pdf/00000000-0000-0000-0000-000000000202/", OWNER_COOKIE, null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void givenANodeOutsideTheDocumentAllowListThePreviewDocumentApiShouldReturnA400StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000203",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "not-a-document.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET", "/preview/document/00000000-0000-0000-0000-000000000203", OWNER_COOKIE, null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  // --- Generic unmatched fall-through --------------------------------------------------------
+
+  @Test
+  void givenAnUnmatchedPreviewSubPathTheApiShouldReturnA400StatusCode() {
+    final HttpRequest httpRequest =
+        HttpRequest.of("GET", "/preview/some-unsupported-kind/whatever", OWNER_COOKIE, null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  // --- IllegalArgumentException catch (unparsable query parameter) --------------------------
+
+  @Test
+  void givenANonNumericVersionQueryParameterThePreviewApiShouldReturnA400StatusCode() {
+    // No node needs to exist: parseQueryParameters() runs, and fails, before any DB lookup.
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000299/?version=not-a-number",
+            OWNER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+  }
+
+  // --- Permission-denied / not-found on the shared checkNodePermissionAndExistence path -------
+
+  @Test
+  void givenANonExistentNodeThePreviewApiShouldReturnA404StatusCode() {
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET", "/preview/pdf/00000000-0000-0000-0000-000000000298/", OWNER_COOKIE, null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenARequesterWithoutPermissionThePreviewApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000204",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "private.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+    // No share created for OTHER_USER_ID: it has no permission on this node.
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000204/",
+            OTHER_USER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  // --- ETag / If-None-Match caching -----------------------------------------------------------
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedPreviewRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000205",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/pdf/00000000-0000-0000-0000-000000000205/1/",
+                OWNER_ID,
+                "content".getBytes(),
+                "application/pdf");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET", "/preview/pdf/00000000-0000-0000-0000-000000000205/", OWNER_COOKIE, null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000205/",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  @Test
+  void givenAStaleIfNoneMatchHeaderTheRepeatedPreviewRequestShouldReturnA200StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000206",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable-stale.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/pdf/00000000-0000-0000-0000-000000000206/1/",
+                OWNER_ID,
+                "content".getBytes(),
+                "application/pdf");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET", "/preview/pdf/00000000-0000-0000-0000-000000000206/", OWNER_COOKIE, null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000206/",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", "clearly-stale-etag-value")),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(extractHeader(secondResponse, "etag")).isEqualTo(etag);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedDocumentPreviewRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000207",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable.xls",
+                "",
+                NodeType.SPREADSHEET,
+                "LOCAL_ROOT",
+                7L,
+                "application/vnd.ms-excel"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/document/00000000-0000-0000-0000-000000000207/1/",
+                OWNER_ID,
+                "0".getBytes(),
+                "application/pdf");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET", "/preview/document/00000000-0000-0000-0000-000000000207", OWNER_COOKIE, null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/document/00000000-0000-0000-0000-000000000207",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadApiIT.java
@@ -2,22 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -27,46 +19,31 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockserver.model.HttpError;
-import org.mockserver.model.Parameter;
-import org.mockserver.verify.VerificationTimes;
 
 public class PublicDownloadApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(Map.of("fake-token", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
             .withStorages()
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.getStoragesMock().reset();
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @ParameterizedTest
@@ -78,7 +55,8 @@ public class PublicDownloadApiIT {
       givenAUserWithOrWithoutCookieAnExistingFileAndAValidPublicLinkAssociatedThePublicDownloadByNodeIdShouldReturnTheBlob(
           String userToken) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -99,35 +77,25 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.empty());
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download")
-                .withQueryStringParameter(
-                    Parameter.param("node", "00000000-0000-0000-0000-000000000000"))
-                .withQueryStringParameter(Parameter.param("version", "1"))
-                .withQueryStringParameter(Parameter.param("type", "files")),
-            VerificationTimes.once());
+    app.mocks().verifyStoragesDownloaded("00000000-0000-0000-0000-000000000000", 1);
   }
 
   @Test
   void givenAnExistingFileAndAnExpiredLinkThePublicDownloadByNodeIdShouldReturnA404StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -152,26 +120,20 @@ public class PublicDownloadApiIT {
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
   void givenAnExistingFileAndANotExistingLinkThePublicDownloadByNodeIdShouldReturnA404StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -189,20 +151,13 @@ public class PublicDownloadApiIT {
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
@@ -211,27 +166,21 @@ public class PublicDownloadApiIT {
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
     Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"),
-            VerificationTimes.never());
+    app.mocks().verifyStoragesNeverDownloaded();
   }
 
   @Test
   void
       givenAnExistingFileAndAValidPublicLinkAssociatedAndAConnectionProblemToStoragesTheThePublicDownloadByNodeIdShouldReturnA500StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -252,20 +201,13 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.empty());
 
-    simulator
-        .getStoragesMock()
-        .when(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download"))
-        .error(HttpError.error().withDropConnection(true));
+    app.mocks().storagesDownloadConnectionDrops();
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
@@ -281,7 +223,8 @@ public class PublicDownloadApiIT {
       givenAUserWithOrWithoutCookieAnExistingFileAndAValidPublicLinkAssociatedButNotPassedInUrlThePublicDownloadByNodeIdShouldReturnA404StatusCode(
           String userToken) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -302,14 +245,13 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.empty());
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, userToken, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
@@ -318,7 +260,8 @@ public class PublicDownloadApiIT {
   @Test
   void givenAnExistingFileWithAccessCodeAndAValidLinkThePublicDownloadByNodeIdWithoutAccessCodeShouldReturnA404StatusCode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -343,8 +286,7 @@ public class PublicDownloadApiIT {
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
@@ -353,7 +295,8 @@ public class PublicDownloadApiIT {
   @Test
   void givenAnExistingFileWithAccessCodeAndAValidLinkThePublicDownloadByNodeIdWithAccessCodeShouldReturnTheBlob() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -374,14 +317,13 @@ public class PublicDownloadApiIT {
             Optional.empty(),
             Optional.of("accesscode"));
 
-    storagesMockHelper.getBlob("00000000-0000-0000-0000-000000000000", 1);
+    app.mocks().storagesServesBlob("00000000-0000-0000-0000-000000000000", 1);
 
     final String publicDownloadUrl = "/public/download/00000000-0000-0000-0000-000000000000?node_link_id=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab&access_code=accesscode";
     final HttpRequest httpRequest = HttpRequest.of("GET", publicDownloadUrl, null, null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadEdgeApiIT.java
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Edge-branch coverage for {@code PublicBlobController} that {@code PublicDownloadApiIT}/{@code
+ * PublicDownloadMultipleApiIT}/{@code DownloadByPublicLinkApiIT} do not exercise. Those three
+ * cover: {@code downloadByNodeId} (plain, non-check, node-id download), {@code
+ * downloadPublicMultiple} (form-encoded, non-check, zip download) and {@code downloadByPublicLink}
+ * (including its 307 redirect for an access-code-protected link). This class targets the two
+ * "check" variants (which those files do not cover at all) plus one routing-level regex quirk:
+ *
+ * <ul>
+ *   <li>{@code checkDownloadPublicFile} ({@code GET /public/download/{id}/check?node_link_id=...})
+ *       -&gt; 204 on success, 404 on any not-accessible condition.
+ *   <li>{@code checkDownloadPublicMultiple} ({@code POST /public/download-multiple/check}) -&gt;
+ *       204/404/400. Note the body-encoding asymmetry versus the non-check {@code
+ *       downloadPublicMultiple}: the non-check endpoint reads a form-urlencoded body, but the
+ *       check endpoint reads a raw JSON body (see {@code
+ *       PublicBlobController#checkDownloadPublicMultiple}).
+ *   <li>Query-string parameter ORDER on {@code DOWNLOAD_PUBLIC_FILE_CHECK}: the endpoint's regex
+ *       hard-codes {@code node_link_id} immediately after {@code ?}, with {@code access_code} (if
+ *       present) only allowed to follow it. Reversing the order makes the regex fail to match at
+ *       the {@code HttpRoutingHandler} level (before any handler runs at all) — this is a routing
+ *       404, not a {@code PublicBlobController}/{@code ExceptionsHandler} 404, and is a distinct,
+ *       currently-undocumented behaviour.
+ * </ul>
+ *
+ * <p>The 307 redirect on {@code /link/{id}} for an access-code-protected link is already covered
+ * by {@code DownloadByPublicLinkApiIT#givenAUserWithOrWithoutCookieAnExistingFileAndAnExistingPublicLinkAssociatedWithAccessCodeTheDownloadByPublicLinkShouldRedirect}
+ * — not duplicated here.
+ */
+public class PublicDownloadEdgeApiIT {
+
+  static FilesTestApp app;
+  static ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of())
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  // --- checkDownloadPublicFile (GET /public/download/{id}/check?node_link_id=...) ------------
+
+  @Test
+  void givenAnAccessibleNodeTheCheckDownloadPublicFileApiShouldReturnA204StatusCode() {
+    String userId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String fileId = "00000000-0000-0000-0000-000000000301";
+    String linkPublicId = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                userId,
+                userId,
+                "LOCAL_ROOT",
+                "file.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad76",
+            fileId,
+            linkPublicId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    final String url = "/public/download/" + fileId + "/check?node_link_id=" + linkPublicId;
+    final HttpResponse httpResponse = app.send(HttpRequest.of("GET", url, null, null));
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenANotExistingLinkTheCheckDownloadPublicFileApiShouldReturnA404StatusCode() {
+    final String url =
+        "/public/download/00000000-0000-0000-0000-000000000302/check?node_link_id=nonexistentlink0000000000000000000000000000000ab";
+    final HttpResponse httpResponse = app.send(HttpRequest.of("GET", url, null, null));
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenAProtectedLinkWithoutTheAccessCodeTheCheckDownloadPublicFileApiShouldReturnA404StatusCode() {
+    String userId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String fileId = "00000000-0000-0000-0000-000000000303";
+    String linkPublicId = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                userId,
+                userId,
+                "LOCAL_ROOT",
+                "protected.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad77",
+            fileId,
+            linkPublicId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("secretcode123"));
+
+    final String url = "/public/download/" + fileId + "/check?node_link_id=" + linkPublicId;
+    final HttpResponse httpResponse = app.send(HttpRequest.of("GET", url, null, null));
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  // --- checkDownloadPublicMultiple (POST /public/download-multiple/check, JSON body) ----------
+
+  @Test
+  void givenAccessibleNodesTheCheckDownloadPublicMultipleApiShouldReturnA204StatusCode()
+      throws Exception {
+    String userId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String folderId = "11111111-1111-1111-1111-111111110401";
+    String fileId = "00000000-0000-0000-0000-000000000401";
+    String linkPublicId = "abcd1234-abcd-1234-abcd-1234abcd1401";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                folderId,
+                userId,
+                userId,
+                "LOCAL_ROOT",
+                "check-folder",
+                "",
+                NodeType.FOLDER,
+                "LOCAL_ROOT",
+                0L,
+                null))
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                userId,
+                userId,
+                folderId,
+                "file.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT," + folderId,
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad78",
+            folderId,
+            linkPublicId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("nodeIds", List.of(fileId));
+    body.put("nodeLinkId", linkPublicId);
+    String requestBody = objectMapper.writeValueAsString(body);
+
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/json"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/public/download-multiple/check", null, headers, requestBody);
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenANotExistingLinkTheCheckDownloadPublicMultipleApiShouldReturnA404StatusCode()
+      throws Exception {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("nodeIds", List.of("00000000-0000-0000-0000-000000000402"));
+    body.put("nodeLinkId", "nonexistentlink0000000000000000000000000000000ab");
+    String requestBody = objectMapper.writeValueAsString(body);
+
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/json"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of("POST", "/public/download-multiple/check", null, headers, requestBody);
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenAMalformedJsonBodyTheCheckDownloadPublicMultipleApiShouldReturnA500StatusCode() {
+    // Divergence from the naive expectation of 400 (documented as a finding, NOT fixed — Phase 1
+    // forbids src/main changes): PublicBlobController#checkDownloadPublicMultiple wraps the
+    // JsonProcessingException in `new IllegalArgumentException("Invalid JSON body", e)` and fires
+    // THAT. But ExceptionsHandler unconditionally unwraps exactly one getCause() level
+    // (`cause = cause.getCause() == null ? cause : cause.getCause()`), so the exception it
+    // actually switches on is the ORIGINAL JsonProcessingException, not the IllegalArgumentException
+    // — which matches ExceptionsHandler's `JsonProcessingException -> 500` branch, not its
+    // `IllegalArgumentException -> 400` branch. The same wrapping pattern in the sibling
+    // downloadPublicMultiple (non-check) method has the identical bug, just untested elsewhere.
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/json"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "POST", "/public/download-multiple/check", null, headers, "{not-valid-json");
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+  }
+
+  // --- Query-string parameter ORDER edge on DOWNLOAD_PUBLIC_FILE_CHECK ------------------------
+
+  @Test
+  void givenNodeLinkIdBeforeAccessCodeTheCheckDownloadPublicFileApiShouldReturnA204StatusCode() {
+    String userId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String fileId = "00000000-0000-0000-0000-000000000501";
+    String linkPublicId = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
+    String accessCode = "secretcode123";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                userId,
+                userId,
+                "LOCAL_ROOT",
+                "ordered.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad79",
+            fileId,
+            linkPublicId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(accessCode));
+
+    final String correctOrderUrl =
+        "/public/download/"
+            + fileId
+            + "/check?node_link_id="
+            + linkPublicId
+            + "&access_code="
+            + accessCode;
+    final HttpResponse httpResponse = app.send(HttpRequest.of("GET", correctOrderUrl, null, null));
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(204);
+  }
+
+  @Test
+  void givenAccessCodeBeforeNodeLinkIdTheCheckDownloadPublicFileApiShouldReturnA404StatusCode() {
+    String userId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    String fileId = "00000000-0000-0000-0000-000000000502";
+    String linkPublicId = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab";
+    String accessCode = "secretcode123";
+
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                fileId,
+                userId,
+                userId,
+                "LOCAL_ROOT",
+                "misordered.txt",
+                "",
+                NodeType.TEXT,
+                "LOCAL_ROOT",
+                10L,
+                "text/plain"))
+        .addLink(
+            "94103c01-e701-4f3d-9dc9-54b79064ad80",
+            fileId,
+            linkPublicId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(accessCode));
+
+    // Same node/link/access-code as the previous test, only the query-parameter ORDER differs:
+    // access_code first, node_link_id second. DOWNLOAD_PUBLIC_FILE_CHECK's regex hard-codes
+    // node_link_id immediately after '?', so this URI matches NO route in HttpRoutingHandler and
+    // falls straight to its raw NOT_FOUND fallback -- PublicBlobController is never invoked.
+    final String wrongOrderUrl =
+        "/public/download/"
+            + fileId
+            + "/check?access_code="
+            + accessCode
+            + "&node_link_id="
+            + linkPublicId;
+    final HttpResponse httpResponse = app.send(HttpRequest.of("GET", wrongOrderUrl, null, null));
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadMultipleApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicDownloadMultipleApiIT.java
@@ -2,24 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.Injector;
 import com.zextras.carbonio.files.Constants;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -31,45 +23,31 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockserver.model.Parameter;
-import org.mockserver.verify.VerificationTimes;
 
 public class PublicDownloadMultipleApiIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
   static ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(Map.of())
             .withStorages()
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   @Test
@@ -83,7 +61,8 @@ public class PublicDownloadMultipleApiIT {
     String linkId = UUID.randomUUID().toString();
     String publicId = UUID.randomUUID().toString();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -140,9 +119,9 @@ public class PublicDownloadMultipleApiIT {
             Optional.of("Public folder link"),
             Optional.empty());
 
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
-    storagesMockHelper.getBlob(fileId3, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId3, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2, fileId3);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -158,8 +137,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
     Assertions.assertThat(httpResponse.getHeaders())
@@ -174,16 +152,7 @@ public class PublicDownloadMultipleApiIT {
                     && header.getValue().contains("attachment")
                     && header.getValue().contains("Files.zip"));
 
-    simulator
-        .getStoragesMock()
-        .verify(
-            org.mockserver.model.HttpRequest.request()
-                .withMethod(HttpMethod.GET.toString())
-                .withPath("/download")
-                .withQueryStringParameter(Parameter.param("node", fileId1))
-                .withQueryStringParameter(Parameter.param("version", "1"))
-                .withQueryStringParameter(Parameter.param("type", "files")),
-            VerificationTimes.once());
+    app.mocks().verifyStoragesDownloaded(fileId1, 1);
   }
 
   @Test
@@ -196,7 +165,8 @@ public class PublicDownloadMultipleApiIT {
     String publicId = UUID.randomUUID().toString();
     String accessCode = "secret123";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -241,8 +211,8 @@ public class PublicDownloadMultipleApiIT {
             Optional.of("Protected link"),
             Optional.of(accessCode));
 
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, fileId2);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -260,8 +230,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
   }
@@ -272,7 +241,8 @@ public class PublicDownloadMultipleApiIT {
     String fileId = "00000000-0000-0000-0000-000000000401";
     String invalidPublicId = UUID.randomUUID().toString();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 fileId,
@@ -300,8 +270,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
   }
@@ -318,8 +287,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
   }
@@ -341,8 +309,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
   }
@@ -357,7 +324,8 @@ public class PublicDownloadMultipleApiIT {
     String linkId = UUID.randomUUID().toString();
     String publicId = UUID.randomUUID().toString();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 parentFolderId,
@@ -409,8 +377,8 @@ public class PublicDownloadMultipleApiIT {
         .addLink(
             linkId, parentFolderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
 
-    storagesMockHelper.getBlob(fileId1, 1);
-    storagesMockHelper.getBlob(fileId2, 1);
+    app.mocks().storagesServesBlob(fileId1, 1);
+    app.mocks().storagesServesBlob(fileId2, 1);
 
     List<String> nodeIds = List.of(fileId1, subFolderId);
     String jsonArray = objectMapper.writeValueAsString(nodeIds);
@@ -426,8 +394,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
   }
@@ -441,7 +408,8 @@ public class PublicDownloadMultipleApiIT {
     String publicId = UUID.randomUUID().toString();
     String accessCode = "required123";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -488,8 +456,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
   }
@@ -501,7 +468,8 @@ public class PublicDownloadMultipleApiIT {
     String linkId = UUID.randomUUID().toString();
     String publicId = UUID.randomUUID().toString();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 folderId,
@@ -536,8 +504,7 @@ public class PublicDownloadMultipleApiIT {
     final HttpRequest httpRequest =
         HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody);
 
-    final HttpResponse httpResponse =
-        TestUtils.sendFormRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.sendForm(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
   }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicFindNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicFindNodesApiIT.java
@@ -2,28 +2,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.search;
+package com.zextras.carbonio.files.acceptance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSQLCondition;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SQLExpression;
-import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SortOrder;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,40 +25,32 @@ import org.junit.jupiter.api.Test;
 
 public class PublicFindNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator().init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFolderTree() {
     String ownerId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -104,7 +85,8 @@ public class PublicFindNodesApiIT {
 
     childrenFileIds.forEach(
         fileId -> {
-          DatabasePopulator.aNodePopulator(simulator.getInjector())
+          app.backdoor()
+              .populator()
               .addNode(
                   new PopulatorNode(
                       fileId,
@@ -129,7 +111,8 @@ public class PublicFindNodesApiIT {
   void givenAnExistingFolderAndAValidPublicLinkTheFindNodesShouldReturnTheFirstPage() {
     // Given
     createFolderTree();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -149,8 +132,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -183,7 +165,8 @@ public class PublicFindNodesApiIT {
   void givenAnExistingFolderAndAValidLinkTheFindNodesShouldReturnTheSecondPage() {
     // Given
     createFolderTree();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -203,8 +186,7 @@ public class PublicFindNodesApiIT {
 
     final HttpRequest firstHttpRequest =
         HttpRequest.of("POST", "/public/graphql/", null, firstBodyPayload);
-    final HttpResponse firstHttpResponse =
-        TestUtils.sendRequest(firstHttpRequest, simulator.getNettyChannel());
+    final HttpResponse firstHttpResponse = app.send(firstHttpRequest);
 
     Assertions.assertThat(firstHttpResponse.getStatus()).isEqualTo(200);
     String pageToken =
@@ -225,8 +207,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     final Map<String, Object> page =
@@ -254,7 +235,8 @@ public class PublicFindNodesApiIT {
   void givenAnExistingFolderAndAValidPublicLinkTheFindNodesShouldReturnTheOnlyPageExisting() {
     // Given
     createFolderTree();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -274,8 +256,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -312,7 +293,8 @@ public class PublicFindNodesApiIT {
   @Test
   void givenAnExistingEmptyFolderAndAValidPublicLinkTheFindNodesShouldReturnAnEmptyFirstPage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -343,8 +325,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -367,7 +348,8 @@ public class PublicFindNodesApiIT {
   void
       givenAnExistingFolderAndAnExpiredPublicLinkTheFindNodesShouldReturn200CodeAndAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -398,8 +380,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -431,8 +412,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -457,8 +437,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -476,11 +455,12 @@ public class PublicFindNodesApiIT {
     not public and an hacked page token that is formed to try access a private node: the findNodes
     should return an empty page""")
   @Test
-  void givenAnHackedPageTokenWithoutSignatureTheFindNodesShouldReturnAnError() throws JsonProcessingException {
+  void givenAnHackedPageTokenWithoutSignatureTheFindNodesShouldReturnAnError() {
     // Given
     createFolderTree();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -525,52 +505,21 @@ public class PublicFindNodesApiIT {
                 0L,
                 null));
 
-    SQLExpression keySet = SQLExpression.or(List.of(
-      new NodeSQLCondition("node_category", SortOrder.ASCENDING, 1),
-      SQLExpression.and(List.of(
-        new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
-        new NodeSQLCondition("name", SortOrder.ASCENDING, "folder child")
-      )),
-        SQLExpression.and(List.of(
-          new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
-          new NodeSQLCondition("name", SortOrder.EQUAL, "folder child"),
-          new NodeSQLCondition("node_id", SortOrder.ASCENDING, "88888888-8888-8888-8888-888888888888")
-        ))
-      ));
-    String jsonKeySet = new ObjectMapper().writeValueAsString(keySet);
-
-      String pageTokenHacked = String.format(
-        """
-    {
-      "limit": 1,
-      "keywords": [],
-      "keySet": %s,
-      "sort": "NAME_ASC",
-      "flagged": null,
-      "folderId": "77777777-7777-7777-7777-777777777777",
-      "cascade": null,
-      "sharedWithMe": null,
-      "sharedByMe": null,
-      "directShare": null,
-      "nodeType": null,
-      "ownerId": null
-    }""", jsonKeySet);
+    String pageTokenHacked = app.backdoor().forgeTamperedPageTokenMissingSignature();
 
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 1)
             .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
-            .withString(
-                "page_token", Base64.getEncoder().encodeToString(pageTokenHacked.getBytes()))
+            .withString("page_token", pageTokenHacked)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -583,11 +532,12 @@ public class PublicFindNodesApiIT {
   }
 
   @Test
-  void givenAnHackedPageTokenWithWrongSignatureTheFindNodesShouldReturnAnError() throws JsonProcessingException {
+  void givenAnHackedPageTokenWithWrongSignatureTheFindNodesShouldReturnAnError() {
     // Given
     createFolderTree();
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -632,53 +582,22 @@ public class PublicFindNodesApiIT {
                 0L,
                 null));
 
-    SQLExpression keySet = SQLExpression.or(List.of(
-      new NodeSQLCondition("node_category", SortOrder.ASCENDING, 1),
-      SQLExpression.and(List.of(
-        new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
-        new NodeSQLCondition("name", SortOrder.ASCENDING, "folder child")
-      )),
-        SQLExpression.and(List.of(
-          new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
-          new NodeSQLCondition("name", SortOrder.EQUAL, "folder child"),
-          new NodeSQLCondition("node_id", SortOrder.ASCENDING, "88888888-8888-8888-8888-888888888888")
-        ))
-      ));
-    String jsonKeySet = new ObjectMapper().writeValueAsString(keySet);
-
-      String pageTokenHacked = String.format(
-        """
-    {
-      "signature": "wrong_signature",
-      "limit": 1,
-      "keywords": [],
-      "keySet": %s,
-      "sort": "NAME_ASC",
-      "flagged": null,
-      "folderId": "77777777-7777-7777-7777-777777777777",
-      "cascade": null,
-      "sharedWithMe": null,
-      "sharedByMe": null,
-      "directShare": null,
-      "nodeType": null,
-      "ownerId": null
-    }""", jsonKeySet);
+    String pageTokenHacked =
+        app.backdoor().forgeTamperedPageTokenWithWrongSignature("wrong_signature");
 
     String bodyPayload =
         GraphqlCommandBuilder.aQueryBuilder("findNodes")
             .withString("folder_id", "00000000-0000-0000-0000-000000000000")
             .withInteger("limit", 1)
             .withString("node_link_id", "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234ab")
-            .withString(
-                "page_token", Base64.getEncoder().encodeToString(pageTokenHacked.getBytes()))
+            .withString("page_token", pageTokenHacked)
             .withWantedResultFormat("{ nodes { id name }, page_token }")
             .build();
 
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -694,7 +613,8 @@ public class PublicFindNodesApiIT {
   void givenAnExistingFolderAndAValidPublicLinkNotPassedInQueryTheFindNodesShouldReturn200AndAnErrorCode() {
     // Given
     createFolderTree();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -713,8 +633,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -730,7 +649,8 @@ public class PublicFindNodesApiIT {
   void
       givenAnExistingFolderAndAValidPublicLinkWithAccessCodeTheFindNodesWithoutAccessCodeShouldReturn200CodeAndAnErrorMessage() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
@@ -761,8 +681,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -779,7 +698,8 @@ public class PublicFindNodesApiIT {
       givenAnExistingFolderAndAValidPublicLinkWithAccessCodeTheFindNodesWithAccessCodeShouldReturnTheCorrectPage() {
     // Given
     createFolderTree();
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "54ef41f2-8edf-4023-8b70-b29441a8e8b0",
             "00000000-0000-0000-0000-000000000000",
@@ -800,8 +720,7 @@ public class PublicFindNodesApiIT {
     final HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicGraphQLIntrospectionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicGraphQLIntrospectionApiIT.java
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@code POST /public/graphql/} introspection (Task 1.8 of the acceptance
+ * coverage-expansion plan).
+ *
+ * <p><b>SECURITY FINDING (documented, not fixed — Phase 1 forbids {@code src/main} changes):</b>
+ * unlike the authenticated {@code /graphql/} endpoint ({@code IntrospectionApiIT} confirms
+ * introspection is blocked there via {@code GraphQLProvider#buildSchema}'s {@code
+ * BlockedFields.newBlock().addPattern("__.*")} field-visibility transform), {@code
+ * PublicGraphQLProvider#buildSchema} applies NO such transform. The public, unauthenticated
+ * GraphQL endpoint therefore serves full schema introspection to anyone, with no login required.
+ * These tests pin down and demonstrate the current (unblocked) behaviour.
+ */
+class PublicGraphQLIntrospectionApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenFullSchemaIntrospectionQueryOnPublicGraphqlThenItSucceedsUnauthenticated()
+      throws Exception {
+    // Given — the exact introspection query that IntrospectionApiIT proves is BLOCKED on the
+    // authenticated /graphql/ endpoint.
+    String introspectionQuery = "query introspectionQuery { __schema { types { name } } }";
+
+    HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, introspectionQuery);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then — 200, NO errors, and the full type list is disclosed (finding: not blocked here).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> result =
+        OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+
+    Assertions.assertThat(result.get("errors")).as("introspection is not blocked; no errors expected").isNull();
+
+    Map<String, Object> data = (Map<String, Object>) result.get("data");
+    Map<String, Object> schema = (Map<String, Object>) data.get("__schema");
+    List<Map<String, Object>> types = (List<Map<String, Object>>) schema.get("types");
+
+    Assertions.assertThat(types).isNotEmpty();
+    Assertions.assertThat(types)
+        .extracting(type -> type.get("name"))
+        .as("the public schema's own types are disclosed via introspection")
+        .contains("Query", "Folder", "File", "NodePage");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenTypeIntrospectionOnQueryTypeOnPublicGraphqlThenFieldNamesAreDisclosed()
+      throws Exception {
+    // Given — a narrower introspection query revealing the exact Query field names/shape.
+    String bodyPayload =
+        "query { __type(name: \\\"Query\\\") { name fields { name } } }";
+
+    HttpRequest httpRequest = HttpRequest.of("POST", "/public/graphql/", null, bodyPayload);
+
+    // When
+    HttpResponse httpResponse = app.send(httpRequest);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+
+    Map<String, Object> result =
+        OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(result.get("errors")).isNull();
+
+    Map<String, Object> data = (Map<String, Object>) result.get("data");
+    Map<String, Object> type = (Map<String, Object>) data.get("__type");
+    List<Map<String, Object>> fields = (List<Map<String, Object>>) type.get("fields");
+
+    Assertions.assertThat(fields)
+        .extracting(field -> field.get("name"))
+        .contains("getPublicNode", "findNodes");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicMultiDownloadZipApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PublicMultiDownloadZipApiIT.java
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.Constants;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Public-link-specific ZIP-building branches of {@code rest.services.BlobService} that are NOT
+ * reachable through the authenticated path (see {@link MultiDownloadZipApiIT}, which covers the
+ * shared {@code createZip}/{@code addNodeToZip}/{@code getUniqueNameForZip} internals via the
+ * authenticated route). {@link PublicDownloadMultipleApiIT} already covers the public
+ * happy-path/basic-validation surface; this file targets the branches jacoco showed as uncovered
+ * that are unique to {@code checkDownloadPublicMultiple}/{@code downloadPublicMultiple}'s own
+ * accessChecker (link-validity + not-trashed, instead of permission-based) and to the
+ * public-only {@code requesterId == null} branch of {@code checkDownloadMultipleInternal}'s
+ * LOCAL_ROOT-alias handling.
+ *
+ * <p>See {@link MultiDownloadZipApiIT}'s class-level javadoc for the streamed-body / real-HTTP
+ * transport seam-limitation note; the same {@code assertBodyContainsWhenObservable} pattern is
+ * used here.
+ */
+class PublicMultiDownloadZipApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of())
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private void addFile(String id, String parentId, String ancestorIds, String name, long size) {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                id, USER_ID, USER_ID, parentId, name, "", NodeType.TEXT, ancestorIds, size, "text/plain"));
+  }
+
+  private void addFolder(String id, String parentId, String ancestorIds, String name) {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                id, USER_ID, USER_ID, parentId, name, "", NodeType.FOLDER, ancestorIds, 0L, null));
+  }
+
+  private HttpResponse checkPublicMultiple(List<String> nodeIds, String nodeLinkId) throws Exception {
+    Map<String, Object> body = new HashMap<>();
+    body.put("nodeIds", nodeIds);
+    body.put("nodeLinkId", nodeLinkId);
+    String jsonBody = OBJECT_MAPPER.writeValueAsString(body);
+    List<Map.Entry<String, String>> headers = List.of(Map.entry("Content-Type", "application/json"));
+    return app.sendForm(HttpRequest.of("POST", "/public/download-multiple/check", null, headers, jsonBody));
+  }
+
+  private HttpResponse downloadPublicMultiple(List<String> nodeIds, String nodeLinkId) throws Exception {
+    String jsonArray = OBJECT_MAPPER.writeValueAsString(nodeIds);
+    String requestBody =
+        "nodeIds=" + URLEncoder.encode(jsonArray, StandardCharsets.UTF_8) + "&nodeLinkId=" + nodeLinkId;
+    List<Map.Entry<String, String>> headers =
+        List.of(Map.entry("Content-Type", "application/x-www-form-urlencoded"));
+    return app.sendForm(HttpRequest.of("POST", "/public/download-multiple", null, headers, requestBody));
+  }
+
+  private void assertBodyContainsWhenObservable(HttpResponse response, String expectedSubstring) {
+    if (response.getBodyPayload() != null) {
+      Assertions.assertThat(response.getBodyPayload()).contains(expectedSubstring);
+    }
+  }
+
+  private void assertBodyDoesNotContainWhenObservable(HttpResponse response, String unexpectedSubstring) {
+    if (response.getBodyPayload() != null) {
+      Assertions.assertThat(response.getBodyPayload()).doesNotContain(unexpectedSubstring);
+    }
+  }
+
+  /**
+   * {@code checkDownloadPublicMultiple}'s accessChecker is {@code
+   * linkRepository.isLinkValidForNode(nodeLinkId, node) && !trashed} (link-scope validity), a
+   * DIFFERENT check than the authenticated path's permission-based one (see {@code
+   * LinkRepositoryEbean#isLinkValidForNode}: valid iff the node IS the link's node or one of its
+   * ancestors). A node entirely outside the linked folder's tree fails it and is silently
+   * skipped — same {@code continue} branch as the authenticated path, but a different reason.
+   */
+  @Test
+  void givenNodeOutsideLinkScopeMixedWithValidNodeCheckDownloadPublicMultipleShouldReturn204SkippingIt()
+      throws Exception {
+    String folderId = "11111111-1111-1111-1111-1111c0000001";
+    String insideFileId = "00000000-0000-0000-0000-00000000c001";
+    String outsideFileId = "00000000-0000-0000-0000-00000000c002";
+    String linkId = UUID.randomUUID().toString();
+    String publicId = UUID.randomUUID().toString();
+
+    addFolder(folderId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "linked-folder");
+    addFile(
+        insideFileId,
+        folderId,
+        Constants.Db.RootId.LOCAL_ROOT + "," + folderId,
+        "inside.txt",
+        10L);
+    // A completely separate top-level file, outside the linked folder's ancestor chain.
+    addFile(outsideFileId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "outside.txt", 10L);
+    app.backdoor()
+        .populator()
+        .addLink(linkId, folderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
+
+    HttpResponse response = checkPublicMultiple(List.of(insideFileId, outsideFileId), publicId);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  /**
+   * Distinguishes the {@code checkDownloadMultipleInternal}'s own {@code nodeIds.isEmpty()} ->
+   * {@code Optional.empty()} -> 404 branch from the "link not found" -> {@code Optional.empty()}
+   * -> 404 branch already exercised by {@code PublicDownloadMultipleApiIT}'s
+   * "givenEmptyNodeListTheDownloadMultipleShouldReturn404" (which uses a random, never-created
+   * public id, so the request never reaches {@code checkDownloadMultipleInternal} at all). Here
+   * the link genuinely exists and resolves, so the empty-list check inside {@code
+   * checkDownloadMultipleInternal} is what actually fires.
+   */
+  @Test
+  void givenEmptyNodeIdsWithAValidPublicLinkCheckDownloadPublicMultipleShouldReturn404() throws Exception {
+    String folderId = "11111111-1111-1111-1111-1111c0000003";
+    String linkId = UUID.randomUUID().toString();
+    String publicId = UUID.randomUUID().toString();
+    addFolder(folderId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "real-folder");
+    app.backdoor()
+        .populator()
+        .addLink(linkId, folderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
+
+    HttpResponse response = checkPublicMultiple(List.of(), publicId);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(404);
+  }
+
+  /**
+   * The LOCAL_ROOT-alias branch's {@code if (requesterId == null) return Optional.empty();} is
+   * UNREACHABLE for the authenticated path (requester is never null there) — it only exists for
+   * the public path, where {@code checkDownloadPublicMultiple} always passes {@code null} as the
+   * requesterId. This is the only way to reach it.
+   */
+  @Test
+  void givenLocalRootAliasWithAValidPublicLinkCheckDownloadPublicMultipleShouldReturn404()
+      throws Exception {
+    String folderId = "11111111-1111-1111-1111-1111c0000004";
+    String linkId = UUID.randomUUID().toString();
+    String publicId = UUID.randomUUID().toString();
+    addFolder(folderId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "another-folder");
+    app.backdoor()
+        .populator()
+        .addLink(linkId, folderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
+
+    HttpResponse response = checkPublicMultiple(List.of(Constants.Db.RootId.LOCAL_ROOT), publicId);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(404);
+  }
+
+  /**
+   * NOTE on what this test actually exercises (corrected after investigation — see below):
+   * {@code DatabasePopulator#addNodeToTrash} mirrors real production trashing ({@code
+   * NodeDataFetcher}'s trash mutation, core lines ~872-876): both reparent the node to {@code
+   * TRASH_ROOT} (changing {@code parentId}/{@code ancestorIds}), in addition to inserting the
+   * {@code TrashedNode} marker row. Because {@code NodeRepository#getChildrenIds} filters purely
+   * on {@code parent_id} (no anti-join against {@code TrashedNode}, no ancestor/TRASH_ROOT check),
+   * a trashed child is excluded from {@code getChildrenIds(originalFolder)}'s result INCIDENTALLY,
+   * one level above {@code addNodeToZip} — {@code BlobService}'s own {@code
+   * !nodeRepository.getTrashedNode(node.getId()).isEmpty()} half of the public accessChecker
+   * (lines 219-220) is never actually reached for a normally-trashed node, because
+   * {@code isLinkValidForNode} would ALSO already be false (ancestorIds no longer include the
+   * folder) and/or the node is never yielded as a child at all. This test still documents a real,
+   * valuable behaviour (a folder download naturally omits a since-trashed sibling), but it is NOT
+   * evidence that {@code addNodeToZip}'s accessChecker-level trashed-check is reachable. That
+   * check appears to be defense-in-depth for a "TrashedNode row exists but the node was NOT
+   * reparented" state that the sanctioned seam (whose only trash-simulating primitive,
+   * {@code addNodeToTrash}, always reparents, matching production) cannot construct. Reported as a
+   * seam-capability gap rather than faked with a nonstandard DB state.
+   */
+  @Test
+  void givenTrashedChildInsideAPubliclyLinkedFolderDownloadPublicMultipleOmitsItFromTheZip()
+      throws Exception {
+    String folderId = "11111111-1111-1111-1111-1111c0000005";
+    String keptFileId = "00000000-0000-0000-0000-00000000c005";
+    String trashedFileId = "00000000-0000-0000-0000-00000000c006";
+    String linkId = UUID.randomUUID().toString();
+    String publicId = UUID.randomUUID().toString();
+
+    addFolder(folderId, Constants.Db.RootId.LOCAL_ROOT, Constants.Db.RootId.LOCAL_ROOT, "public-folder");
+    addFile(keptFileId, folderId, Constants.Db.RootId.LOCAL_ROOT + "," + folderId, "kept.txt", 10L);
+    addFile(trashedFileId, folderId, Constants.Db.RootId.LOCAL_ROOT + "," + folderId, "trashed.txt", 10L);
+    app.backdoor()
+        .populator()
+        .addLink(linkId, folderId, publicId, Optional.empty(), Optional.empty(), Optional.empty());
+    app.backdoor().populator().addNodeToTrash(trashedFileId, folderId);
+    app.mocks().storagesServesBlob(keptFileId, 1);
+
+    HttpResponse response = downloadPublicMultiple(List.of(folderId), publicId);
+
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+    app.mocks().verifyStoragesDownloaded(keptFileId, 1);
+    assertBodyContainsWhenObservable(response, "kept.txt");
+    assertBodyDoesNotContainWhenObservable(response, "trashed.txt");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/PurgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/PurgeApiIT.java
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Task 6.1 of the acceptance coverage-expansion plan: {@code tasks.PurgeService}, driven through
+ * the APPROVED non-HTTP backdoor {@code backdoor().runPurge()} (see plan §2.5/§10). There is no
+ * HTTP trigger for this cron {@code Runnable} at all; {@code runPurge()} calls the same public
+ * {@code PurgeService#run()} entry point the scheduler uses, which invokes {@code
+ * purgeTombstones()} then {@code purgeTrashedNodes(RETENTION_TRASHED_ITEMS_IN_DAYS)} in that order
+ * every time. Effects are asserted via the neutral backdoor inspectors ({@code tombstoneCount()}/
+ * {@code tombstoneCountForNode()}/{@code nodeExists()}), mirroring the white-box {@code
+ * tasks.PurgeServiceIT}/{@code tasks.PurgeTombstonesJobIT} scenarios exactly, but through the
+ * seam instead of a same-package direct call.
+ *
+ * <p><b>FINDING — the "old trashed nodes actually removed" retention half of this task is
+ * UNREACHABLE via the current, APPROVED backdoor (reported, not faked):</b> {@code
+ * Constants.Config.PurgeService.RETENTION_TRASHED_ITEMS_IN_DAYS} is a hardcoded compile-time
+ * constant ({@code 30L}), not overridable via {@code FilesConfig}/Service-Discover/any {@code
+ * Mocks} knob, and {@code runPurge()} always calls {@code purgeTrashedNodes} with that production
+ * value (per its Javadoc/impl — no reflection/package-bridge workaround is sanctioned). {@code
+ * NodeRepositoryEbean#getAllTrashedNodes(Long)} selects strictly on {@code updated_at <
+ * retentionTimestamp}; the ONLY public write path that persists a node's {@code updated_at} is
+ * {@code NodeRepository#updateNode(Node)}, which unconditionally stamps it to {@code
+ * System.currentTimeMillis()} (see {@code NodeRepositoryEbean#updateNode}) — including inside
+ * {@code DatabasePopulator#addNodeToTrash}, the only seeding path to the TRASH_ROOT subtree. There
+ * is therefore no way, through {@code backdoor().populator()} or any other Wave-0 hook, to seed a
+ * trashed node whose {@code updated_at} predates "now minus 30 days"; backdating it would require
+ * a NEW seam capability (e.g. raw-SQL/ebean access to stamp an arbitrary {@code updated_at}), which
+ * is out of scope for this wave (Wave 6 is scoped to the three already-approved hooks: {@code
+ * runPurge()}, {@code injectUserStatusChanged()}, {@code injectMaxVersionNumberChanged()}). Only
+ * the "recent trashed node is retained" half of the retention behaviour is exercised below;
+ * the "old trashed node is actually deleted" half stays covered ONLY by the white-box {@code
+ * PurgeServiceIT} (which calls the package-private {@code purgeTrashedNodes(0)} directly with an
+ * arbitrary retention argument, sidestepping the constant entirely).
+ */
+class PurgeApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withStorages()
+            .withUserManagement(Map.of("fake-token", OWNER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    // TOMBSTONE is not FK-linked to NODE, so resetDatabase() does not cascade into it.
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse executeDeleteNodes(String... nodeIds) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteNodes")
+            .withListOfStrings("node_ids", nodeIds)
+            .withWantedResultFormat("")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", OWNER_COOKIE, null, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  // --- purgeTrashedNodes — retention -------------------------------------------------------
+
+  /**
+   * Reachable half of the retention behaviour: a node trashed "just now" (the only age {@code
+   * DatabasePopulator#addNodeToTrash} can produce) is NOT older than the production 30-day
+   * retention window, so {@code purgeTrashedNodes} must leave it alone. See the class-level
+   * FINDING for why the "old enough to be removed" half cannot be driven through this backdoor.
+   */
+  @Test
+  void givenARecentlyTrashedNodeThenRunPurgeLeavesItInPlace() {
+    // Given
+    String fileId = "00000000-0000-0000-0000-600000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "recent.txt"))
+        .addNodeToTrash(fileId, "LOCAL_ROOT");
+
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isTrue();
+
+    // When
+    app.backdoor().runPurge();
+
+    // Then — recent trash age never crosses the 30-day retention threshold, so it is kept.
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isTrue();
+  }
+
+  // --- purgeTombstones — success / partial-failure / outage ------------------------------
+
+  @Test
+  void givenAStrandedTombstoneWhenRunPurgeSucceedsThenTombstoneIsCleared() {
+    // Given — node deleted while storages is completely down: DB row gone, tombstone stranded.
+    String fileId = "00000000-0000-0000-0000-600000000002";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    HttpResponse deleteResponse = executeDeleteNodes(fileId);
+    Assertions.assertThat(deleteResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // When — storages is fixed, then the purge job runs.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
+    app.backdoor().runPurge();
+
+    // Then
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(0);
+  }
+
+  @Test
+  void givenTwoStrandedTombstonesWhenRunPurgeReportsOnePartialFailureThenOnlyThatOneIsKept() {
+    // Given — two nodes owned by the same user, both deleted while storages is down.
+    String keptFailingId = "00000000-0000-0000-0000-600000000003";
+    String succeedingId = "00000000-0000-0000-0000-600000000004";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(keptFailingId, OWNER_ID, "a.txt"))
+        .addNode(new SimplePopulatorTextFile(succeedingId, OWNER_ID, "b.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    executeDeleteNodes(keptFailingId, succeedingId);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(2);
+
+    // When — PowerStore reports keptFailingId as still-failed, succeedingId as deleted.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of(keptFailingId));
+    app.backdoor().runPurge();
+
+    // Then
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(keptFailingId)).isEqualTo(1);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(succeedingId)).isEqualTo(0);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
+  }
+
+  @Test
+  void givenAStrandedTombstoneWhenRunPurgeHitsACompleteOutageThenTombstoneIsKeptForRetry() {
+    // Given
+    String fileId = "00000000-0000-0000-0000-600000000005";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    executeDeleteNodes(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // When — PowerStore is STILL completely down during the purge run.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteFails();
+    app.backdoor().runPurge();
+
+    // Then — kept for the next cycle.
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+  }
+
+  @Test
+  void givenAStrandedTombstoneWhenRunPurgeGetsANullBulkDeleteResponseThenTombstoneIsKept() {
+    // Given — a null/empty PowerStore response is NOT a success signal and must be treated like
+    // an outage (per PurgeService#purgeTombstones), never as "all deleted".
+    String fileId = "00000000-0000-0000-0000-600000000006";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    executeDeleteNodes(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // When
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteReturnsNullResponse();
+    app.backdoor().runPurge();
+
+    // Then
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+  }
+
+  @Test
+  void givenAnOutageAcrossThreeConsecutiveRunPurgeCallsThenTombstoneIsNeverDropped() {
+    // Given — an outage must NEVER burn the retry budget, no matter how many cycles pass.
+    String fileId = "00000000-0000-0000-0000-600000000007";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    executeDeleteNodes(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // When — run the purge job 3 times while PowerStore is still down.
+    for (int run = 1; run <= 3; run++) {
+      app.mocks().reset();
+      app.mocks().storagesBulkDeleteFails();
+      app.backdoor().runPurge();
+
+      // Then
+      Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId))
+          .as("tombstone must still exist after outage run " + run)
+          .isEqualTo(1);
+    }
+  }
+
+  // --- purgeTombstones — retry cap / give-up ----------------------------------------------
+
+  /**
+   * {@code MAX_TOMBSTONE_RETRIES = 3}: a blob that PowerStore keeps genuinely rejecting (HTTP 200,
+   * listed in the failed-ids response — NOT an outage) is dropped as an accepted orphan on the
+   * 3rd {@code runPurge()} call. Each {@code runPurge()} call is one full {@code
+   * PurgeService#run()} cycle, i.e. one retry attempt for {@code purgeTombstones}'s per-blob
+   * counter — mirrors {@code PurgeTombstonesJobIT
+   * #givenBlobAlwaysFailsWithPartialFailureThenTombstoneRemovedAfterThirdJobRun} exactly, driven
+   * through the seam instead of a same-package direct call to {@code purgeTombstones()}.
+   */
+  @Test
+  void givenABlobAlwaysFailsWithPartialFailureThenTombstoneIsDroppedAfterTheThirdRunPurgeCall() {
+    // Given — seed the tombstone via a partial-failure delete (HTTP 200, node in failed list).
+    String fileId = "00000000-0000-0000-0000-600000000008";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
+    HttpResponse deleteResponse = executeDeleteNodes(fileId);
+    Assertions.assertThat(deleteResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // Run 1: still failing -> attempts=1, kept.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
+    app.backdoor().runPurge();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId))
+        .as("kept after run 1 (attempts=1)")
+        .isEqualTo(1);
+
+    // Run 2: still failing -> attempts=2, kept.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
+    app.backdoor().runPurge();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId))
+        .as("kept after run 2 (attempts=2)")
+        .isEqualTo(1);
+
+    // Run 3: still failing -> attempts+1==3==MAX -> orphan accepted, tombstone dropped.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
+    app.backdoor().runPurge();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId))
+        .as("dropped as orphan after the 3rd run hits the retry cap")
+        .isEqualTo(0);
+  }
+
+  /**
+   * Retry-and-recover: a blob that fails once but succeeds on the second {@code runPurge()} call
+   * is removed normally, well before the retry cap — the counter is not a one-way ratchet toward
+   * deletion, recovery clears it immediately.
+   */
+  @Test
+  void givenABlobFailsOnceThenSucceedsOnTheSecondRunPurgeCallTombstoneIsRemovedNormally() {
+    // Given
+    String fileId = "00000000-0000-0000-0000-600000000009";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "a.txt"));
+
+    app.mocks().storagesBulkDeleteFails();
+    executeDeleteNodes(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // Run 1: still failing -> attempts=1, kept.
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
+    app.backdoor().runPurge();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
+
+    // Run 2: blob deletion now succeeds -> tombstone removed (nowhere near the retry cap).
+    app.mocks().reset();
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
+    app.backdoor().runPurge();
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(0);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/RemovedNodeNotificationMoveApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/RemovedNodeNotificationMoveApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,17 +23,12 @@ import java.util.Map;
 
 class RemovedNodeNotificationMoveApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class RemovedNodeNotificationMoveApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create the folder to be shared
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"));
@@ -89,8 +71,7 @@ class RemovedNodeNotificationMoveApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
@@ -109,7 +90,7 @@ class RemovedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Move node inside of base node away
     bodyPayload =
@@ -122,8 +103,7 @@ class RemovedNodeNotificationMoveApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    httpResponse = app.send(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
   }
@@ -143,8 +123,7 @@ class RemovedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -160,11 +139,7 @@ class RemovedNodeNotificationMoveApiIT {
   @Test
   void givenANodeRemovalByMoveOnASharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -177,8 +152,7 @@ class RemovedNodeNotificationMoveApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -191,10 +165,6 @@ class RemovedNodeNotificationMoveApiIT {
     Assertions.assertThat(notifications).hasSize(0);
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/RemovedNodeNotificationTrashApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/RemovedNodeNotificationTrashApiIT.java
@@ -2,21 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api.notifications;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
-import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -30,17 +23,12 @@ import java.util.Map;
 
 class RemovedNodeNotificationTrashApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static MockFilesConfig mockConfig;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,31 +37,25 @@ class RemovedNodeNotificationTrashApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-2",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    mockConfig = (MockFilesConfig) injector.getInstance(FilesConfig.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.reinitializeMocks();
-    mockConfig.setAreNotificationsEnabled(true);
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setNotificationsEnabled(true);
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private void createBaseScenario() {
     // Create the folder to be shared
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorFolder(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "folder"));
@@ -89,8 +71,7 @@ class RemovedNodeNotificationTrashApiIT {
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     Map<String, Object> page =
         TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "createFolder");
@@ -109,7 +90,7 @@ class RemovedNodeNotificationTrashApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    app.send(httpRequest);
 
     // Trash node inside of base node
     bodyPayload =
@@ -121,8 +102,7 @@ class RemovedNodeNotificationTrashApiIT {
     httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
-    httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    httpResponse = app.send(httpRequest);
 
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
   }
@@ -142,8 +122,7 @@ class RemovedNodeNotificationTrashApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -159,11 +138,7 @@ class RemovedNodeNotificationTrashApiIT {
   @Test
   void givenANodeRemovalByTrashingItOnASharedDirectoryAndDisabledNotificationsNoNotificationShouldBeSavedOrReturned() {
     // Given
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(false);
+    app.mocks().setNotificationsEnabled(false);
     createBaseScenario();
 
     String bodyPayload =
@@ -176,8 +151,7 @@ class RemovedNodeNotificationTrashApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-2", bodyPayload);
 
     // When
-    HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -190,10 +164,6 @@ class RemovedNodeNotificationTrashApiIT {
     Assertions.assertThat(notifications).hasSize(0);
 
     //reset
-    ((MockFilesConfig)
-        simulator
-            .getInjector()
-            .getInstance(FilesConfig.class))
-        .setAreNotificationsEnabled(true);
+    app.mocks().setNotificationsEnabled(true);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/RestoreNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/RestoreNodesApiIT.java
@@ -2,20 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Constants;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.dao.ebean.Node;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -26,60 +19,50 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 class RestoreNodesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement( // create a fake token to use in cookie for auth
                 Map.of(
                     "fake-token",
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
-  private void trashNode(String nodeId){
-    Optional<Node> trashedNodeOpt = nodeRepository.getNode(nodeId);
-    trashedNodeOpt.ifPresent(trashedNode -> {
-      String nodeParentId = trashedNode.getParentId().get();
-      trashedNode.setAncestorIds(Constants.Db.RootId.TRASH_ROOT);
-      trashedNode.setParentId(Constants.Db.RootId.TRASH_ROOT);
-      nodeRepository.trashNode(trashedNode.getId(), nodeParentId);
-      nodeRepository.updateNode(trashedNode);
-    });
+  /**
+   * Functionally identical to the pre-migration hand-rolled trashNode() (which loaded the node,
+   * flipped its ancestor/parent ids to TRASH_ROOT and called nodeRepository.trashNode(...)
+   * directly): {@link com.zextras.carbonio.files.api.utilities.DatabasePopulator#addNodeToTrash}
+   * already does exactly this. All nodes in this file are created via {@link
+   * SimplePopulatorTextFile}, whose parent is always {@code "LOCAL_ROOT"}.
+   */
+  private void trashNode(String nodeId) {
+    app.backdoor().populator().addNodeToTrash(nodeId, "LOCAL_ROOT");
   }
 
   @Test
   void givenATrashedNodeRestoreNodesShouldRestoreThatNode() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000002", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
@@ -96,8 +79,7 @@ class RestoreNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -117,14 +99,14 @@ class RestoreNodesApiIT {
   @Test
   void givenTwoFilesOnWithTheSameNameAndOneIsTrashedBothWithSameParentDirectoryRestoreNodeShouldRestoreFileWithDifferentNameFromAlreadyExisting() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
 
     trashNode("00000000-0000-0000-0000-000000000000");
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor().populator()
         .addNode(
             new SimplePopulatorTextFile(
                 "00000000-0000-0000-0000-000000000001", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
@@ -139,8 +121,7 @@ class RestoreNodesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ThumbnailApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ThumbnailApiIT.java
@@ -2,19 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
 import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
-import io.netty.handler.codec.http.HttpMethod;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -22,81 +17,48 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockserver.client.MockServerClient;
-import org.mockserver.model.BinaryBody;
-import org.mockserver.model.MediaType;
-import org.mockserver.model.Parameter;
 
 import java.util.Map;
 
 class ThumbnailApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withPreview()
             .withUserManagement(
-                Map.of(
-                    "fake-token",
-                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
+                Map.of("fake-token", OWNER_ID))
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
-    simulator.clearFileVersionCache();
+    app.backdoor().resetDatabase();
+    app.backdoor().clearFileVersionCache();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
-  }
-
-  static String mockSuccessThumbnailResponse(String thumbnailPathEndpoint) {
-
-    org.mockserver.model.HttpRequest request = org.mockserver.model.HttpRequest.request()
-        .withMethod(HttpMethod.GET.toString())
-        .withPath(thumbnailPathEndpoint)
-        .withQueryStringParameter(new Parameter("service_type", "files"))
-        .withHeader("FileOwnerId", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
-    if (thumbnailPathEndpoint.contains("document")) {
-      request.withQueryStringParameter(new Parameter("lang_tag", "en"));
-    }
-
-    return simulator.getPreviewMock()
-        .when(request)
-        .respond(org.mockserver.model.HttpResponse.response()
-            .withStatusCode(200)
-            .withBody(new BinaryBody("0".getBytes())).withContentType(MediaType.JPEG))[0].getId();
-  }
-
-  static void verifyAndClearExpectationInThumbnailMockService(String expectationId) {
-    MockServerClient previewServiceMock = simulator.getPreviewMock();
-    previewServiceMock.verify(expectationId).clear(expectationId);
+    app.close();
   }
 
   @Test
   void givenAnExistingDocumentTheGetThumbnailApiShouldGetAndReturnTheThumbnailWithLangTag() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "FILE.XLS",
                 "",
@@ -106,8 +68,11 @@ class ThumbnailApiIT {
                 "application/vnd.ms-excel")
         );
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -117,7 +82,7 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -125,7 +90,7 @@ class ThumbnailApiIT {
         .extracting(header -> header.getKey().equals("content-type") ? header.getValue() : null)
         .contains("image/jpeg");
 
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
@@ -134,12 +99,13 @@ class ThumbnailApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "pres.odp",
                 "",
@@ -149,8 +115,11 @@ class ThumbnailApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/document/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -160,22 +129,23 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @Test
   void givenTwoVersionsOfAnExistingDocumentTheGetThumbnailApiShouldReturnTheJpegOfTheFirstVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "pres.odp",
                 "",
@@ -185,8 +155,11 @@ class ThumbnailApiIT {
                 "application/vnd.oasis.opendocument.presentation")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/document/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -196,11 +169,11 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
@@ -209,12 +182,13 @@ class ThumbnailApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "buy_me.pdf",
                 "",
@@ -225,8 +199,11 @@ class ThumbnailApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/pdf/00000000-0000-0000-0000-000000000000/3/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/pdf/00000000-0000-0000-0000-000000000000/3/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -236,22 +213,23 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @Test
   void givenThreeVersionsOfAnExistingPdfTheGetThumbnailApiShouldReturnTheJpegOfTheSecondVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "buy_me.pdf",
                 "",
@@ -262,8 +240,11 @@ class ThumbnailApiIT {
         ).addVersion("00000000-0000-0000-0000-000000000000")
         .addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/pdf/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/pdf/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -273,11 +254,11 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @ParameterizedTest
@@ -286,12 +267,13 @@ class ThumbnailApiIT {
       String versionQueryParam
   ) {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "don't open.png",
                 "",
@@ -301,8 +283,11 @@ class ThumbnailApiIT {
                 "image/png")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/image/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/image/00000000-0000-0000-0000-000000000000/2/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -312,22 +297,23 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse = TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 
   @Test
   void givenTwoVersionsOfAnExistingJpegImageTheGetThumbnailApiShouldReturnTheJpegOfTheFirstVersion() {
     // Given
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(
             new PopulatorNode(
                 "00000000-0000-0000-0000-000000000000",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                OWNER_ID,
+                OWNER_ID,
                 "LOCAL_ROOT",
                 "don't open.png",
                 "",
@@ -337,8 +323,11 @@ class ThumbnailApiIT {
                 "image/jpeg")
         ).addVersion("00000000-0000-0000-0000-000000000000");
 
-    String callThumbnailExpectationId = mockSuccessThumbnailResponse(
-        "/preview/image/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/"
+    String callThumbnailExpectationId = app.mocks().previewServes(
+        "/preview/image/00000000-0000-0000-0000-000000000000/1/5x5/thumbnail/",
+        OWNER_ID,
+        "0".getBytes(),
+        "image/jpeg"
     );
 
     final HttpRequest httpRequest =
@@ -348,11 +337,10 @@ class ThumbnailApiIT {
             null);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    verifyAndClearExpectationInThumbnailMockService(callThumbnailExpectationId);
+    app.mocks().verifyPreviewServed(callThumbnailExpectationId);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ThumbnailEdgeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ThumbnailEdgeApiIT.java
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Gap-closing pass: edge-branch coverage for {@code PreviewController}'s three {@code
+ * thumbnailXxx} methods (image/pdf/document) that {@code ThumbnailApiIT} does not exercise (that
+ * class covers only happy-path retrieval and version resolution). Each of the three methods shares
+ * the same two-branch shape as their {@code previewXxx} siblings:
+ *
+ * <ul>
+ *   <li>{@code tryCheckNode.isSuccess()} — {@code PreviewEdgeApiIT} covers the not-found/
+ *       permission-denied direction only via the {@code previewXxx} methods (shared bytecode
+ *       validation logic, but a DIFFERENT call site/method in {@code PreviewController}); the
+ *       {@code thumbnailXxx} call sites themselves were never exercised with a failing {@code
+ *       checkNodePermissionAndExistence}.
+ *   <li>{@code isPreviewChanged(...)} — {@code PreviewEdgeApiIT} covers the ETag/304 direction for
+ *       {@code previewPdf}/{@code previewDocument}/{@code previewImage}, but never for any of the
+ *       three {@code thumbnailXxx} methods.
+ * </ul>
+ */
+class ThumbnailEdgeApiIT {
+
+  static FilesTestApp app;
+
+  private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String OWNER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String OTHER_USER_COOKIE = "ZM_AUTH_TOKEN=fake-token-other";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withPreview()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", OWNER_ID,
+                    "fake-token-other", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.backdoor().clearFileVersionCache();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String extractHeader(HttpResponse response, String name) {
+    return response.getHeaders().stream()
+        .filter(header -> header.getKey().equalsIgnoreCase(name))
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  // --- tryCheckNode.isSuccess() == false (permission-denied), one per thumbnail family ----------
+
+  @Test
+  void givenARequesterWithoutPermissionTheImageThumbnailApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000220",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "private.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+    // No share created for OTHER_USER_ID.
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000220/5x5/thumbnail",
+            OTHER_USER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenARequesterWithoutPermissionThePdfThumbnailApiShouldReturnA404StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000221",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "private.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000221/5x5/thumbnail",
+            OTHER_USER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void givenANonExistentNodeTheDocumentThumbnailApiShouldReturnA404StatusCode() {
+    final HttpRequest httpRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/document/00000000-0000-0000-0000-00000000ff01/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+
+    final HttpResponse httpResponse = app.send(httpRequest);
+
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+  }
+
+  // --- isPreviewChanged() == false (ETag match -> 304), one per thumbnail family -----------------
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedImageThumbnailRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000222",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable-thumb.png",
+                "",
+                NodeType.IMAGE,
+                "LOCAL_ROOT",
+                10L,
+                "image/png"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/image/00000000-0000-0000-0000-000000000222/1/5x5/thumbnail/",
+                OWNER_ID,
+                "content".getBytes(),
+                "image/jpeg");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000222/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/image/00000000-0000-0000-0000-000000000222/5x5/thumbnail",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedPdfThumbnailRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000223",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable-thumb.pdf",
+                "",
+                NodeType.APPLICATION,
+                "LOCAL_ROOT",
+                10L,
+                "application/pdf"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/pdf/00000000-0000-0000-0000-000000000223/1/5x5/thumbnail/",
+                OWNER_ID,
+                "content".getBytes(),
+                "image/jpeg");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000223/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/pdf/00000000-0000-0000-0000-000000000223/5x5/thumbnail",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+
+  @Test
+  void givenAMatchingIfNoneMatchHeaderTheRepeatedDocumentThumbnailRequestShouldReturnA304StatusCode() {
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                "00000000-0000-0000-0000-000000000224",
+                OWNER_ID,
+                OWNER_ID,
+                "LOCAL_ROOT",
+                "cacheable-thumb.xls",
+                "",
+                NodeType.SPREADSHEET,
+                "LOCAL_ROOT",
+                7L,
+                "application/vnd.ms-excel"));
+
+    String expectationId =
+        app.mocks()
+            .previewServes(
+                "/preview/document/00000000-0000-0000-0000-000000000224/1/5x5/thumbnail/",
+                OWNER_ID,
+                "0".getBytes(),
+                "image/jpeg");
+
+    final HttpRequest firstRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/document/00000000-0000-0000-0000-000000000224/5x5/thumbnail",
+            OWNER_COOKIE,
+            null);
+    final HttpResponse firstResponse = app.send(firstRequest);
+
+    Assertions.assertThat(firstResponse.getStatus()).isEqualTo(200);
+    String etag = extractHeader(firstResponse, "etag");
+    Assertions.assertThat(etag).isNotNull();
+
+    final HttpRequest secondRequest =
+        HttpRequest.of(
+            "GET",
+            "/preview/document/00000000-0000-0000-0000-000000000224/5x5/thumbnail",
+            OWNER_COOKIE,
+            List.of(Map.entry("If-None-Match", etag)),
+            null);
+    final HttpResponse secondResponse = app.send(secondRequest);
+
+    Assertions.assertThat(secondResponse.getStatus()).isEqualTo(304);
+
+    app.mocks().verifyPreviewServed(expectationId);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/TombstoneDeleteIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/TombstoneDeleteIT.java
@@ -2,18 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
-import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
-import com.zextras.carbonio.files.utilities.StoragesMockHelper;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import org.assertj.core.api.Assertions;
@@ -37,43 +31,32 @@ import java.util.Map;
  */
 class TombstoneDeleteIT {
 
-  static Simulator simulator;
-  static StoragesMockHelper storagesMockHelper;
-  static NodeRepository nodeRepository;
-  static TombstoneRepository tombstoneRepository;
+  static FilesTestApp app;
 
   private static final String OWNER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withStorages()
             .withUserManagement(Map.of("fake-token", OWNER_ID))
-            .build()
-            .start();
-
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    tombstoneRepository = injector.getInstance(TombstoneRepository.class);
-    storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
     // TOMBSTONE is not FK-linked to NODE, so resetDatabase() does not cascade into it.
-    tombstoneRepository.getTombstones().forEach(t ->
-        tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
-    simulator.reinitializeMocks();
+    app.backdoor().clearTombstones();
+    app.mocks().reset();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   private HttpResponse executeDeleteNodes(String... nodeIds) {
@@ -84,7 +67,7 @@ class TombstoneDeleteIT {
             .build();
     HttpRequest httpRequest =
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", null, bodyPayload);
-    return TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    return app.send(httpRequest);
   }
 
   // --- Test 1: tombstone created → removed on sync-path success ---
@@ -95,20 +78,21 @@ class TombstoneDeleteIT {
     // Given
     String fileId = "00000000-0000-0000-0000-200000000001";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "file.txt"));
 
-    storagesMockHelper.bulkDelete(List.of());
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(fileId);
 
     // Then — node deleted from DB.
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
 
     // Tombstone was created and then immediately removed after confirmed bulkDelete.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).isEmpty();
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(0);
   }
 
   // --- Test 2: tombstone remains when bulkDelete reports the blob as failed ---
@@ -119,23 +103,23 @@ class TombstoneDeleteIT {
     // Given
     String fileId = "00000000-0000-0000-0000-200000000002";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "file.txt"));
 
     // PowerStore responds 200 but reports this node as failed.
-    storagesMockHelper.bulkDelete(List.of(fileId));
+    app.mocks().storagesBulkDeleteSucceeds(List.of(fileId));
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(fileId);
 
     // Then — DB delete committed (DB-first contract).
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
 
     // Tombstone remains so PurgeService can retry blob deletion.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(1);
-    Assertions.assertThat(tombstoneRepository.getTombstones().get(0).getNodeId())
-        .isEqualTo(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
   }
 
   // --- Test 3: tombstone remains on complete PowerStore outage (HTTP 500) ---
@@ -145,21 +129,21 @@ class TombstoneDeleteIT {
     // Given
     String fileId = "00000000-0000-0000-0000-200000000003";
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addNode(new SimplePopulatorTextFile(fileId, OWNER_ID, "file.txt"));
 
-    storagesMockHelper.bulkDeleteError();
+    app.mocks().storagesBulkDeleteFails();
 
     // When
     HttpResponse httpResponse = executeDeleteNodes(fileId);
 
     // Then — DB delete committed; user sees success (DB-first contract).
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
-    Assertions.assertThat(nodeRepository.getNode(fileId)).isEmpty();
+    Assertions.assertThat(app.backdoor().nodeExists(fileId)).isFalse();
 
     // Tombstone remains for PurgeService retry.
-    Assertions.assertThat(tombstoneRepository.getTombstones()).hasSize(1);
-    Assertions.assertThat(tombstoneRepository.getTombstones().get(0).getNodeId())
-        .isEqualTo(fileId);
+    Assertions.assertThat(app.backdoor().tombstoneCount()).isEqualTo(1);
+    Assertions.assertThat(app.backdoor().tombstoneCountForNode(fileId)).isEqualTo(1);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/TrashNodesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/TrashNodesApiIT.java
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 1.5 (part 2) of the acceptance coverage-expansion plan: direct HTTP coverage of the {@code
+ * trashNodes} mutation itself. Existing tests only use the test-only backdoor ({@code
+ * DatabasePopulator#addNodeToTrash}) to SET UP other scenarios (e.g. {@code RestoreNodesApiIT}) —
+ * none exercise the real mutation's own branches (root-rejected, not-found, permission-denied,
+ * partial-success list semantics, subtree cascade).
+ */
+class TrashNodesApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private HttpResponse trashNodes(String[] nodeIds, String cookie) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("trashNodes")
+            .withListOfStrings("node_ids", nodeIds)
+            .withWantedResultFormat("")
+            .build();
+    HttpRequest httpRequest = HttpRequest.of("POST", "/graphql/", cookie, bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> findNodeIdsInFolder(String folderId, boolean cascade) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", folderId)
+            .withBoolean("cascade", cascade)
+            .withEnumLiteral("sort", "NAME_ASC")
+            .withInteger("limit", 20)
+            .withWantedResultFormat("{ nodes { id }, page_token }")
+            .build();
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+    HttpResponse httpResponse = app.send(httpRequest);
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+    List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+    return nodes.stream().map(node -> (String) node.get("id")).toList();
+  }
+
+  @Test
+  void givenANodeInRootTrashNodesShouldMoveItToTrashAndExcludeItFromRootSearch() {
+    // Given
+    String nodeId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "toTrash.txt"));
+
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {nodeId}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> data = (List<String>) TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "trashNodes").get("data");
+    Assertions.assertThat(data).containsExactly(nodeId);
+
+    // the row still exists (soft trash), but is no longer visible from LOCAL_ROOT and is visible from TRASH_ROOT
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+    Assertions.assertThat(findNodeIdsInFolder("LOCAL_ROOT", true)).doesNotContain(nodeId);
+    Assertions.assertThat(findNodeIdsInFolder("TRASH_ROOT", false)).containsExactly(nodeId);
+  }
+
+  @Test
+  void givenTheRootNodeItselfTrashNodesShouldRejectItWithNodeWriteError() {
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {"LOCAL_ROOT"}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "trashNodes");
+    Assertions.assertThat((List<String>) page.get("data")).isEmpty();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: LOCAL_ROOT");
+  }
+
+  @Test
+  void givenANonExistentNodeTrashNodesShouldReturnNodeWriteError() {
+    // Given
+    String nonExistentId = "00000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {nonExistentId}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + nonExistentId);
+  }
+
+  @Test
+  void givenNoWritePermissionTrashNodesShouldReturnNodeWriteError() {
+    // Given — owned by someone else, shared to the requester as READ_ONLY (no write)
+    String nodeId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "notMine.txt"))
+        .addShare(nodeId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {nodeId}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + nodeId);
+  }
+
+  @Test
+  void givenAMixOfTrashableAndBadNodesTrashNodesShouldReturnPartialSuccess() {
+    // Given
+    String goodId = "00000000-0000-0000-0000-000000000001";
+    String badId = "00000000-0000-0000-0000-00000000ffff";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(goodId, REQUESTER_ID, "good.txt"));
+
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {goodId, badId}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "trashNodes");
+    Assertions.assertThat((List<String>) page.get("data")).containsExactly(goodId);
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("There was a problem while executing requested operation on node: " + badId);
+  }
+
+  @Test
+  void givenAFolderWithAChildTrashNodesShouldCascadeTheSubtreeIntoTrash() {
+    // Given
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    String childId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID, "parentFolder"))
+        .addNode(new SimplePopulatorTextFile(childId, REQUESTER_ID, "child.txt"));
+    // move the child under the folder directly via a real HTTP moveNodes call so its ancestor
+    // chain is consistent before we trash the folder
+    String movePayload =
+        GraphqlCommandBuilder.aMutationBuilder("moveNodes")
+            .withListOfStrings("node_ids", new String[] {childId})
+            .withString("destination_id", folderId)
+            .withWantedResultFormat("{ id }")
+            .build();
+    HttpResponse moveResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", movePayload));
+    Assertions.assertThat(moveResponse.getStatus()).isEqualTo(200);
+
+    // When
+    HttpResponse httpResponse = trashNodes(new String[] {folderId}, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "trashNodes");
+    Assertions.assertThat((List<String>) page.get("data")).containsExactly(folderId);
+
+    // the whole subtree (folder + child) is now reachable under TRASH_ROOT and gone from LOCAL_ROOT
+    Assertions.assertThat(findNodeIdsInFolder("TRASH_ROOT", true)).containsExactlyInAnyOrder(folderId, childId);
+    Assertions.assertThat(findNodeIdsInFolder("LOCAL_ROOT", true)).isEmpty();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdateNodeApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdateNodeApiIT.java
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NEW canonical file: the {@code updateNode} mutation (bound to {@code
+ * NodeDataFetcher#updateNodeFetcher}) had ZERO direct acceptance coverage before this file — every
+ * other {@code *ApiIT} only exercises it transitively (never at all, in fact: no other file calls
+ * the {@code updateNode} mutation).
+ *
+ * <p>Covers: happy rename, permission-denied, the rename-collision -&gt; {@code duplicateNode}
+ * branch (the JaCoCo-confirmed 0%-covered {@code searchAlternativeName(...).equals(nodeFullName)}
+ * check — contrast with {@code createFolder}'s auto-rename-on-collision behaviour: {@code
+ * updateNode} REJECTS a collision instead of auto-renaming), a description-only update (no rename
+ * search performed at all since {@code name} is absent), and a flagged-only update.
+ */
+class UpdateNodeApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse updateNode(
+      String nodeId, String name, String description, Boolean flagged, String cookie) {
+    GraphqlCommandBuilder builder =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode").withString("node_id", nodeId);
+    if (name != null) {
+      builder.withString("name", name);
+    }
+    if (description != null) {
+      builder.withString("description", description);
+    }
+    if (flagged != null) {
+      builder.withBoolean("flagged", flagged);
+    }
+    String bodyPayload = builder.withWantedResultFormat("{ id name description }").build();
+    return app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+  }
+
+  @Test
+  void givenWritePermissionUpdateNodeShouldRenameTheNode() {
+    // Given
+    String nodeId = "70000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "old.txt"));
+
+    // When
+    HttpResponse httpResponse = updateNode(nodeId, "renamed", null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateNode");
+    Assertions.assertThat(node).containsEntry("name", "renamed");
+  }
+
+  @Test
+  void givenNoWritePermissionUpdateNodeShouldReturnNodeNotFoundError() {
+    // Given — owned by someone else, shared READ_ONLY (no write) with the requester
+    String nodeId = "70000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "notMine.txt"))
+        .addShare(nodeId, REQUESTER_ID, SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse = updateNode(nodeId, "renamed", null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — updateNodeFetcher's permission-denied branch returns nodeNotFound, not nodeWriteError
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find node with id " + nodeId);
+  }
+
+  @Test
+  void givenANameCollisionInTheSameParentUpdateNodeShouldReturnDuplicateNodeErrorNotAutoRename() {
+    // Given — two files in LOCAL_ROOT; renaming the second to collide with the first's full name
+    String existingId = "70000000-0000-0000-0000-000000000003";
+    String nodeId = "70000000-0000-0000-0000-000000000004";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(existingId, REQUESTER_ID, "taken.txt"))
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "original.txt"));
+
+    // When — renaming to "taken" would produce the full name "taken.txt", already present
+    HttpResponse httpResponse = updateNode(nodeId, "taken", null, null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then — REJECTED with duplicateNode, unlike createFolder's silent " (1)" auto-rename
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "Trying to create a duplicate for the node " + nodeId + " in destination folder LOCAL_ROOT");
+
+    // the node was NOT renamed
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+  }
+
+  @Test
+  void givenOnlyADescriptionUpdateNodeShouldUpdateItWithoutTouchingTheName() {
+    // Given — closes the `optName.isPresent()` FALSE branch: no rename search is performed at all
+    String nodeId = "70000000-0000-0000-0000-000000000005";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "untouched.txt"));
+
+    // When
+    HttpResponse httpResponse =
+        updateNode(nodeId, null, "a new description", null, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateNode");
+    Assertions.assertThat(node)
+        .containsEntry("name", "untouched")
+        .containsEntry("description", "a new description");
+  }
+
+  @Test
+  void givenOnlyAFlaggedValueUpdateNodeShouldFlagTheNodeWithoutTouchingItsName() {
+    // Given
+    String nodeId = "70000000-0000-0000-0000-000000000006";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "flagme.txt"));
+
+    // When
+    HttpResponse httpResponse = updateNode(nodeId, null, null, true, "ZM_AUTH_TOKEN=fake-token");
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "updateNode");
+    Assertions.assertThat(node).containsEntry("name", "flagme");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdatePublicLinkApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdatePublicLinkApiIT.java
@@ -2,21 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
-import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -30,17 +24,12 @@ import org.junit.jupiter.api.Test;
 
 class UpdatePublicLinkApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static FileVersionRepository fileVersionRepository;
-  static LinkRepository linkRepository;
-  static ShareRepository shareRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -49,38 +38,29 @@ class UpdatePublicLinkApiIT {
                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "fake-token-account-for-sharing",
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
-            .build()
-            .start();
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFile(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
   }
 
   void createFolder(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorFolder(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(nodeId, ownerId));
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addShare(nodeId, targetUserId, permission);
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
   }
 
   @Test
@@ -88,7 +68,8 @@ class UpdatePublicLinkApiIT {
       givenAnExistingFileAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -110,8 +91,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -137,7 +117,8 @@ class UpdatePublicLinkApiIT {
       givenAnExistingFileAnExistingLinkAndEmptyAccessCodeTheUpdateLinkShouldReturnTheUpdatedLink() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -159,8 +140,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -186,7 +166,8 @@ class UpdatePublicLinkApiIT {
       givenAnExistingFileAnExistingLinkAndNoFieldsToUpdateTheUpdateLinkShouldReturnTheUntouchedLink() {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -205,8 +186,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -233,7 +213,8 @@ class UpdatePublicLinkApiIT {
       givenAnExistingFolderAnExistingLinkAndAllUpdatedFieldsTheUpdateLinkShouldReturnTheUpdatedLink() {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -254,8 +235,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -287,8 +267,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -309,7 +288,8 @@ class UpdatePublicLinkApiIT {
         "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
         SharePermission.READ_AND_SHARE);
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -330,8 +310,7 @@ class UpdatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -349,7 +328,8 @@ class UpdatePublicLinkApiIT {
     // Given
     createFolder("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -369,8 +349,7 @@ class UpdatePublicLinkApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -392,7 +371,8 @@ class UpdatePublicLinkApiIT {
         "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
         SharePermission.READ_ONLY);
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -412,8 +392,7 @@ class UpdatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -430,7 +409,8 @@ class UpdatePublicLinkApiIT {
     // Given
     createFile("00000000-0000-0000-0000-000000000000", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
+    app.backdoor()
+        .populator()
         .addLink(
             "cc83bd73-8c5c-4e7c-8c34-3e3919ff6c9b",
             "00000000-0000-0000-0000-000000000000",
@@ -450,8 +430,7 @@ class UpdatePublicLinkApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdateSharesApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UpdateSharesApiIT.java
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package com.zextras.carbonio.files.api;
+package com.zextras.carbonio.files.acceptance;
 
-import com.google.inject.Injector;
-import com.zextras.carbonio.files.Simulator;
-import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.files.TestUtils;
-import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
 import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
 import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
 import com.zextras.carbonio.files.dal.dao.ebean.ACL.SharePermission;
-import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
-import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.utilities.http.HttpRequest;
 import com.zextras.carbonio.files.utilities.http.HttpResponse;
 import java.util.List;
@@ -26,15 +22,12 @@ import org.junit.jupiter.api.Test;
 
 class UpdateSharesApiIT {
 
-  static Simulator simulator;
-  static NodeRepository nodeRepository;
-  static ShareRepository shareRepository;
+  static FilesTestApp app;
 
   @BeforeAll
   static void init() {
-    simulator =
-        SimulatorBuilder.aSimulator()
-            .init()
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
             .withDatabase()
             .withServiceDiscover()
             .withUserManagement(
@@ -45,31 +38,25 @@ class UpdateSharesApiIT {
                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
                     "fake-token-account-for-sharing-2",
                     "cccccccc-cccc-cccc-cccc-cccccccccccc"))
-            .build()
-            .start();
-    final Injector injector = simulator.getInjector();
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+            .build();
   }
 
   @AfterEach
   void cleanUp() {
-    simulator.resetDatabase();
+    app.backdoor().resetDatabase();
   }
 
   @AfterAll
   static void cleanUpAll() {
-    simulator.stopAll();
+    app.close();
   }
 
   void createFile(String nodeId, String ownerId) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addNode(new SimplePopulatorTextFile(nodeId, ownerId));
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, ownerId));
   }
 
   void createShare(String nodeId, String targetUserId, SharePermission permission) {
-    DatabasePopulator.aNodePopulator(simulator.getInjector())
-        .addShare(nodeId, targetUserId, permission);
+    app.backdoor().populator().addShare(nodeId, targetUserId, permission);
   }
 
   @Test
@@ -103,8 +90,7 @@ class UpdateSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -146,8 +132,7 @@ class UpdateSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -193,8 +178,7 @@ class UpdateSharesApiIT {
             "POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token-account-for-sharing", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
@@ -236,8 +220,7 @@ class UpdateSharesApiIT {
         HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
 
     // When
-    final HttpResponse httpResponse =
-        TestUtils.sendRequest(httpRequest, simulator.getNettyChannel());
+    final HttpResponse httpResponse = app.send(httpRequest);
 
     // Then
     Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileApiIT.java
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Task 2.1 of the acceptance coverage-expansion plan: {@code POST /upload}, the plain new-node
+ * upload route. Driven exclusively through {@link FilesTestApp#upload}/{@code HttpRequest.ofUpload}
+ * (the Wave-0 binary-upload seam) and {@code Mocks#storagesUploadSucceeds}/{@code
+ * storagesUploadFails}/{@code storagesVerifyMissing}/{@code setMaxUploadableSizeMb}.
+ *
+ * <p><b>FINDING — one scenario is untestable with the current seam:</b> the plan's "missing
+ * {@code Content-Length} header -> 500 (NumberFormatException)" row cannot be produced through
+ * {@code FilesTestApp#upload} on EITHER transport. {@code TestUtils#sendUpload} always calls
+ * {@code httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length))} — this
+ * REPLACES any caller-supplied value, so a request can never arrive at {@code BlobController}
+ * without (or with a wrong) {@code Content-Length}. On the real-HTTP transport it is even less
+ * reachable: {@code java.net.http.HttpClient} treats {@code Content-Length} as a JDK-restricted
+ * header it computes itself from the {@code BodyPublisher} and will not let a caller override or
+ * omit (see {@code RealHttpFilesTestApp#upload}'s own comment to this effect). Both behaviours are
+ * DELIBERATE Wave-0 design choices (see {@code HttpRequest#ofUpload}'s javadoc: "the Content-Length
+ * sent on the wire is always computed from this array's length ... never taken from headers"), not
+ * oversights — reproducing a genuinely missing/malformed header would require editing the shared
+ * seam (`TestUtils.sendUpload`/`RealHttpFilesTestApp.upload`), which is out of scope for this task
+ * per the "don't silently edit shared seam" guardrail. This scenario is therefore DELIBERATELY
+ * OMITTED here rather than faked with a test that would silently degrade to the happy path.
+ *
+ * <p><b>SECOND FINDING — a genuine Wave-0 seam BUG (not a design tradeoff), confirmed by running
+ * BOTH transports:</b> any scenario where {@code BlobController} throws SYNCHRONOUSLY while
+ * handling the request HEAD object -- i.e. before any {@code HttpContent} is read (the
+ * size-over-limit check and the {@code Filename} validation both run this early) -- makes {@code
+ * TestUtils#sendUpload} (the EMBEDDED-transport implementation only) throw a raw {@code
+ * java.nio.channels.ClosedChannelException}, instead of returning the {@code HttpResponse} the
+ * server already produced. Root cause: {@code sendUpload} unconditionally issues TWO separate
+ * {@code EmbeddedChannel#writeInbound} calls (head, then {@code LastHttpContent}); when the first
+ * call's synchronous exception handling already wrote the response AND closed the channel (via
+ * {@code ExceptionsHandler}'s {@code ChannelFutureListener.CLOSE}), the second call hits {@code
+ * EmbeddedChannel#ensureOpen()} and throws. This is REPRODUCIBLE and CONFIRMED transport-specific:
+ * the identical scenarios pass cleanly under {@code -Dfiles.test.transport=http} (see the
+ * disabled tests below), because {@code RealHttpFilesTestApp#upload} makes a single blocking
+ * {@code HttpClient.send} call with no analogous second write. A one-line fix (guarding the
+ * second {@code writeInbound} on {@code nettyChannel.isOpen()}, or catching {@code
+ * ClosedChannelException} and returning whatever the first write already produced) would resolve
+ * it, but {@code TestUtils.java} is shared Wave-0 seam infrastructure outside this task's scope --
+ * per the "don't silently edit shared seam" guardrail, the affected tests are NOT deleted or
+ * weakened: they are gated with {@code @EnabledIfSystemProperty(... matches = "http")} so they
+ * still run (and pass) under {@code -Dfiles.test.transport=http}, and are only skipped on the
+ * default embedded transport where the seam bug lives -- reporting this rather than patching it
+ * unilaterally.
+ */
+class UploadFileApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String EMBEDDED_TRANSPORT_SEAM_BUG =
+      "FINDING: TestUtils#sendUpload's second writeInbound(LastHttpContent) call throws "
+          + "ClosedChannelException on the EMBEDDED transport when BlobController already "
+          + "responded+closed synchronously while handling the request head (before any content "
+          + "is read) -- see this class's javadoc. Passes cleanly under "
+          + "-Dfiles.test.transport=http; disabled here rather than silently editing the shared "
+          + "seam (TestUtils.java) without approval.";
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setMaxUploadableSizeMb(null);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String toBase64(String value) {
+    return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private HttpResponse upload(String parentId, String filenameB64, byte[] body, String cookie) {
+    List<Map.Entry<String, String>> headers = new ArrayList<>();
+    headers.add(Map.entry("Filename", filenameB64));
+    if (parentId != null) {
+      headers.add(Map.entry("ParentId", parentId));
+    }
+    HttpRequest httpRequest = HttpRequest.ofUpload("POST", "/upload", cookie, headers, body);
+    return app.upload(httpRequest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getNode(String nodeId, String cookie) {
+    // NOTE: the GraphQL Node interface splits the stored filename into a base `name` (extension
+    // stripped, see Node#getName()) and a separate `extension` field -- there is no combined
+    // "full name" field on File/Folder. Both must be queried and reassembled to check a filename.
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id name owner { id } ... on File { extension } }")
+            .build();
+    HttpResponse httpResponse = app.send(HttpRequest.of("POST", "/graphql/", cookie, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    return TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> childNodeIds(String folderId) {
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("findNodes")
+            .withString("folder_id", folderId)
+            .withEnumLiteral("sort", "NAME_ASC")
+            .withInteger("limit", 50)
+            .withWantedResultFormat("{ nodes { id }, page_token }")
+            .build();
+    HttpResponse httpResponse =
+        app.send(HttpRequest.of("POST", "/graphql/", REQUESTER_COOKIE, bodyPayload));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> page = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "findNodes");
+    List<Map<String, Object>> nodes = (List<Map<String, Object>>) page.get("nodes");
+    return nodes.stream().map(node -> (String) node.get("id")).toList();
+  }
+
+  /**
+   * Reads the current value of the Prometheus {@code files_upload_total{...,uri="/upload",...}}
+   * counter off {@code GET /metrics} (an unauthenticated route, see {@code MetricsApiIT}). Used to
+   * assert a delta rather than an absolute value so the check is order-independent across tests in
+   * this class.
+   */
+  private double uploadCounterValue() {
+    HttpResponse httpResponse = app.send(HttpRequest.of("GET", "/metrics", null, null));
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    for (String line : httpResponse.getBodyPayload().split("\n")) {
+      if (line.startsWith("files_upload_total") && line.contains("uri=\"/upload\"")) {
+        String[] tokens = line.trim().split("\\s+");
+        return Double.parseDouble(tokens[tokens.length - 1]);
+      }
+    }
+    return 0.0;
+  }
+
+  @Test
+  void givenAValidUploadIntoLocalRootItShouldCreateTheNodeAndOmitVersionFromTheResponse()
+      throws Exception {
+    // Given
+    app.mocks().storagesUploadSucceeds();
+    double counterBefore = uploadCounterValue();
+
+    // When
+    HttpResponse httpResponse =
+        upload(null, toBase64("hello.txt"), "hello world".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsKey("nodeId");
+    String nodeId = (String) json.get("nodeId");
+    Assertions.assertThat(nodeId).isNotBlank();
+    // KNOWN QUIRK (Wave 0): UploadVersionResponse#setVersion(int) only stores values > 1, so a
+    // fresh upload's version (1) is never set -> the field is entirely absent from the JSON.
+    Assertions.assertThat(json).doesNotContainKey("version");
+
+    Assertions.assertThat(app.backdoor().nodeExists(nodeId)).isTrue();
+
+    Map<String, Object> node = getNode(nodeId, REQUESTER_COOKIE);
+    Assertions.assertThat(node).containsEntry("name", "hello").containsEntry("extension", "txt");
+    Assertions.assertThat(((Map<String, Object>) node.get("owner"))).containsEntry("id", REQUESTER_ID);
+
+    Assertions.assertThat(uploadCounterValue()).isEqualTo(counterBefore + 1.0);
+  }
+
+  @Test
+  void givenAnUploadIntoASharedFolderItShouldInheritTheFolderOwner() throws Exception {
+    // Given — folder owned by OTHER_USER_ID, shared with the requester with write access
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorFolder(folderId, OTHER_USER_ID, "sharedParent"))
+        .addShare(folderId, REQUESTER_ID, ACL.SharePermission.READ_AND_WRITE);
+    app.mocks().storagesUploadSucceeds();
+
+    // When
+    HttpResponse httpResponse =
+        upload(folderId, toBase64("shared.txt"), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    String nodeId = (String) json.get("nodeId");
+
+    Map<String, Object> node = getNode(nodeId, REQUESTER_COOKIE);
+    Assertions.assertThat(((Map<String, Object>) node.get("owner"))).containsEntry("id", OTHER_USER_ID);
+  }
+
+  @Test
+  void givenNoWritePermissionOnTheParentUploadShouldReturn404AndCreateNoOrphanNode() {
+    // Given — folder owned by OTHER_USER_ID, never shared with the requester
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(folderId, OTHER_USER_ID, "privateParent"));
+    List<String> childrenBefore = childNodeIds(folderId);
+
+    // When
+    HttpResponse httpResponse =
+        upload(folderId, toBase64("nope.txt"), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then — BlobService#uploadFile returns Optional.empty() -> NoSuchElementException -> 404
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+    Assertions.assertThat(childNodeIds(folderId)).isEqualTo(childrenBefore);
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
+  void givenABodyOverTheConfiguredSizeCapUploadShouldReturn413() {
+    // Given — a 0MB cap + a tiny (few-byte) body: BlobController rejects based on Content-Length
+    // alone, before reading any body bytes, so the server may respond+close the connection while
+    // the client is still transmitting; keeping the body tiny (instead of multi-MB) keeps the
+    // client's write effectively atomic and avoids a genuine client/server TCP race on both
+    // transports (see this class's SECOND FINDING for the embedded-only failure mode).
+    app.mocks().setMaxUploadableSizeMb(0);
+    byte[] oversizedBody = "over the 0MB cap".getBytes(StandardCharsets.UTF_8);
+
+    // When
+    HttpResponse httpResponse = upload(null, toBase64("big.bin"), oversizedBody, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(413);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("413 Request Entity Too Large");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
+  void givenANonBase64FilenameUploadShouldReturn400() {
+    // When — "!" is not part of the base64 alphabet, so Base64.isBase64(...) is false
+    HttpResponse httpResponse =
+        upload(null, "not-!-valid-!-base64", "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
+  void givenAnEmptyFilenameUploadShouldReturn400() {
+    // When — base64 of the empty string decodes to an empty (blank-after-trim) filename
+    HttpResponse httpResponse = upload(null, toBase64(""), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
+  void givenAFilenameLongerThan1024CharactersUploadShouldReturn400() {
+    // Given
+    String tooLongName = "a".repeat(1021) + ".txt"; // 1025 chars decoded
+
+    // When
+    HttpResponse httpResponse =
+        upload(null, toBase64(tooLongName), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  void givenStoragesUploadFailsUploadShouldReturn500AndCreateNoOrphanNode() {
+    // Given
+    app.mocks().storagesUploadFails();
+    List<String> childrenBefore = childNodeIds("LOCAL_ROOT");
+
+    // When
+    HttpResponse httpResponse =
+        upload(null, toBase64("willfail.txt"), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then — DependencyException falls into ExceptionsHandler's generic else-branch -> 500;
+    // the node row created before the storages call is deleted (BlobService#uploadFile's
+    // Try#getOrElseThrow rollback).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+    Assertions.assertThat(childNodeIds("LOCAL_ROOT")).isEqualTo(childrenBefore);
+  }
+
+  @Test
+  void givenStoragesVerifyExistsFailsUploadShouldReturn500AndCreateNoOrphanNode() {
+    // Given
+    app.mocks().storagesVerifyMissing();
+    List<String> childrenBefore = childNodeIds("LOCAL_ROOT");
+
+    // When
+    HttpResponse httpResponse =
+        upload(null, toBase64("willfail2.txt"), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+    Assertions.assertThat(childNodeIds("LOCAL_ROOT")).isEqualTo(childrenBefore);
+  }
+
+  @Test
+  void givenANameCollisionUploadShouldDedupTheName() throws Exception {
+    // Given
+    String existingId = "10000000-0000-0000-0000-000000000002";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(existingId, REQUESTER_ID, "sameName.txt"));
+    app.mocks().storagesUploadSucceeds();
+
+    // When
+    HttpResponse httpResponse =
+        upload(null, toBase64("sameName.txt"), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    String nodeId = (String) json.get("nodeId");
+
+    Map<String, Object> node = getNode(nodeId, REQUESTER_COOKIE);
+    Assertions.assertThat(node).containsEntry("name", "sameName (1)").containsEntry("extension", "txt");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileApiIT.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Task 2.1 of the acceptance coverage-expansion plan: {@code POST /upload}, the plain new-node
@@ -48,41 +47,21 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * per the "don't silently edit shared seam" guardrail. This scenario is therefore DELIBERATELY
  * OMITTED here rather than faked with a test that would silently degrade to the happy path.
  *
- * <p><b>SECOND FINDING — a genuine Wave-0 seam BUG (not a design tradeoff), confirmed by running
- * BOTH transports:</b> any scenario where {@code BlobController} throws SYNCHRONOUSLY while
- * handling the request HEAD object -- i.e. before any {@code HttpContent} is read (the
- * size-over-limit check and the {@code Filename} validation both run this early) -- makes {@code
- * TestUtils#sendUpload} (the EMBEDDED-transport implementation only) throw a raw {@code
- * java.nio.channels.ClosedChannelException}, instead of returning the {@code HttpResponse} the
- * server already produced. Root cause: {@code sendUpload} unconditionally issues TWO separate
- * {@code EmbeddedChannel#writeInbound} calls (head, then {@code LastHttpContent}); when the first
- * call's synchronous exception handling already wrote the response AND closed the channel (via
- * {@code ExceptionsHandler}'s {@code ChannelFutureListener.CLOSE}), the second call hits {@code
- * EmbeddedChannel#ensureOpen()} and throws. This is REPRODUCIBLE and CONFIRMED transport-specific:
- * the identical scenarios pass cleanly under {@code -Dfiles.test.transport=http} (see the
- * disabled tests below), because {@code RealHttpFilesTestApp#upload} makes a single blocking
- * {@code HttpClient.send} call with no analogous second write. A one-line fix (guarding the
- * second {@code writeInbound} on {@code nettyChannel.isOpen()}, or catching {@code
- * ClosedChannelException} and returning whatever the first write already produced) would resolve
- * it, but {@code TestUtils.java} is shared Wave-0 seam infrastructure outside this task's scope --
- * per the "don't silently edit shared seam" guardrail, the affected tests are NOT deleted or
- * weakened: they are gated with {@code @EnabledIfSystemProperty(... matches = "http")} so they
- * still run (and pass) under {@code -Dfiles.test.transport=http}, and are only skipped on the
- * default embedded transport where the seam bug lives -- reporting this rather than patching it
- * unilaterally.
+ * <p><b>SECOND FINDING — RESOLVED:</b> {@code TestUtils#sendUpload} used to throw a raw {@code
+ * java.nio.channels.ClosedChannelException} on the EMBEDDED transport whenever {@code
+ * BlobController} responded and closed the channel synchronously while handling the request HEAD
+ * (before any {@code HttpContent} is read — the size-over-limit check and the {@code Filename}
+ * validation both run this early), because {@code sendUpload} unconditionally issued a second
+ * {@code EmbeddedChannel#writeInbound} call (the {@code LastHttpContent}) even when the first call
+ * had already closed the channel. {@code TestUtils#sendUpload} now guards that second write with
+ * {@code nettyChannel.isOpen()}, so the response the handler already produced during head
+ * processing is read out normally on both transports. The scenarios below now run (and pass) on
+ * both the embedded and {@code -Dfiles.test.transport=http} transports.
  */
 class UploadFileApiIT {
 
   static FilesTestApp app;
   static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private static final String EMBEDDED_TRANSPORT_SEAM_BUG =
-      "FINDING: TestUtils#sendUpload's second writeInbound(LastHttpContent) call throws "
-          + "ClosedChannelException on the EMBEDDED transport when BlobController already "
-          + "responded+closed synchronously while handling the request head (before any content "
-          + "is read) -- see this class's javadoc. Passes cleanly under "
-          + "-Dfiles.test.transport=http; disabled here rather than silently editing the shared "
-          + "seam (TestUtils.java) without approval.";
 
   private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
   private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
@@ -249,13 +228,13 @@ class UploadFileApiIT {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
   void givenABodyOverTheConfiguredSizeCapUploadShouldReturn413() {
     // Given — a 0MB cap + a tiny (few-byte) body: BlobController rejects based on Content-Length
     // alone, before reading any body bytes, so the server may respond+close the connection while
     // the client is still transmitting; keeping the body tiny (instead of multi-MB) keeps the
     // client's write effectively atomic and avoids a genuine client/server TCP race on both
-    // transports (see this class's SECOND FINDING for the embedded-only failure mode).
+    // transports (see this class's SECOND FINDING javadoc for the now-fixed embedded-transport
+    // seam bug this used to trigger).
     app.mocks().setMaxUploadableSizeMb(0);
     byte[] oversizedBody = "over the 0MB cap".getBytes(StandardCharsets.UTF_8);
 
@@ -268,7 +247,6 @@ class UploadFileApiIT {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
   void givenANonBase64FilenameUploadShouldReturn400() {
     // When — "!" is not part of the base64 alphabet, so Base64.isBase64(...) is false
     HttpResponse httpResponse =
@@ -280,7 +258,6 @@ class UploadFileApiIT {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
   void givenAnEmptyFilenameUploadShouldReturn400() {
     // When — base64 of the empty string decodes to an empty (blank-after-trim) filename
     HttpResponse httpResponse = upload(null, toBase64(""), "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
@@ -291,7 +268,6 @@ class UploadFileApiIT {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
   void givenAFilenameLongerThan1024CharactersUploadShouldReturn400() {
     // Given
     String tooLongName = "a".repeat(1021) + ".txt"; // 1025 chars decoded

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileVersionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileVersionApiIT.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Task 2.2 of the acceptance coverage-expansion plan: {@code POST /upload-version}, driven through
@@ -50,27 +49,19 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * code from a black-box perspective. Both scenarios are asserted below with their real, identical
  * 404 shape.
  *
- * <p><b>SECOND FINDING (shared with {@code UploadFileApiIT} -- see that class's javadoc for full
- * detail):</b> {@code TestUtils#sendUpload}'s second {@code writeInbound} call throws {@code
- * ClosedChannelException} on the EMBEDDED transport whenever {@code BlobController} responds
- * synchronously while handling the request head, before any content is read -- which is exactly
- * when the size-over-limit check fires. Confirmed to pass cleanly under {@code
- * -Dfiles.test.transport=http}; the affected test is gated with {@code
- * @EnabledIfSystemProperty(... matches = "http")} (still runs and passes under the http
- * transport) rather than editing the shared seam without approval.
+ * <p><b>SECOND FINDING (shared with {@code UploadFileApiIT}) -- RESOLVED:</b> {@code
+ * TestUtils#sendUpload} used to throw a raw {@code ClosedChannelException} on the EMBEDDED
+ * transport whenever {@code BlobController} responded and closed the channel synchronously while
+ * handling the request head, before any content is read -- which is exactly when the
+ * size-over-limit check fires. {@code TestUtils#sendUpload} now guards its second {@code
+ * writeInbound} with {@code nettyChannel.isOpen()}, so the response the handler already produced
+ * during head processing is read out normally on both transports. The size-cap test below now runs
+ * (and passes) on both the embedded and {@code -Dfiles.test.transport=http} transports.
  */
 class UploadFileVersionApiIT {
 
   static FilesTestApp app;
   static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private static final String EMBEDDED_TRANSPORT_SEAM_BUG =
-      "FINDING: TestUtils#sendUpload's second writeInbound(LastHttpContent) call throws "
-          + "ClosedChannelException on the EMBEDDED transport when BlobController already "
-          + "responded+closed synchronously while handling the request head (before any content "
-          + "is read) -- see UploadFileApiIT's javadoc. Passes cleanly under "
-          + "-Dfiles.test.transport=http; disabled here rather than silently editing the shared "
-          + "seam (TestUtils.java) without approval.";
 
   private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
   private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
@@ -261,7 +252,6 @@ class UploadFileVersionApiIT {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
   void givenABodyOverTheConfiguredSizeCapUploadVersionShouldReturn413() {
     // Given — a 0MB cap + a tiny body; see UploadFileApiIT's analogous test for why the body is
     // kept tiny rather than multi-MB (avoids a genuine client/server TCP race on both transports).

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileVersionApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadFileVersionApiIT.java
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Task 2.2 of the acceptance coverage-expansion plan: {@code POST /upload-version}, driven through
+ * {@link FilesTestApp#upload}/{@code HttpRequest.ofUpload} and {@code
+ * Mocks#setMaxNumberOfVersions}/{@code storagesBulkDeleteSucceeds}/{@code
+ * storagesBulkDeleteReturnsNullResponse}.
+ *
+ * <p><b>Seam clarification (do not use the builder knob here):</b> {@code
+ * BlobService#uploadFileVersion}'s 405 version-cap re-reads {@code
+ * FilesConfig#getMaxNumberOfFileVersion()} on EVERY call, which is exactly what {@code
+ * Mocks#setMaxNumberOfVersions} (a post-build {@code MockFilesConfig} override) drives — see that
+ * method's own javadoc. The builder's {@code withMaxNumberOfVersions(int)} instead targets a
+ * DIFFERENT, pre-build-only cap ({@code NodeDataFetcher}'s keep-cap for {@code keepVersions}/{@code
+ * cloneVersion}, read once from Service-Discover at construction) that this class's mutation never
+ * touches, so it is intentionally unused here.
+ *
+ * <p><b>FINDING (mirrors {@code CreateFolderApiIT}'s permission-gate finding):</b> {@code
+ * uploadFileVersion}'s permission check ({@code
+ * permissionsChecker.getPermissions(nodeId,...).has(READ_AND_WRITE)}) runs BEFORE {@code
+ * nodeRepository.getNodeForUpdate(nodeId)}. Since {@code PermissionsChecker#getPermissions} maps
+ * ANY non-existent node id to {@code ACL.NONE} (its {@code Optional<Node>} lookup is empty), a
+ * genuinely non-existent {@code NodeId} fails the SAME early permission gate as an existing node
+ * the requester cannot write to — both return the identical 404 via the identical early-return
+ * branch. The deeper {@code getNodeForUpdate(...).orElseThrow(() -> new
+ * NoSuchElementException("Node not found: " + nodeId))} line is therefore unreachable via any
+ * legitimate HTTP request (the permission gate cannot pass for an id with no backing row) — dead
+ * code from a black-box perspective. Both scenarios are asserted below with their real, identical
+ * 404 shape.
+ *
+ * <p><b>SECOND FINDING (shared with {@code UploadFileApiIT} -- see that class's javadoc for full
+ * detail):</b> {@code TestUtils#sendUpload}'s second {@code writeInbound} call throws {@code
+ * ClosedChannelException} on the EMBEDDED transport whenever {@code BlobController} responds
+ * synchronously while handling the request head, before any content is read -- which is exactly
+ * when the size-over-limit check fires. Confirmed to pass cleanly under {@code
+ * -Dfiles.test.transport=http}; the affected test is gated with {@code
+ * @EnabledIfSystemProperty(... matches = "http")} (still runs and passes under the http
+ * transport) rather than editing the shared seam without approval.
+ */
+class UploadFileVersionApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String EMBEDDED_TRANSPORT_SEAM_BUG =
+      "FINDING: TestUtils#sendUpload's second writeInbound(LastHttpContent) call throws "
+          + "ClosedChannelException on the EMBEDDED transport when BlobController already "
+          + "responded+closed synchronously while handling the request head (before any content "
+          + "is read) -- see UploadFileApiIT's javadoc. Passes cleanly under "
+          + "-Dfiles.test.transport=http; disabled here rather than silently editing the shared "
+          + "seam (TestUtils.java) without approval.";
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+    app.mocks().setMaxNumberOfVersions(null);
+    app.mocks().setMaxUploadableSizeMb(null);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private static String toBase64(String value) {
+    return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private HttpResponse uploadVersion(
+      String nodeId, String filenameB64, boolean overwrite, byte[] body, String cookie) {
+    List<Map.Entry<String, String>> headers =
+        List.of(
+            Map.entry("NodeId", nodeId),
+            Map.entry("Filename", filenameB64),
+            Map.entry("OverwriteVersion", String.valueOf(overwrite)));
+    HttpRequest httpRequest = HttpRequest.ofUpload("POST", "/upload-version", cookie, headers, body);
+    return app.upload(httpRequest);
+  }
+
+  @Test
+  void givenANewVersionUploadShouldSucceedAndReturnTheIncrementedVersion() throws Exception {
+    // Given — a single existing version (v1)
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"));
+    app.mocks().storagesUploadSucceeds();
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), false, "v2 content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsEntry("nodeId", nodeId);
+    Assertions.assertThat(json).containsEntry("version", 2);
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2);
+  }
+
+  @Test
+  void givenOverwriteTrueUploadShouldReplaceTheCurrentVersionInPlace() throws Exception {
+    // Given — two existing versions (v1, v2); current version is 2
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"))
+        .addVersion(nodeId);
+    app.mocks().storagesUploadSucceeds();
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), true, "overwritten content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then — the response's version (2) IS > 1, so (unlike a fresh v1 upload) it IS present
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsEntry("nodeId", nodeId);
+    Assertions.assertThat(json).containsEntry("version", 2);
+    // Same version count/numbers as before -- v2's row was replaced in place, not appended to
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(1, 2);
+    app.mocks().verifyStoragesUploaded(nodeId, 2);
+  }
+
+  @Test
+  void givenNoWritePermissionUploadVersionShouldReturn404() {
+    // Given — node owned by OTHER_USER_ID, shared READ_ONLY (no write) with the requester
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, OTHER_USER_ID, "notMine.txt"))
+        .addShare(nodeId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("notMine.txt"), false, "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+
+  @Test
+  void givenANonExistentNodeIdUploadVersionShouldReturnTheSame404AsNoPermission() {
+    // Given — see class-level FINDING: a syntactically-valid but non-existent id fails the SAME
+    // early permission gate as "no permission", not the deeper (dead) not-found branch.
+    String nonExistentId = "10000000-0000-0000-0000-00000000ffff";
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nonExistentId, toBase64("ghost.txt"), false, "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+
+  @Test
+  void givenTheVersionCapIsExceededUploadVersionShouldReturn405() {
+    // Given — cap = 2, node already has 3 versions (3 > 2)
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"))
+        .addVersion(nodeId)
+        .addVersion(nodeId);
+    app.mocks().setMaxNumberOfVersions(2);
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), false, "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(405);
+    Assertions.assertThat(httpResponse.getBodyPayload())
+        .isEqualTo(
+            String.format(
+                "Node %s has reached max number of versions (2), cannot add more versions", nodeId));
+  }
+
+  @Test
+  void givenTheVersionCountAtTheCapUploadVersionShouldSucceedAndEvictTheOldestVersion()
+      throws Exception {
+    // Given — cap = 2, node has exactly 2 versions (2 > 2 is false -> upload succeeds; 2 >= 2 is
+    // true -> the oldest non-keptForever version is evicted after the new one lands)
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"))
+        .addVersion(nodeId);
+    app.mocks().setMaxNumberOfVersions(2);
+    app.mocks().storagesUploadSucceeds();
+    app.mocks().storagesBulkDeleteSucceeds(List.of());
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), false, "v3 content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsEntry("version", 3);
+    // v1 (the oldest) was evicted; v2 and the new v3 remain
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(2, 3);
+  }
+
+  @Test
+  void givenAMimeTypeMismatchUploadVersionShouldReturn400() {
+    // Given — existing node is TEXT (fake.txt); new filename maps to IMAGE
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"));
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("photo.png"), false, "content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then — FileTypeMismatchException groups with the GENERIC-body BAD_REQUEST branch in
+    // ExceptionsHandler (same group as BadRequestException/IllegalArgumentException), so the
+    // actual descriptive message is discarded just like FileSizeException's.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "files.test.transport", matches = "http", disabledReason = EMBEDDED_TRANSPORT_SEAM_BUG)
+  void givenABodyOverTheConfiguredSizeCapUploadVersionShouldReturn413() {
+    // Given — a 0MB cap + a tiny body; see UploadFileApiIT's analogous test for why the body is
+    // kept tiny rather than multi-MB (avoids a genuine client/server TCP race on both transports).
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"));
+    app.mocks().setMaxUploadableSizeMb(0);
+    byte[] oversizedBody = "over the 0MB cap".getBytes(StandardCharsets.UTF_8);
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), false, oversizedBody, REQUESTER_COOKIE);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(413);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("413 Request Entity Too Large");
+
+    // reset — this override is independent of the @AfterEach's setMaxNumberOfVersions(null) reset
+    app.mocks().setMaxUploadableSizeMb(null);
+  }
+
+  @Test
+  void givenStoragesBulkDeleteReturnsANullResponseTheEvictedVersionIsStillDeleted()
+      throws Exception {
+    // Given — same cap/eviction setup as the successful-eviction test, but the bulk-delete
+    // endpoint returns a body the SDK deserialises as ids=null, which throws an NPE that
+    // production explicitly catches and treats as "all deletes succeeded" (documents the SDK-bug
+    // current behaviour, per the plan's finding — NOT fixed here).
+    String nodeId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(new SimplePopulatorTextFile(nodeId, REQUESTER_ID, "fake.txt"))
+        .addVersion(nodeId);
+    app.mocks().setMaxNumberOfVersions(2);
+    app.mocks().storagesUploadSucceeds();
+    app.mocks().storagesBulkDeleteReturnsNullResponse();
+
+    // When
+    HttpResponse httpResponse =
+        uploadVersion(nodeId, toBase64("fake.txt"), false, "v3 content".getBytes(StandardCharsets.UTF_8), REQUESTER_COOKIE);
+
+    // Then — upload succeeds, and despite the SDK-null bug the oldest version is STILL deleted
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json).containsEntry("version", 3);
+    Assertions.assertThat(app.backdoor().remainingVersionNumbers(nodeId)).containsExactly(2, 3);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadToApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UploadToApiIT.java
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorTextFile;
+import com.zextras.carbonio.files.rest.types.UploadToRequest;
+import com.zextras.carbonio.files.rest.types.UploadToRequest.TargetModule;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.Map;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tasks 4.1/4.2 of the acceptance coverage-expansion plan: {@code POST /upload-to}
+ * ({@code ProcedureController}/{@code ProcedureService}), the "attach node to mailbox" route.
+ *
+ * <p><b>FINDING (seam-usage correction):</b> the brief for this task assumed {@code app.send(...)}
+ * was the right seam call because the body is "a small JSON control message, not a blob". That is
+ * WRONG: {@code FilesTestApp#send}/{@code TestUtils#sendRequest} UNCONDITIONALLY wraps whatever
+ * body it is given as a GraphQL envelope ({@code TestUtils#queryPayload} -> {@code
+ * {"query":"<body>"}}) on BOTH transports (see {@code RealHttpFilesTestApp#send}'s own comment:
+ * "All send() POSTs target the GraphQL endpoints"). {@code ProcedureController} does not run
+ * GraphQL at all -- it deserializes {@code httpRequest.content()} directly into {@link
+ * UploadToRequest} with a plain {@code ObjectMapper}, so a {@code send()}-wrapped body would
+ * itself be a (valid JSON, wrong-shape) parse target, corrupting every scenario below into the
+ * "unrecognized property" flavour of the JSON-parse-failure case. {@link FilesTestApp#sendForm}
+ * is the correct call: {@code TestUtils#sendFormRequest}/{@code RealHttpFilesTestApp#sendForm}
+ * forward the given body payload string VERBATIM on both transports (no wrapping at all) --
+ * exactly what a raw, non-GraphQL JSON control message needs. This is already the established
+ * idiom for other raw-JSON/form REST bodies (see {@code DownloadMultipleApiIT}/{@code
+ * AliasNotAloneDownloadApiIT}, which also use {@code sendForm} for a non-GraphQL POST body).
+ * Every scenario here therefore uses {@code sendForm}, not {@code send}.
+ */
+class UploadToApiIT {
+
+  static FilesTestApp app;
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(
+                Map.of(
+                    "fake-token", REQUESTER_ID,
+                    "fake-token-b", OTHER_USER_ID))
+            .withStorages()
+            .withMailbox()
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+    app.mocks().reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  /** Builds the raw (non-GraphQL) JSON body {@code ProcedureController} deserializes directly. */
+  private static String uploadToBody(String nodeId, TargetModule targetModule) throws Exception {
+    UploadToRequest request = new UploadToRequest();
+    request.setNodeId(UUID.fromString(nodeId));
+    request.setTargetModule(targetModule);
+    return OBJECT_MAPPER.writeValueAsString(request);
+  }
+
+  private HttpResponse uploadTo(String method, String cookie, String body) {
+    return app.sendForm(HttpRequest.of(method, "/upload-to", cookie, body));
+  }
+
+  @Test
+  void givenANonPostVerbUploadToShouldReturn400() throws Exception {
+    // Given -- a syntactically-valid body; irrelevant, since ProcedureController#channelRead0
+    // rejects any non-POST method before ever looking at the body.
+    String body = uploadToBody(REQUESTER_ID, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("GET", REQUESTER_COOKIE, body);
+
+    // Then -- BadRequestException -> ExceptionsHandler's generic 400 branch
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  void givenAMalformedJsonBodyUploadToShouldReturn500() {
+    // Given -- syntactically-invalid JSON (unterminated object): ObjectMapper#readValue throws a
+    // JsonParseException (a JsonProcessingException) with NO cause of its own, so
+    // ExceptionsHandler's single getCause() unwrap is a no-op here and the ORIGINAL
+    // JsonProcessingException is what matches its `cause instanceof JsonProcessingException`
+    // branch -> 500 with the GENERIC payload (not the parser's own message).
+    String malformedBody = "{\"nodeId\": \"" + REQUESTER_ID + "\", \"targetModule\": \"MAILS\"";
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, malformedBody);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+  }
+
+  @Test
+  void givenNoPermissionOnTheNodeUploadToShouldReturn404() throws Exception {
+    // Given -- a file owned by another user, never shared with the requester
+    String fileId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, OTHER_USER_ID, "private.txt"));
+    String body = uploadToBody(fileId, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, body);
+
+    // Then -- PermissionsChecker returns ACL.NONE -> !.has(READ_ONLY) -> NodeNotFoundException -> 404
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(404);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("404 Not Found");
+  }
+
+  @Test
+  void givenAFolderTargetUploadToShouldReturn400() throws Exception {
+    // Given -- the requester owns the folder (so the permission check passes), but
+    // ProcedureService#uploadToModule rejects any FOLDER node type.
+    String folderId = "10000000-0000-0000-0000-000000000002";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID, "myFolder"));
+    String body = uploadToBody(folderId, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, body);
+
+    // Then -- BadRequestException (folder) -> ExceptionsHandler's generic 400 branch
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(400);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("400 Bad Request");
+  }
+
+  @Test
+  void givenStoragesDownloadFailsUploadToShouldReturn500() throws Exception {
+    // Given -- requester owns the file, but the storages download connection drops
+    String fileId = "10000000-0000-0000-0000-000000000003";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, REQUESTER_ID, "toattach.txt"));
+    app.mocks().storagesDownloadConnectionDrops();
+    String body = uploadToBody(fileId, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, body);
+
+    // Then -- fileStoreClient.download(...) throws -> ProcedureService wraps it in
+    // InternalServerErrorException(cause) -> ExceptionsHandler unwraps ONE getCause() level to
+    // the raw underlying (non-mapped) exception -> falls into the generic else-branch -> 500
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+  }
+
+  @Test
+  void givenMailboxAcceptsUploadToShouldReturn200WithTheAttachmentId() throws Exception {
+    // Given
+    String fileId = "10000000-0000-0000-0000-000000000004";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, REQUESTER_ID, "attach.txt"));
+    app.mocks().storagesServesBlob(fileId, 1);
+    app.mocks().mailboxAccepts("85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c");
+    String body = uploadToBody(fileId, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, body);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> json = OBJECT_MAPPER.readValue(httpResponse.getBodyPayload(), Map.class);
+    Assertions.assertThat(json)
+        .containsEntry(
+            "attachmentId", "85e4b3d9-1f41-4292-9dc8-e933194cc1f2:dbca72a2-8b05-45c5-a83f-bbae05ab907c");
+  }
+
+  @Test
+  void givenMailboxDownUploadToShouldReturn500() throws Exception {
+    // Given
+    String fileId = "10000000-0000-0000-0000-000000000005";
+    app.backdoor().populator().addNode(new SimplePopulatorTextFile(fileId, REQUESTER_ID, "attach2.txt"));
+    app.mocks().storagesServesBlob(fileId, 1);
+    app.mocks().mailboxDown();
+    String body = uploadToBody(fileId, TargetModule.MAILS);
+
+    // When
+    HttpResponse httpResponse = uploadTo("POST", REQUESTER_COOKIE, body);
+
+    // Then -- MailboxHttpClient#uploadFile sees a non-200 status -> Try.failure(new
+    // InternalServerErrorException(errorMessage)) (the String constructor, so getCause() is
+    // null) -> ExceptionsHandler's unwrap is a no-op -> matches `cause instanceof
+    // InternalServerErrorException` -> 500 with the GENERIC payload (not the error message).
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(500);
+    Assertions.assertThat(httpResponse.getBodyPayload()).isEqualTo("500 Internal Server Error");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/UserResolversApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/UserResolversApiIT.java
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.api.utilities.entities.PopulatorNode;
+import com.zextras.carbonio.files.api.utilities.entities.SimplePopulatorFolder;
+import com.zextras.carbonio.files.dal.dao.ebean.ACL;
+import com.zextras.carbonio.files.dal.dao.ebean.NodeType;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Task 5.2 of the acceptance coverage-expansion plan: {@code UserDataFetcher}'s account/creator/
+ * owner/last_editor resolvers.
+ *
+ * <p>Every registered user-management fixture in this suite (both the class-level {@code
+ * withUserManagement(Map)} builder call and the {@code Mocks#registerUser} post-build helper) maps
+ * to the SAME hardcoded email {@code "fake-email@example.com"} ({@code
+ * MockUserManagementService#registerToken}) — there is no seam capability to give two different
+ * registered users two different, distinguishable emails. This is not a blocker for what is tested
+ * here (the partial-success/order-preservation test below only needs ONE known-resolvable email
+ * plus one deliberately-unregistered one), so it is noted here rather than reported as a missing
+ * capability the way the {@code getConfigs} ServiceDiscover-stubbing gap is in {@code
+ * GetConfigsApiIT}.
+ *
+ * <p><b>{@code creator}/{@code owner}/{@code last_editor} are coupled in test data:</b> {@code
+ * DatabasePopulator#addNode} stores a separate {@code creatorId} but derives the FIRST file
+ * version's {@code last_editor} from the SAME {@code ownerId} parameter passed to {@code
+ * FileVersionRepository#createNewFileVersion} (see {@code NodeDataFetcher}'s "TODO Move up when
+ * the last_editor coherent between node and file version will be coherent" comment). There is no
+ * populator method that sets a file version's last-editor independently of the node's owner, so
+ * "owner unresolvable" and "last_editor unresolvable" are demonstrated TOGETHER on one file node
+ * below (both really do share the same underlying id in this fixture), while {@code creator} is
+ * demonstrated independently (it has its own column).
+ */
+class UserResolversApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+  private static final String KNOWN_EMAIL = "fake-email@example.com";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse execute(String bodyPayload) {
+    return app.send(HttpRequest.of("POST", "/graphql/", REQUESTER_COOKIE, bodyPayload));
+  }
+
+  @Test
+  void givenARegisteredEmailGetAccountByEmailShouldReturnTheUser() {
+    // Given — REQUESTER_ID is already registered with KNOWN_EMAIL via the class-level
+    // withUserManagement(...) fixture (MockUserManagementService#registerToken hardcodes this
+    // email for every registered user).
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getAccountByEmail")
+            .withString("email", KNOWN_EMAIL)
+            .withWantedResultFormat("{ ... on User { id email full_name } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> account =
+        TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getAccountByEmail");
+    Assertions.assertThat(account).containsEntry("id", REQUESTER_ID).containsEntry("email", KNOWN_EMAIL);
+  }
+
+  @Test
+  void givenAnUnregisteredEmailGetAccountByEmailShouldReturnAccountNotFound() {
+    // Given
+    String unknownEmail = "nobody-knows-this@example.com";
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getAccountByEmail")
+            .withString("email", unknownEmail)
+            .withWantedResultFormat("{ ... on User { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Could not find user with identifier " + unknownEmail);
+    Assertions.assertThat(TestUtils.jsonResponseToValue(httpResponse.getBodyPayload(), "getAccountByEmail"))
+        .isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void givenAMixOfKnownAndUnknownEmailsGetAccountsByEmailShouldReturnPartialSuccessInOrder() {
+    // Given — [unknown, known, unknown]: order-preservation must hold even with data sandwiched
+    // between two failures, not just alternating from the first element.
+    String missingA = "missing-a@example.com";
+    String missingB = "missing-b@example.com";
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getAccountsByEmail")
+            .withListOfStrings("emails", new String[] {missingA, KNOWN_EMAIL, missingB})
+            .withWantedResultFormat("{ ... on User { id email } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<Map<String, Object>> accounts =
+        TestUtils.jsonResponseToList(httpResponse.getBodyPayload(), "getAccountsByEmail");
+    Assertions.assertThat(accounts).hasSize(3);
+    Assertions.assertThat(accounts.get(0)).isNull();
+    Assertions.assertThat(accounts.get(1)).containsEntry("id", REQUESTER_ID).containsEntry("email", KNOWN_EMAIL);
+    Assertions.assertThat(accounts.get(2)).isNull();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(2)
+        .containsExactly(
+            "Could not find user with identifier " + missingA,
+            "Could not find user with identifier " + missingB);
+  }
+
+  @Test
+  void givenAnUnresolvableCreatorIdTheCreatorSubFieldShouldSurfaceAccountNotFound() {
+    // Given — a file OWNED by the requester (so the requester has full read access trivially) but
+    // CREATED by a ghost id never registered in the UM mock. creator/owner are stored in separate
+    // columns by DatabasePopulator#addNode, so this isolates creator's resolver independently of
+    // owner's.
+    String ghostCreatorId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    String nodeId = "00000000-0000-0000-0000-000000000001";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId, ghostCreatorId, REQUESTER_ID, "LOCAL_ROOT", "creatorless.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id name creator { id } owner { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .anySatisfy(
+            message ->
+                Assertions.assertThat(message)
+                    .isEqualTo("Could not find user with identifier " + ghostCreatorId));
+
+    // creator: User! is NON-NULL in the schema (unlike owner/last_editor), so per GraphQL
+    // null-propagation a null-data DataFetcherResult on `creator` bubbles up to the nearest
+    // nullable ancestor — `getNode` itself (schema: `getNode(...): Node`, nullable) — nulling the
+    // WHOLE node, not just the `creator` sub-field. This is asserted as the REAL, current
+    // behaviour (a divergence from the plan's generic "error scoped to that sub-field, rest of
+    // node resolves" expectation, which only actually holds for the NULLABLE owner/last_editor
+    // fields — see the next test): id/name/owner do NOT survive here alongside the error.
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).isEmpty();
+  }
+
+  @Test
+  void
+      givenAnUnresolvableOwnerIdTheOwnerAndLastEditorSubFieldsShouldBeNullWithScopedErrorsWhileTheRestOfTheNodeResolves() {
+    // Given — a file CREATED by the requester (so creator resolves fine) but OWNED by a ghost id
+    // never registered in the UM mock; a direct Share row grants the requester READ access despite
+    // not owning it (same deliberately-inconsistent-fixture technique as GetNodeEdgeApiIT/
+    // GetPathApiIT). Because DatabasePopulator#addNode derives the file version's last_editor from
+    // the SAME ownerId, last_editor is unresolvable for the identical reason as owner here.
+    String ghostOwnerId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    String nodeId = "00000000-0000-0000-0000-000000000002";
+    app.backdoor()
+        .populator()
+        .addNode(
+            new PopulatorNode(
+                nodeId, REQUESTER_ID, ghostOwnerId, "LOCAL_ROOT", "ownerless.txt", "",
+                NodeType.TEXT, "LOCAL_ROOT", 1L, "text/plain"))
+        .addShare(nodeId, REQUESTER_ID, ACL.SharePermission.READ_ONLY);
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", nodeId)
+            .withWantedResultFormat("{ id name creator { id } owner { id } last_editor { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then — owner/last_editor: User (nullable in the schema) resolve to null WITHOUT bubbling,
+    // so the rest of the node (id/name/creator) survives alongside the two scoped errors.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).containsEntry("id", nodeId).containsEntry("name", "ownerless");
+    Assertions.assertThat((Map<String, Object>) node.get("creator")).containsEntry("id", REQUESTER_ID);
+    Assertions.assertThat(node.get("owner")).isNull();
+    Assertions.assertThat(node.get("last_editor")).isNull();
+
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .filteredOn(message -> message.equals("Could not find user with identifier " + ghostOwnerId))
+        .hasSize(2); // one for `owner`, one for `last_editor` — same ghost id, two separate fields
+  }
+
+  @Test
+  void givenAFolderThatWasNeverEditedTheLastEditorSubFieldShouldBeNullWithNoError() {
+    // Given — a plain folder. NodeDataFetcher only ever populates the LAST_EDITOR key in the
+    // field-resolver's local context for FILE nodes (it reads it off the file version's
+    // last_editor column); for FOLDER/ROOT nodes the key is never put into the context at all, so
+    // UserDataFetcher#getUserFetcher's local-context lookup finds nothing and returns an empty
+    // (no data, no error) result — not an accountNotFound error.
+    String folderId = "10000000-0000-0000-0000-000000000001";
+    app.backdoor().populator().addNode(new SimplePopulatorFolder(folderId, REQUESTER_ID));
+
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", folderId)
+            .withWantedResultFormat("{ id last_editor { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    Assertions.assertThat(TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload())).isEmpty();
+    Map<String, Object> node = TestUtils.jsonResponseToMap(httpResponse.getBodyPayload(), "getNode");
+    Assertions.assertThat(node).containsEntry("id", folderId);
+    Assertions.assertThat(node.get("last_editor")).isNull();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ValidationErrorsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ValidationErrorsApiIT.java
@@ -249,6 +249,64 @@ class ValidationErrorsApiIT {
             "Invalid link description. The description cannot be longer than 300 characters");
   }
 
+  /**
+   * Closes {@code GenericControllerEvaluator#checkNodeName}'s missing branch: the sibling test
+   * above ({@code givenEmptyNameOnUpdateNodeThenExactlyOneValidationError}) only exercises the
+   * {@code trim().isEmpty()} direction; every happy-path test elsewhere in the suite exercises
+   * {@code length &lt;= 1024}. The {@code length &gt; 1024} direction (non-blank but too long) was
+   * never exercised.
+   */
+  @Test
+  void givenTooLongNameOnUpdateNodeThenExactlyOneValidationError() {
+    // Given
+    String tooLongName = "a".repeat(1025);
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode")
+            .withString("node_id", VALID_NODE_ID)
+            .withString("name", tooLongName)
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "Invalid node name. The name cannot be empty, longer than 1024 characters, nor be"
+                + " composed only by blank spaces.");
+  }
+
+  /**
+   * Closes {@code GenericControllerEvaluator#checkLimitPagination}'s missing branch: every other
+   * test in this suite either omits {@code limit} (default) or passes a negative value (covering
+   * the {@code limit &gt;= 0} false direction); the {@code limit &gt; LIMIT_ELEMENTS_FOR_PAGE}
+   * direction (a value that's non-negative but over the page-size cap) was never exercised.
+   */
+  @Test
+  void givenOverTheCapLimitOnGetNodeChildrenThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", "LOCAL_ROOT")
+            .withWantedResultFormat(
+                "{ ... on Folder { children(limit: 999, sort: NAME_ASC) { nodes { id } } } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Invalid limit value. The allowed range is between 0 and 50.");
+  }
+
   @Test
   void givenEmptyShareTargetIdOnGetShareThenExactlyOneValidationError() {
     // Given

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/ValidationErrorsApiIT.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/ValidationErrorsApiIT.java
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance;
+
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.impl.GuiceNettyFilesTestAppBuilder;
+import com.zextras.carbonio.files.api.utilities.GraphqlCommandBuilder;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@code GenericControllerEvaluator}'s field-validation error paths (Task 1.2 of the
+ * acceptance coverage-expansion plan). Each test sends a GraphQL operation with exactly one
+ * invalid field and asserts exactly one validation error with the exact message text produced by
+ * {@code GenericControllerEvaluator}.
+ *
+ * <p>Validation runs in a {@code FieldValidationInstrumentation} that fires BEFORE any resolver
+ * executes (it aborts the whole operation via {@code AbortExecutionException} as soon as any
+ * bound rule fails), so none of these scenarios need any node/share/link to actually exist in the
+ * database — only argument shape matters.
+ */
+class ValidationErrorsApiIT {
+
+  static FilesTestApp app;
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String VALID_NODE_ID = "00000000-0000-0000-0000-000000000042";
+
+  @BeforeAll
+  static void init() {
+    app =
+        GuiceNettyFilesTestAppBuilder.aFilesTestApp()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(Map.of("fake-token", REQUESTER_ID))
+            .build();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    app.backdoor().resetDatabase();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    app.close();
+  }
+
+  private HttpResponse execute(String bodyPayload) {
+    HttpRequest httpRequest =
+        HttpRequest.of("POST", "/graphql/", "ZM_AUTH_TOKEN=fake-token", bodyPayload);
+    return app.send(httpRequest);
+  }
+
+  @Test
+  void givenInvalidEmailOnGetAccountByEmailThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getAccountByEmail")
+            .withString("email", "not-an-email")
+            .withWantedResultFormat("{ ... on User { id } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1).containsExactly("Invalid Email");
+  }
+
+  /**
+   * FINDING: {@code GenericControllerEvaluator#checkLinkPassword} is dead code — it is never
+   * wired into any {@code InputFieldsController} rule, AND the {@code createLink} schema field has
+   * no {@code password} argument at all (confirmed against {@code schema.graphql}). The plan's
+   * table row ("link password &lt; 8 chars on createLink password" -&gt; "Invalid link password...")
+   * describes a scenario that cannot happen through the real API. The closest honest behaviour to
+   * pin down is: passing an unrecognised {@code password} argument to {@code createLink} fails
+   * standard GraphQL document validation (unknown argument), NOT the advertised custom message.
+   */
+  @Test
+  void givenPasswordArgumentOnCreateLinkThenFailsSchemaValidationNotCustomPasswordCheck() {
+    // Given — "password" is not a declared argument of createLink; checkLinkPassword is never
+    // invoked by InputFieldsController, so this argument cannot reach it either way.
+    String bodyPayload =
+        "mutation { createLink(node_id: \\\""
+            + VALID_NODE_ID
+            + "\\\", password: \\\"short\\\") { id } }";
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then — a standard GraphQL "unknown argument" validation error, not our custom validator.
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors).hasSize(1);
+    Assertions.assertThat(errors.get(0))
+        .as("createLink has no password argument in schema.graphql; checkLinkPassword is dead code")
+        .contains("Validation error")
+        .contains("password");
+  }
+
+  /**
+   * FINDING: the plan's table describes this as "on findNodes", but {@code findNodes}' top-level
+   * {@code limit} argument has NO bound {@code FieldValidationInstrumentation} rule at all — only
+   * {@code getNode.children}'s {@code limit} is validated (see {@code
+   * GraphQLProvider#buildValidationInstrumentation}, which binds {@code childrenArgumentValidation}
+   * to {@code "/getNode/children"}, and has no rule for {@code "/findNodes"}). The reachable path
+   * is exercised here instead.
+   */
+  @Test
+  void givenOutOfRangeLimitOnGetNodeChildrenThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getNode")
+            .withString("node_id", "LOCAL_ROOT")
+            .withWantedResultFormat(
+                "{ ... on Folder { children(limit: -1, sort: NAME_ASC) { nodes { id } } } }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Invalid limit value. The allowed range is between 0 and 50.");
+  }
+
+  @Test
+  void givenTooLongDescriptionOnUpdateNodeThenExactlyOneValidationError() {
+    // Given
+    String tooLongDescription = "a".repeat(1025);
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode")
+            .withString("node_id", VALID_NODE_ID)
+            .withString("description", tooLongDescription)
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "Invalid node description. Length cannot be empty or more than 1024 characters");
+  }
+
+  @Test
+  void givenEmptyNameOnUpdateNodeThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode")
+            .withString("node_id", VALID_NODE_ID)
+            .withString("name", "")
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "Invalid node name. The name cannot be empty, longer than 1024 characters, nor be"
+                + " composed only by blank spaces.");
+  }
+
+  @Test
+  void givenWrongLengthNodeIdOnUpdateNodeThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("updateNode")
+            .withString("node_id", "short-id")
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Invalid node ID: \"short-id\". Length must be 36 characters");
+  }
+
+  @Test
+  void givenWrongLengthLinkIdOnDeleteLinksThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("deleteLinks")
+            .withListOfStrings("link_ids", new String[] {"short-link-id"})
+            .withWantedResultFormat("")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Invalid link ID: \"short-link-id\". Length must be 36 characters");
+  }
+
+  @Test
+  void givenTooLongDescriptionOnCreateLinkThenExactlyOneValidationError() {
+    // Given
+    String tooLongDescription = "b".repeat(301);
+    String bodyPayload =
+        GraphqlCommandBuilder.aMutationBuilder("createLink")
+            .withString("node_id", VALID_NODE_ID)
+            .withString("description", tooLongDescription)
+            .withWantedResultFormat("{ id }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly(
+            "Invalid link description. The description cannot be longer than 300 characters");
+  }
+
+  @Test
+  void givenEmptyShareTargetIdOnGetShareThenExactlyOneValidationError() {
+    // Given
+    String bodyPayload =
+        GraphqlCommandBuilder.aQueryBuilder("getShare")
+            .withString("node_id", "LOCAL_ROOT")
+            .withString("share_target_id", "")
+            .withWantedResultFormat("{ permission }")
+            .build();
+
+    // When
+    HttpResponse httpResponse = execute(bodyPayload);
+
+    // Then
+    Assertions.assertThat(httpResponse.getStatus()).isEqualTo(200);
+    List<String> errors = TestUtils.jsonResponseToErrors(httpResponse.getBodyPayload());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .containsExactly("Invalid user ID. Length cannot be empty");
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/FilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/FilesTestApp.java
@@ -23,6 +23,14 @@ public interface FilesTestApp extends AutoCloseable {
   /** Multipart/form send (replaces TestUtils.sendFormRequest). */
   HttpResponse sendForm(HttpRequest request);
 
+  /**
+   * Binary/streamed upload send, for the upload routes ({@code /upload}, {@code /upload-version},
+   * {@code /internal/upload}, {@code /upload-to}) whose body {@code BlobController} reads as a raw
+   * byte stream rather than aggregated JSON/form text. Build the request with {@code
+   * HttpRequest#ofUpload}.
+   */
+  HttpResponse upload(HttpRequest request);
+
   /** Seed + inspect state without touching the DI container or the ORM directly. */
   TestDataAccess backdoor();
 

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/FilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/FilesTestApp.java
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam;
+
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+
+/**
+ * Neutral facade over a running Files instance. The ONLY seam that acceptance-test bodies see.
+ *
+ * <p>Today the sole implementation, {@code GuiceNettyFilesTestApp} (in {@code seam.impl}), wraps
+ * the existing Guice+Netty {@code Simulator}. At Quarkus-rewrite time a sibling
+ * {@code QuarkusFilesTestApp} implementation is added in the same {@code seam.impl} package and
+ * the acceptance-test bodies are not touched.
+ */
+public interface FilesTestApp extends AutoCloseable {
+
+  /** Send a request over the app's HTTP contract and get the response. Transport-agnostic. */
+  HttpResponse send(HttpRequest request);
+
+  /** Multipart/form send (replaces TestUtils.sendFormRequest). */
+  HttpResponse sendForm(HttpRequest request);
+
+  /** Seed + inspect state without touching the DI container or the ORM directly. */
+  TestDataAccess backdoor();
+
+  /** Configure external-dependency fakes (Storages/Preview/DocsConnector/UM) neutrally. */
+  Mocks mocks();
+
+  @Override
+  void close();
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
@@ -175,6 +175,37 @@ public interface Mocks {
   /** Mailbox's upload endpoint is unreachable/erroring, simulating the mailbox being down. */
   void mailboxDown();
 
+  /**
+   * Preview/thumbnail service responds at {@code pathEndpoint} with a non-2xx status (HTTP 500),
+   * simulating the Preview microservice ITSELF failing — distinct from a permission/mime-type
+   * failure (which never reaches the Preview service at all, see {@code
+   * PreviewController#checkNodePermissionAndExistence}). Reaches {@code
+   * PreviewController#failureResponse} via the {@code previewService.getXxx(...).onFailure(...)}
+   * path (production maps this, via the SDK's {@code PreviewException} not being a {@code
+   * BadRequestException}, to a {@code NoSuchElementException} -&gt; HTTP 404).
+   */
+  void previewFails(String pathEndpoint);
+
+  /**
+   * Stubs an arbitrary raw ServiceDiscover KV value for {@code carbonio-files/<key>} (e.g. a
+   * non-numeric {@code max-number-of-versions}), read live on every call by {@code
+   * ConfigDataFetcher}/{@code ServiceDiscoverHttpClient} (unlike {@code NodeDataFetcher}'s
+   * construction-time read, this needs no pre-build builder knob). {@code rawValue} is sent
+   * verbatim (base64-encoded, matching the real Consul KV response shape) so any string —
+   * including a non-numeric one that trips {@code ConfigDataFetcher#updateMaxKeepVersionsValue}'s
+   * uncaught {@code Integer.parseInt(...)} — can be exercised.
+   */
+  void serviceDiscoverReturns(String key, String rawValue);
+
+  /**
+   * ServiceDiscover is unreachable (connection-level outage, not merely a missing/unstubbed key)
+   * for {@code carbonio-files/<key>}: the request will error before any HTTP status is even read.
+   * Distinct from simply never stubbing the key (which MockServer answers with a 404, exercising
+   * {@code ServiceDiscoverHttpClient#getConfig}'s "non-200 status" branch, already reachable
+   * without this method) — this instead exercises its {@code catch (IOException)} branch.
+   */
+  void serviceDiscoverConfigDown(String key);
+
   /** Resets all mock expectations to a clean baseline between tests. */
   void reset();
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam;
+
+import java.util.List;
+
+/**
+ * Neutral facade over external-dependency fakes (Storages/Preview/DocsConnector/UM). Keeps
+ * {@code org.mockserver.*} types out of test bodies — they stay confined to the {@code seam.impl}
+ * implementation and to {@code StoragesMockHelper}.
+ *
+ * <p>Extend this interface with more behavior-named methods as later migrations need additional
+ * mocked capabilities (Preview thumbnails, DocsConnector, UM outage, notification toggle, etc.).
+ */
+public interface Mocks {
+
+  /**
+   * Storages bulk-delete succeeds; node ids listed in {@code failedIds} are reported as failed
+   * (an empty list means full success). Replaces {@code StoragesMockHelper.bulkDelete(...)}.
+   */
+  void storagesBulkDeleteSucceeds(List<String> failedIds);
+
+  /**
+   * Storages bulk-delete endpoint returns an HTTP 500, simulating a complete PowerStore outage.
+   * Replaces {@code StoragesMockHelper.bulkDeleteError()}.
+   */
+  void storagesBulkDeleteFails();
+
+  /**
+   * Storages bulk-delete endpoint returns HTTP 200 with a null/empty ids payload. Replaces
+   * {@code StoragesMockHelper.bulkDeleteNullResponse()}.
+   */
+  void storagesBulkDeleteReturnsNullResponse();
+
+  /** Resets all mock expectations to a clean baseline between tests. */
+  void reset();
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
@@ -34,6 +34,64 @@ public interface Mocks {
    */
   void storagesBulkDeleteReturnsNullResponse();
 
+  /**
+   * Toggles the notifications feature flag. Replaces {@code ((MockFilesConfig)
+   * injector.getInstance(FilesConfig.class)).setAreNotificationsEnabled(bool)} (special case 1 —
+   * the 7 notification ITs).
+   */
+  void setNotificationsEnabled(boolean enabled);
+
+  /**
+   * Shuts down the in-process user-management gRPC server, simulating user-management being
+   * unreachable so health checks report it as unhealthy. Replaces {@code
+   * simulator.shutdownUserManagementServer()} (special case 2 — {@code HealthApiIT}). There is no
+   * corresponding "bring back up": once shut down the in-process server is gone for the rest of
+   * the test, matching the one-shot usage of the original {@code Simulator} method.
+   */
+  void userManagementDown();
+
+  /** Storages health endpoint ({@code GET /health/live}) reports live (HTTP 200). */
+  void storagesLive();
+
+  /** Storages health endpoint ({@code GET /health/live}) reports unreachable (HTTP 502). */
+  void storagesUnreachable();
+
+  /** Preview health endpoint ({@code GET /health/ready/}) reports ready (HTTP 200). */
+  void previewReady();
+
+  /** DocsConnector health endpoint ({@code GET /q/health/live}) reports live (HTTP 200). */
+  void docsConnectorLive();
+
+  /**
+   * Storages will return deterministic bytes for a download of {@code nodeId}/{@code version}.
+   * Replaces {@code StoragesMockHelper.getBlob(nodeId, version)} used directly in test bodies.
+   */
+  void storagesServesBlob(String nodeId, int version);
+
+  /**
+   * Storages' download endpoint ({@code GET /download}) drops the connection, simulating a
+   * network-level failure (production surfaces this as a 500). Distinct from {@link
+   * #storagesBulkDeleteFails()}, which targets the bulk-delete endpoint, not the download one.
+   */
+  void storagesDownloadConnectionDrops();
+
+  /** Verifies storages' download endpoint was hit exactly once for this {@code nodeId}/{@code version}. */
+  void verifyStoragesDownloaded(String nodeId, int version);
+
+  /** Verifies storages' download endpoint was never hit. */
+  void verifyStoragesNeverDownloaded();
+
+  /**
+   * Preview/thumbnail service will respond at {@code pathEndpoint} with {@code content} typed as
+   * {@code mediaType} (e.g. {@code "application/pdf"}, {@code "image/png"}, {@code "image/jpeg"}),
+   * tagged with the requesting file's owner id via the {@code FileOwnerId} header the production
+   * code sends. Returns an opaque expectation handle for {@link #verifyPreviewServed(String)}.
+   */
+  String previewServes(String pathEndpoint, String fileOwnerId, byte[] content, String mediaType);
+
+  /** Verifies the preview/thumbnail expectation identified by {@code expectationId} was matched, then clears it. */
+  void verifyPreviewServed(String expectationId);
+
   /** Resets all mock expectations to a clean baseline between tests. */
   void reset();
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/Mocks.java
@@ -92,6 +92,89 @@ public interface Mocks {
   /** Verifies the preview/thumbnail expectation identified by {@code expectationId} was matched, then clears it. */
   void verifyPreviewServed(String expectationId);
 
+  /**
+   * Storages' upload endpoint (both the new-node/new-version POST and the overwrite PUT) succeeds
+   * with a syntactically-valid response, AND the post-upload existence check ({@code
+   * BlobService#verifyBlobExists}, which re-uses a plain {@code GET /download} since there is no
+   * dedicated "exists" endpoint) also succeeds generically for any node id/version. Required by
+   * every upload happy-path scenario. Replaces {@code StoragesMockHelper#uploadSucceeds()}.
+   */
+  void storagesUploadSucceeds();
+
+  /**
+   * Storages' upload endpoint returns an HTTP 500, simulating an upload failure (production maps
+   * this to a {@code DependencyException} -> 500 and rolls back the node/version DB row). Replaces
+   * {@code StoragesMockHelper#uploadFails()}.
+   */
+  void storagesUploadFails();
+
+  /**
+   * The upload itself succeeds but the post-upload existence check reports the blob missing
+   * (production's {@code verifyBlobExists} == false -> {@code DependencyException} -> 500, DB row
+   * rolled back). Replaces {@code StoragesMockHelper#verifyMissing()}.
+   */
+  void storagesVerifyMissing();
+
+  /** Storages' copy endpoint ({@code copyFile}/{@code cloneVersion}) succeeds. Replaces {@code StoragesMockHelper#copySucceeds()}. */
+  void storagesCopySucceeds();
+
+  /** Storages' copy endpoint returns an HTTP 500, simulating a filestore-copy failure. Replaces {@code StoragesMockHelper#copyFails()}. */
+  void storagesCopyFails();
+
+  /** Verifies storages' upload endpoint was hit at least once for this {@code nodeId}/{@code version}. */
+  void verifyStoragesUploaded(String nodeId, int version);
+
+  /**
+   * Overrides {@code FilesConfig#getMaxUploadableFileSizeInMb()} for the lifetime of this app
+   * instance (falls through to the real Service-Discover-backed value when {@code null}). Drives
+   * the 413 upload-size-cap path (both {@code BlobController#isRequestSizeOverLimit} for uploads).
+   */
+  void setMaxUploadableSizeMb(Integer maxSizeMb);
+
+  /**
+   * Overrides {@code FilesConfig#getMaxDownloadableFileSizeInMb()} for the lifetime of this app
+   * instance (falls through to the real Service-Discover-backed value when {@code null}). Drives
+   * the 413 download/zip-size-cap path.
+   */
+  void setMaxDownloadableSizeMb(Integer maxSizeMb);
+
+  /**
+   * Overrides {@code FilesConfig#getMaxNumberOfFileVersion()} for the lifetime of this app
+   * instance (falls through to the real Service-Discover-backed value when {@code null}). Drives
+   * the 405 version-cap check that {@code BlobService#uploadFileVersion} re-reads on every call.
+   *
+   * <p><b>Does NOT affect {@code keepVersions}/{@code cloneVersion}'s cap</b> — {@code
+   * NodeDataFetcher} reads its own keep-cap directly from Service-Discover ONCE at construction,
+   * bypassing {@code FilesConfig} entirely; use the builder's {@code withMaxNumberOfVersions(int)}
+   * (set BEFORE {@code build()}) for that path instead.
+   */
+  void setMaxNumberOfVersions(Integer maxVersions);
+
+  /**
+   * Registers (or overwrites) a user-management fixture with explicit status/type/feature-flag
+   * attributes, so {@code AuthenticationHandler}'s non-happy-path branches (inactive user, guest
+   * user, feature-disabled user) become HTTP-reachable. Requires {@code withUserManagement(...)}
+   * to have already been called on the builder (so the in-process UM gRPC server is running); this
+   * just adds/replaces one token's fixture on it.
+   *
+   * @param status a UM status string (e.g. "active", "maintenance", "closed", "locked", ...),
+   *     matched case-insensitively by the production mapper.
+   * @param isGuest true for a GUEST user, false for INTERNAL.
+   * @param filesFeatureEnabled whether "carbonioFeatureFilesEnabled" is present for this user;
+   *     when false, {@code AuthenticationHandler} sees it as absent and treats it as "FALSE".
+   */
+  void registerUser(String cookie, String userId, String status, boolean isGuest, boolean filesFeatureEnabled);
+
+  /**
+   * Mailbox's upload endpoint ({@code POST /service/upload?fmt=raw}, used by {@code
+   * ProcedureService#uploadToModule} for {@code /upload-to}) accepts the upload and reports back
+   * {@code attachmentId} (mirroring the mailbox's real quirky response format).
+   */
+  void mailboxAccepts(String attachmentId);
+
+  /** Mailbox's upload endpoint is unreachable/erroring, simulating the mailbox being down. */
+  void mailboxDown();
+
   /** Resets all mock expectations to a clean baseline between tests. */
   void reset();
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
@@ -85,4 +85,40 @@ public interface TestDataAccess {
    * PublicFindNodesApiIT}'s "hacked page token with wrong signature" test.
    */
   String forgeTamperedPageTokenWithWrongSignature(String wrongSignature);
+
+  /**
+   * Runs one full {@code PurgeService} cycle (equivalent to what its scheduled {@code Runnable}
+   * does: {@code purgeTombstones()} then {@code purgeTrashedNodes(RETENTION_TRASHED_ITEMS_IN_DAYS)}
+   * — see {@code PurgeService#run()}). There is no HTTP trigger for this in production; this is a
+   * deliberate, APPROVED non-HTTP backdoor (see the acceptance-coverage plan §2.5/§10) — it is the
+   * only way the acceptance suite can cover purge logic at all, since a black-box request can never
+   * reach a cron {@code Runnable}. Effects (tombstones cleared, trashed nodes removed) are asserted
+   * via other backdoor accessors ({@link #tombstoneCount()}, {@link #nodeExists(String)}) and/or
+   * HTTP reads, exactly like the white-box {@code PurgeServiceIT}/{@code PurgeTombstonesJobIT}.
+   */
+  void runPurge();
+
+  /**
+   * Simulates a {@code UserStatusChanged} message-broker event for {@code userId}, mirroring the
+   * white-box {@code UserStatusChangedIT}'s direct {@code new
+   * UserStatusChangedConsumer(nodeRepository).doHandle(new UserStatusChanged(userId, status))}.
+   * The effect — the user's nodes' hidden flag flipped when transitioning to/from CLOSED — is
+   * HTTP-observable (hidden nodes are excluded from {@code findNodes}). A deliberate, APPROVED
+   * non-HTTP backdoor (no RabbitMQ trigger exists in the acceptance suite); see plan §2.5/§10.
+   *
+   * @param status a raw message-broker UM status string (e.g. "ACTIVE", "CLOSED", "MAINTENANCE"),
+   *     matched case-insensitively.
+   */
+  void injectUserStatusChanged(String userId, String status);
+
+  /**
+   * Simulates a {@code KeyValueChanged("carbonio-files/max-number-of-versions", newMax)}
+   * message-broker event, mirroring the white-box {@code MaxVersionNumberChangedIT}'s direct
+   * {@code new KeyValueChangedConsumer(fileVersionRepository).doHandle(...)}. Trims the least
+   * recent file versions (never the current version, never a keptForever one) for every node
+   * whose version count exceeds {@code newMax}. The effect is HTTP-observable via {@link
+   * #remainingVersionNumbers(String)} and/or a subsequent download of a trimmed version (404). A
+   * deliberate, APPROVED non-HTTP backdoor; see plan §2.5/§10.
+   */
+  void injectMaxVersionNumberChanged(int newMax);
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
@@ -50,6 +50,14 @@ public interface TestDataAccess {
   void clearTombstones();
 
   /**
+   * Flushes the in-memory file-version cache. Not FK/row-linked state, so {@link
+   * #resetDatabase()} alone does not clean it up between tests; replaces {@code
+   * simulator.clearFileVersionCache()} (used directly by {@code PreviewApiIT}/{@code
+   * ThumbnailApiIT}'s {@code @AfterEach}).
+   */
+  void clearFileVersionCache();
+
+  /**
    * True if a share exists for this node/user pair. Replaces {@code
    * shareRepository.getShare(nodeId, userId).isPresent()}.
    */

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
@@ -6,6 +6,8 @@ package com.zextras.carbonio.files.acceptance.seam;
 
 import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
 
+import java.util.List;
+
 /**
  * Neutral backdoor for seeding and inspecting state without touching the DI container or the
  * ORM directly. Methods return domain-neutral primitives/DTOs only — NO {@code com.google.inject}
@@ -35,8 +37,44 @@ public interface TestDataAccess {
   int tombstoneCount();
 
   /**
+   * Number of tombstone rows for a specific node. There is no public API to read these; replaces
+   * {@code tombstoneRepository.getTombstones().stream().filter(t ->
+   * t.getNodeId().equals(nodeId)).count()}.
+   */
+  int tombstoneCountForNode(String nodeId);
+
+  /**
    * Deletes all tombstone rows. Tombstones are not FK-linked to a node, so {@link
    * #resetDatabase()} alone does not clean them up between tests.
    */
   void clearTombstones();
+
+  /**
+   * True if a share exists for this node/user pair. Replaces {@code
+   * shareRepository.getShare(nodeId, userId).isPresent()}.
+   */
+  boolean shareExists(String nodeId, String userId);
+
+  /**
+   * Remaining version numbers for a node, ascending. There is no public API to read these
+   * directly as a flat list; replaces {@code fileVersionRepository.getFileVersions(nodeId,
+   * List.of(FileVersionSort.VERSION_ASC)).stream().map(FileVersion::getVersion)}.
+   */
+  List<Integer> remainingVersionNumbers(String nodeId);
+
+  /**
+   * Builds a base64-encoded, tampered {@code findNodes} page-token with a fixed keySet/folderId/
+   * sort payload and NO {@code signature} field at all. Decoding it server-side fails signature
+   * verification. Replaces hand-rolled construction of {@code NodeSQLCondition}/{@code
+   * SQLExpression}/{@code SortOrder} (Ebean-era DAL internals) directly in a test body — used by
+   * {@code PublicFindNodesApiIT}'s "hacked page token without signature" test.
+   */
+  String forgeTamperedPageTokenMissingSignature();
+
+  /**
+   * Builds the same tampered cursor as {@link #forgeTamperedPageTokenMissingSignature()} but with
+   * an explicit, incorrect {@code signature} field set to {@code wrongSignature}. Used by {@code
+   * PublicFindNodesApiIT}'s "hacked page token with wrong signature" test.
+   */
+  String forgeTamperedPageTokenWithWrongSignature(String wrongSignature);
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/TestDataAccess.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam;
+
+import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+
+/**
+ * Neutral backdoor for seeding and inspecting state without touching the DI container or the
+ * ORM directly. Methods return domain-neutral primitives/DTOs only — NO {@code com.google.inject}
+ * or {@code io.ebean} types are exposed here.
+ *
+ * <p>Every method is named for the behavioral fact it asserts, not for the mechanism. Prefer
+ * asserting via the API (a GraphQL read-back) wherever the public contract can observe the
+ * state; use these inspectors only where API-level observation is impossible (e.g. tombstones,
+ * purge internals). Add narrow, behavior-named accessors as later migrations discover real
+ * needs — do not expose a raw repository or an Injector here.
+ */
+public interface TestDataAccess {
+
+  /** Fluent seeding — wraps the existing {@link DatabasePopulator}. */
+  DatabasePopulator populator();
+
+  /** Resets the DB to a clean baseline between tests (wraps {@code Simulator.resetDatabase()}). */
+  void resetDatabase();
+
+  /** True if a node row still exists. Replaces {@code nodeRepository.getNode(id).isPresent()}. */
+  boolean nodeExists(String nodeId);
+
+  /**
+   * Number of tombstone rows currently in the database. There is no public API to read these;
+   * replaces {@code tombstoneRepository.getTombstones().size()}.
+   */
+  int tombstoneCount();
+
+  /**
+   * Deletes all tombstone rows. Tombstones are not FK-linked to a node, so {@link
+   * #resetDatabase()} alone does not clean them up between tests.
+   */
+  void clearTombstones();
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestApp.java
@@ -44,6 +44,11 @@ public class GuiceNettyFilesTestApp implements FilesTestApp {
   }
 
   @Override
+  public HttpResponse upload(HttpRequest request) {
+    return TestUtils.sendUpload(request, simulator.getNettyChannel());
+  }
+
+  @Override
   public TestDataAccess backdoor() {
     return testDataAccess;
   }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestApp.java
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam.impl;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.Mocks;
+import com.zextras.carbonio.files.acceptance.seam.TestDataAccess;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+
+/**
+ * {@link FilesTestApp} implementation wrapping the current Guice+Netty {@link Simulator} stack.
+ *
+ * <p>This is the ONLY {@link FilesTestApp} implementation today. When the app is rewritten on
+ * Quarkus, a sibling {@code QuarkusFilesTestApp} will be added in this package and the
+ * acceptance-test bodies will not need to change.
+ *
+ * <p>Build instances via {@link GuiceNettyFilesTestAppBuilder}, not directly.
+ */
+public class GuiceNettyFilesTestApp implements FilesTestApp {
+
+  private final Simulator simulator;
+  private final TestDataAccess testDataAccess;
+  private final Mocks mocks;
+
+  GuiceNettyFilesTestApp(Simulator simulator) {
+    this.simulator = simulator;
+    this.testDataAccess = new GuiceNettyTestDataAccess(simulator);
+    this.mocks = new GuiceNettyMocks(simulator);
+  }
+
+  @Override
+  public HttpResponse send(HttpRequest request) {
+    return TestUtils.sendRequest(request, simulator.getNettyChannel());
+  }
+
+  @Override
+  public HttpResponse sendForm(HttpRequest request) {
+    return TestUtils.sendFormRequest(request, simulator.getNettyChannel());
+  }
+
+  @Override
+  public TestDataAccess backdoor() {
+    return testDataAccess;
+  }
+
+  @Override
+  public Mocks mocks() {
+    return mocks;
+  }
+
+  @Override
+  public void close() {
+    simulator.stopAll();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
@@ -39,8 +39,23 @@ public class GuiceNettyFilesTestAppBuilder {
     return this;
   }
 
+  public GuiceNettyFilesTestAppBuilder withMessageBroker() {
+    simulatorBuilder.withMessageBroker();
+    return this;
+  }
+
   public GuiceNettyFilesTestAppBuilder withStorages() {
     simulatorBuilder.withStorages();
+    return this;
+  }
+
+  public GuiceNettyFilesTestAppBuilder withPreview() {
+    simulatorBuilder.withPreview();
+    return this;
+  }
+
+  public GuiceNettyFilesTestAppBuilder withDocsConnector() {
+    simulatorBuilder.withDocsConnector();
     return this;
   }
 

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam.impl;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+
+import java.util.Map;
+
+/**
+ * Builder for a {@link FilesTestApp} backed by the current Guice+Netty stack.
+ *
+ * <p>Mirrors {@link SimulatorBuilder}'s fluent knobs, added one at a time as acceptance tests
+ * need them (see the Phase-1 migration plan) — do not try to cover every {@code SimulatorBuilder}
+ * knob upfront. Extend with more {@code withXxx()} methods as later migrations require
+ * additional {@code Simulator} capabilities (message broker, preview, docs-connector, etc.).
+ * Never expose {@link Simulator} or {@code com.google.inject.Injector} outside this package.
+ */
+public class GuiceNettyFilesTestAppBuilder {
+
+  private final SimulatorBuilder simulatorBuilder = SimulatorBuilder.aSimulator().init();
+
+  private GuiceNettyFilesTestAppBuilder() {}
+
+  public static GuiceNettyFilesTestAppBuilder aFilesTestApp() {
+    return new GuiceNettyFilesTestAppBuilder();
+  }
+
+  public GuiceNettyFilesTestAppBuilder withDatabase() {
+    simulatorBuilder.withDatabase();
+    return this;
+  }
+
+  public GuiceNettyFilesTestAppBuilder withServiceDiscover() {
+    simulatorBuilder.withServiceDiscover();
+    return this;
+  }
+
+  public GuiceNettyFilesTestAppBuilder withStorages() {
+    simulatorBuilder.withStorages();
+    return this;
+  }
+
+  public GuiceNettyFilesTestAppBuilder withUserManagement(Map<String, String> users) {
+    simulatorBuilder.withUserManagement(users);
+    return this;
+  }
+
+  public FilesTestApp build() {
+    Simulator simulator = simulatorBuilder.build().start();
+    return new GuiceNettyFilesTestApp(simulator);
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
@@ -64,6 +64,23 @@ public class GuiceNettyFilesTestAppBuilder {
     return this;
   }
 
+  public GuiceNettyFilesTestAppBuilder withMailbox() {
+    simulatorBuilder.withMailbox();
+    return this;
+  }
+
+  /**
+   * Overrides {@code max-number-of-versions} BEFORE the app is built. Required for {@code
+   * keepVersions}/{@code cloneVersion}'s cap ({@code NodeDataFetcher} reads it directly from
+   * Service-Discover once at construction, bypassing {@code FilesConfig}) — a post-build {@code
+   * Mocks#setMaxNumberOfVersions} call would be too late. For the {@code /upload-version} 405
+   * cap, use {@code Mocks#setMaxNumberOfVersions} instead (re-read live on every call).
+   */
+  public GuiceNettyFilesTestAppBuilder withMaxNumberOfVersions(int maxVersions) {
+    simulatorBuilder.withMaxNumberOfVersions(maxVersions);
+    return this;
+  }
+
   public FilesTestApp build() {
     Simulator simulator = simulatorBuilder.build().start();
     // Transport selection WITHOUT touching any test body: opt in to the real-HTTP transport

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyFilesTestAppBuilder.java
@@ -66,6 +66,13 @@ public class GuiceNettyFilesTestAppBuilder {
 
   public FilesTestApp build() {
     Simulator simulator = simulatorBuilder.build().start();
+    // Transport selection WITHOUT touching any test body: opt in to the real-HTTP transport
+    // (Option B) with -Dfiles.test.transport=http; the DEFAULT stays the embedded EmbeddedChannel
+    // transport, so plain `mvn verify` behavior is unchanged. Both drive the SAME acceptance-test
+    // bodies through the same neutral FilesTestApp seam.
+    if ("http".equalsIgnoreCase(System.getProperty("files.test.transport"))) {
+      return new RealHttpFilesTestApp(simulator);
+    }
     return new GuiceNettyFilesTestApp(simulator);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam.impl;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.acceptance.seam.Mocks;
+import com.zextras.carbonio.files.utilities.StoragesMockHelper;
+
+import java.util.List;
+
+/**
+ * {@link Mocks} implementation delegating to {@link StoragesMockHelper} and the {@link
+ * Simulator}'s MockServer clients. {@code org.mockserver.*} types stay confined to this class and
+ * to {@link StoragesMockHelper} — never in a test body.
+ */
+class GuiceNettyMocks implements Mocks {
+
+  private final Simulator simulator;
+  private final StoragesMockHelper storagesMockHelper;
+
+  GuiceNettyMocks(Simulator simulator) {
+    this.simulator = simulator;
+    this.storagesMockHelper = new StoragesMockHelper(simulator.getStoragesMock());
+  }
+
+  @Override
+  public void storagesBulkDeleteSucceeds(List<String> failedIds) {
+    storagesMockHelper.bulkDelete(failedIds);
+  }
+
+  @Override
+  public void storagesBulkDeleteFails() {
+    storagesMockHelper.bulkDeleteError();
+  }
+
+  @Override
+  public void storagesBulkDeleteReturnsNullResponse() {
+    storagesMockHelper.bulkDeleteNullResponse();
+  }
+
+  @Override
+  public void reset() {
+    simulator.reinitializeMocks();
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
@@ -9,6 +9,7 @@ import com.zextras.carbonio.files.acceptance.seam.Mocks;
 import com.zextras.carbonio.files.config.FilesConfig;
 import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.StoragesMockHelper;
+import com.zextras.carbonio.user_management.sdk.grpc.UserTypeProto;
 import io.netty.handler.codec.http.HttpMethod;
 import org.mockserver.model.BinaryBody;
 import org.mockserver.model.HttpError;
@@ -165,5 +166,93 @@ class GuiceNettyMocks implements Mocks {
   @Override
   public void reset() {
     simulator.reinitializeMocks();
+  }
+
+  @Override
+  public void storagesUploadSucceeds() {
+    storagesMockHelper.uploadSucceeds();
+  }
+
+  @Override
+  public void storagesUploadFails() {
+    storagesMockHelper.uploadFails();
+  }
+
+  @Override
+  public void storagesVerifyMissing() {
+    storagesMockHelper.verifyMissing();
+  }
+
+  @Override
+  public void storagesCopySucceeds() {
+    storagesMockHelper.copySucceeds();
+  }
+
+  @Override
+  public void storagesCopyFails() {
+    storagesMockHelper.copyFails();
+  }
+
+  @Override
+  public void verifyStoragesUploaded(String nodeId, int version) {
+    storagesMockHelper.verifyUploaded(nodeId, version);
+  }
+
+  @Override
+  public void setMaxUploadableSizeMb(Integer maxSizeMb) {
+    ((MockFilesConfig) simulator.getInjector().getInstance(FilesConfig.class))
+        .setMaxUploadableFileSizeInMb(maxSizeMb);
+  }
+
+  @Override
+  public void setMaxDownloadableSizeMb(Integer maxSizeMb) {
+    ((MockFilesConfig) simulator.getInjector().getInstance(FilesConfig.class))
+        .setMaxDownloadableFileSizeInMb(maxSizeMb);
+  }
+
+  @Override
+  public void setMaxNumberOfVersions(Integer maxVersions) {
+    ((MockFilesConfig) simulator.getInjector().getInstance(FilesConfig.class))
+        .setMaxNumberOfFileVersion(maxVersions);
+  }
+
+  @Override
+  public void registerUser(
+      String cookie, String userId, String status, boolean isGuest, boolean filesFeatureEnabled) {
+    simulator
+        .getUserManagementService()
+        .registerToken(
+            cookie,
+            userId,
+            status,
+            isGuest ? UserTypeProto.GUEST : UserTypeProto.INTERNAL,
+            filesFeatureEnabled);
+  }
+
+  @Override
+  public void mailboxAccepts(String attachmentId) {
+    simulator
+        .getMailboxMock()
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.POST.toString())
+                .withPath("/service/upload")
+                .withQueryStringParameter(Parameter.param("fmt", "raw")))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody("200,'null','" + attachmentId + "'"));
+  }
+
+  @Override
+  public void mailboxDown() {
+    simulator
+        .getMailboxMock()
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.POST.toString())
+                .withPath("/service/upload")
+                .withQueryStringParameter(Parameter.param("fmt", "raw")))
+        .respond(HttpResponse.response().withStatusCode(500));
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
@@ -6,7 +6,17 @@ package com.zextras.carbonio.files.acceptance.seam.impl;
 
 import com.zextras.carbonio.files.Simulator;
 import com.zextras.carbonio.files.acceptance.seam.Mocks;
+import com.zextras.carbonio.files.config.FilesConfig;
+import com.zextras.carbonio.files.utilities.MockFilesConfig;
 import com.zextras.carbonio.files.utilities.StoragesMockHelper;
+import io.netty.handler.codec.http.HttpMethod;
+import org.mockserver.model.BinaryBody;
+import org.mockserver.model.HttpError;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
+import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
 
 import java.util.List;
 
@@ -38,6 +48,118 @@ class GuiceNettyMocks implements Mocks {
   @Override
   public void storagesBulkDeleteReturnsNullResponse() {
     storagesMockHelper.bulkDeleteNullResponse();
+  }
+
+  @Override
+  public void setNotificationsEnabled(boolean enabled) {
+    ((MockFilesConfig) simulator.getInjector().getInstance(FilesConfig.class))
+        .setAreNotificationsEnabled(enabled);
+  }
+
+  @Override
+  public void userManagementDown() {
+    simulator.shutdownUserManagementServer();
+  }
+
+  @Override
+  public void storagesLive() {
+    simulator
+        .getStoragesMock()
+        .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+        .respond(HttpResponse.response().withStatusCode(200));
+  }
+
+  @Override
+  public void storagesUnreachable() {
+    simulator
+        .getStoragesMock()
+        .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/health/live"))
+        .respond(HttpResponse.response().withStatusCode(502));
+  }
+
+  @Override
+  public void previewReady() {
+    simulator
+        .getPreviewMock()
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/health/ready/"))
+        .respond(HttpResponse.response().withStatusCode(200));
+  }
+
+  @Override
+  public void docsConnectorLive() {
+    simulator
+        .getDocsConnectorMock()
+        .when(
+            HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/q/health/live"))
+        .respond(HttpResponse.response().withStatusCode(200));
+  }
+
+  @Override
+  public void storagesServesBlob(String nodeId, int version) {
+    storagesMockHelper.getBlob(nodeId, version);
+  }
+
+  @Override
+  public void storagesDownloadConnectionDrops() {
+    simulator
+        .getStoragesMock()
+        .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/download"))
+        .error(HttpError.error().withDropConnection(true));
+  }
+
+  @Override
+  public void verifyStoragesDownloaded(String nodeId, int version) {
+    simulator
+        .getStoragesMock()
+        .verify(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/download")
+                .withQueryStringParameter(Parameter.param("node", nodeId))
+                .withQueryStringParameter(Parameter.param("version", String.valueOf(version)))
+                .withQueryStringParameter(Parameter.param("type", "files")),
+            VerificationTimes.once());
+  }
+
+  @Override
+  public void verifyStoragesNeverDownloaded() {
+    simulator
+        .getStoragesMock()
+        .verify(
+            HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/download"),
+            VerificationTimes.never());
+  }
+
+  @Override
+  public String previewServes(String pathEndpoint, String fileOwnerId, byte[] content, String mediaType) {
+    HttpRequest request =
+        HttpRequest.request()
+            .withMethod(HttpMethod.GET.toString())
+            .withPath(pathEndpoint)
+            .withQueryStringParameter(new Parameter("service_type", "files"))
+            .withHeader("FileOwnerId", fileOwnerId);
+
+    if (pathEndpoint.contains("document")) {
+      request.withQueryStringParameter(new Parameter("lang_tag", "en"));
+    }
+
+    return simulator
+        .getPreviewMock()
+        .when(request)
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(new BinaryBody(content))
+                .withContentType(MediaType.parse(mediaType)))[0]
+        .getId();
+  }
+
+  @Override
+  public void verifyPreviewServed(String expectationId) {
+    simulator.getPreviewMock().verify(expectationId).clear(expectationId);
   }
 
   @Override

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyMocks.java
@@ -19,6 +19,8 @@ import org.mockserver.model.MediaType;
 import org.mockserver.model.Parameter;
 import org.mockserver.verify.VerificationTimes;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -254,5 +256,51 @@ class GuiceNettyMocks implements Mocks {
                 .withPath("/service/upload")
                 .withQueryStringParameter(Parameter.param("fmt", "raw")))
         .respond(HttpResponse.response().withStatusCode(500));
+  }
+
+  @Override
+  public void previewFails(String pathEndpoint) {
+    HttpRequest request =
+        HttpRequest.request()
+            .withMethod(HttpMethod.GET.toString())
+            .withPath(pathEndpoint)
+            .withQueryStringParameter(new Parameter("service_type", "files"));
+
+    if (pathEndpoint.contains("document")) {
+      request.withQueryStringParameter(new Parameter("lang_tag", "en"));
+    }
+
+    simulator.getPreviewMock().when(request).respond(HttpResponse.response().withStatusCode(500));
+  }
+
+  @Override
+  public void serviceDiscoverReturns(String key, String rawValue) {
+    String encodedValue =
+        Base64.getEncoder().encodeToString(rawValue.getBytes(StandardCharsets.UTF_8));
+
+    simulator
+        .getServiceDiscoverMock()
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/" + key))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(200)
+                .withBody(
+                    String.format(
+                        "[{\"Key\":\"%s\",\"Value\":\"%s\"}]",
+                        "carbonio-files/" + key, encodedValue)));
+  }
+
+  @Override
+  public void serviceDiscoverConfigDown(String key) {
+    simulator
+        .getServiceDiscoverMock()
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/v1/kv/carbonio-files/" + key))
+        .error(HttpError.error().withDropConnection(true));
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
@@ -19,9 +19,16 @@ import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
+import com.zextras.carbonio.files.message_broker.consumers.KeyValueChangedConsumer;
+import com.zextras.carbonio.files.message_broker.consumers.UserStatusChangedConsumer;
+import com.zextras.carbonio.files.tasks.PurgeService;
+import com.zextras.carbonio.message_broker.events.services.mailbox.UserStatusChanged;
+import com.zextras.carbonio.message_broker.events.services.mailbox.enums.UserStatus;
+import com.zextras.carbonio.message_broker.events.services.service_discover.KeyValueChanged;
 
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
 
@@ -43,6 +50,7 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
   private final ShareRepository shareRepository;
   private final FileVersionRepository fileVersionRepository;
   private final LinkRepository linkRepository;
+  private final PurgeService purgeService;
 
   GuiceNettyTestDataAccess(Simulator simulator) {
     this.simulator = simulator;
@@ -52,6 +60,7 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
     this.shareRepository = injector.getInstance(ShareRepository.class);
     this.fileVersionRepository = injector.getInstance(FileVersionRepository.class);
     this.linkRepository = injector.getInstance(LinkRepository.class);
+    this.purgeService = injector.getInstance(PurgeService.class);
   }
 
   @Override
@@ -122,6 +131,28 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
     return Base64.getEncoder()
         .encodeToString(
             buildTamperedPageTokenJson(wrongSignature).getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public void runPurge() {
+    // PurgeService#purgeTombstones()/#purgeTrashedNodes(long) are package-private (only directly
+    // callable from com.zextras.carbonio.files.tasks, as the white-box PurgeServiceIT/
+    // PurgeTombstonesJobIT do). run() — its public Runnable entry point, which invokes both with
+    // the production retention constant — is the sanctioned way to trigger the same behaviour
+    // from this (different) package without a reflection/package-bridge workaround.
+    purgeService.run();
+  }
+
+  @Override
+  public void injectUserStatusChanged(String userId, String status) {
+    new UserStatusChangedConsumer(nodeRepository)
+        .doHandle(new UserStatusChanged(userId, UserStatus.valueOf(status.toUpperCase(Locale.ROOT))));
+  }
+
+  @Override
+  public void injectMaxVersionNumberChanged(int newMax) {
+    new KeyValueChangedConsumer(fileVersionRepository)
+        .doHandle(new KeyValueChanged("carbonio-files/max-number-of-versions", String.valueOf(newMax)));
   }
 
   /**

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
@@ -15,6 +15,7 @@ import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSQLC
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SQLExpression;
 import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SortOrder;
 import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.LinkRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
@@ -30,9 +31,9 @@ import java.nio.charset.StandardCharsets;
  * {@link Simulator} itself. Never expose {@link Injector} or repository types through the {@link
  * TestDataAccess} interface.
  *
- * <p>Constructs {@link DatabasePopulator} via its existing {@code Injector} constructor for now;
- * a later migration (Phase-1 Task 2) changes {@link DatabasePopulator} to take repositories
- * directly, at which point only this class changes.
+ * <p>Constructs {@link DatabasePopulator} via its neutral repositories constructor, resolving the
+ * four repositories from the injector here (the sanctioned place for {@code
+ * injector.getInstance(...)}) so {@link DatabasePopulator} itself no longer depends on Guice.
  */
 class GuiceNettyTestDataAccess implements TestDataAccess {
 
@@ -41,6 +42,7 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
   private final TombstoneRepository tombstoneRepository;
   private final ShareRepository shareRepository;
   private final FileVersionRepository fileVersionRepository;
+  private final LinkRepository linkRepository;
 
   GuiceNettyTestDataAccess(Simulator simulator) {
     this.simulator = simulator;
@@ -49,11 +51,13 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
     this.tombstoneRepository = injector.getInstance(TombstoneRepository.class);
     this.shareRepository = injector.getInstance(ShareRepository.class);
     this.fileVersionRepository = injector.getInstance(FileVersionRepository.class);
+    this.linkRepository = injector.getInstance(LinkRepository.class);
   }
 
   @Override
   public DatabasePopulator populator() {
-    return DatabasePopulator.aNodePopulator(simulator.getInjector());
+    return new DatabasePopulator(
+        nodeRepository, fileVersionRepository, linkRepository, shareRepository);
   }
 
   @Override

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
@@ -4,12 +4,25 @@
 
 package com.zextras.carbonio.files.acceptance.seam.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
 import com.zextras.carbonio.files.Simulator;
 import com.zextras.carbonio.files.acceptance.seam.TestDataAccess;
 import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.FileVersionSort;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.NodeSQLCondition;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SQLExpression;
+import com.zextras.carbonio.files.dal.repositories.impl.ebean.utilities.SortOrder;
+import com.zextras.carbonio.files.dal.repositories.interfaces.FileVersionRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.ShareRepository;
 import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.nio.charset.StandardCharsets;
 
 /**
  * {@link TestDataAccess} implementation resolving repositories from the {@link Simulator}'s Guice
@@ -26,12 +39,16 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
   private final Simulator simulator;
   private final NodeRepository nodeRepository;
   private final TombstoneRepository tombstoneRepository;
+  private final ShareRepository shareRepository;
+  private final FileVersionRepository fileVersionRepository;
 
   GuiceNettyTestDataAccess(Simulator simulator) {
     this.simulator = simulator;
     Injector injector = simulator.getInjector();
     this.nodeRepository = injector.getInstance(NodeRepository.class);
     this.tombstoneRepository = injector.getInstance(TombstoneRepository.class);
+    this.shareRepository = injector.getInstance(ShareRepository.class);
+    this.fileVersionRepository = injector.getInstance(FileVersionRepository.class);
   }
 
   @Override
@@ -55,11 +72,100 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
   }
 
   @Override
+  public int tombstoneCountForNode(String nodeId) {
+    return (int)
+        tombstoneRepository.getTombstones().stream()
+            .filter(t -> t.getNodeId().equals(nodeId))
+            .count();
+  }
+
+  @Override
   public void clearTombstones() {
     tombstoneRepository
         .getTombstones()
         .forEach(
             t ->
                 tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
+  }
+
+  @Override
+  public boolean shareExists(String nodeId, String userId) {
+    return shareRepository.getShare(nodeId, userId).isPresent();
+  }
+
+  @Override
+  public List<Integer> remainingVersionNumbers(String nodeId) {
+    return fileVersionRepository
+        .getFileVersions(nodeId, List.of(FileVersionSort.VERSION_ASC))
+        .stream()
+        .map(fv -> fv.getVersion())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String forgeTamperedPageTokenMissingSignature() {
+    return Base64.getEncoder()
+        .encodeToString(buildTamperedPageTokenJson(null).getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public String forgeTamperedPageTokenWithWrongSignature(String wrongSignature) {
+    return Base64.getEncoder()
+        .encodeToString(
+            buildTamperedPageTokenJson(wrongSignature).getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Builds the raw (pre-base64) JSON body of a tampered {@code findNodes} page-token. The
+   * keySet/folderId/sort/limit values are fixture data (arbitrary but stable) built from Ebean-era
+   * DAL internals ({@link NodeSQLCondition}/{@link SQLExpression}/{@link SortOrder}) — confined to
+   * this impl class so no test body needs to import them. When {@code signature} is {@code null}
+   * the JSON has no "signature" field at all (missing-signature case); otherwise it is prepended
+   * as an explicit, deliberately-incorrect field (wrong-signature case).
+   */
+  private static String buildTamperedPageTokenJson(String signature) {
+    SQLExpression keySet =
+        SQLExpression.or(
+            List.of(
+                new NodeSQLCondition("node_category", SortOrder.ASCENDING, 1),
+                SQLExpression.and(
+                    List.of(
+                        new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
+                        new NodeSQLCondition("name", SortOrder.ASCENDING, "folder child"))),
+                SQLExpression.and(
+                    List.of(
+                        new NodeSQLCondition("node_category", SortOrder.EQUAL, 1),
+                        new NodeSQLCondition("name", SortOrder.EQUAL, "folder child"),
+                        new NodeSQLCondition(
+                            "node_id",
+                            SortOrder.ASCENDING,
+                            "88888888-8888-8888-8888-888888888888")))));
+
+    final String jsonKeySet;
+    try {
+      jsonKeySet = new ObjectMapper().writeValueAsString(keySet);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize tampered page-token keySet", e);
+    }
+
+    String signatureField = signature == null ? "" : "\"signature\": \"" + signature + "\",\n  ";
+
+    return String.format(
+        """
+        {
+          %s"limit": 1,
+          "keywords": [],
+          "keySet": %s,
+          "sort": "NAME_ASC",
+          "flagged": null,
+          "folderId": "77777777-7777-7777-7777-777777777777",
+          "cascade": null,
+          "sharedWithMe": null,
+          "sharedByMe": null,
+          "directShare": null,
+          "nodeType": null,
+          "ownerId": null
+        }""",
+        signatureField, jsonKeySet);
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam.impl;
+
+import com.google.inject.Injector;
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.acceptance.seam.TestDataAccess;
+import com.zextras.carbonio.files.api.utilities.DatabasePopulator;
+import com.zextras.carbonio.files.dal.repositories.interfaces.NodeRepository;
+import com.zextras.carbonio.files.dal.repositories.interfaces.TombstoneRepository;
+
+/**
+ * {@link TestDataAccess} implementation resolving repositories from the {@link Simulator}'s Guice
+ * {@link Injector} — the ONE sanctioned {@code injector.getInstance(...)} call site outside
+ * {@link Simulator} itself. Never expose {@link Injector} or repository types through the {@link
+ * TestDataAccess} interface.
+ *
+ * <p>Constructs {@link DatabasePopulator} via its existing {@code Injector} constructor for now;
+ * a later migration (Phase-1 Task 2) changes {@link DatabasePopulator} to take repositories
+ * directly, at which point only this class changes.
+ */
+class GuiceNettyTestDataAccess implements TestDataAccess {
+
+  private final Simulator simulator;
+  private final NodeRepository nodeRepository;
+  private final TombstoneRepository tombstoneRepository;
+
+  GuiceNettyTestDataAccess(Simulator simulator) {
+    this.simulator = simulator;
+    Injector injector = simulator.getInjector();
+    this.nodeRepository = injector.getInstance(NodeRepository.class);
+    this.tombstoneRepository = injector.getInstance(TombstoneRepository.class);
+  }
+
+  @Override
+  public DatabasePopulator populator() {
+    return DatabasePopulator.aNodePopulator(simulator.getInjector());
+  }
+
+  @Override
+  public void resetDatabase() {
+    simulator.resetDatabase();
+  }
+
+  @Override
+  public boolean nodeExists(String nodeId) {
+    return nodeRepository.getNode(nodeId).isPresent();
+  }
+
+  @Override
+  public int tombstoneCount() {
+    return tombstoneRepository.getTombstones().size();
+  }
+
+  @Override
+  public void clearTombstones() {
+    tombstoneRepository
+        .getTombstones()
+        .forEach(
+            t ->
+                tombstoneRepository.deleteTombstonesByNodeAndVersion(t.getNodeId(), t.getVersion()));
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/GuiceNettyTestDataAccess.java
@@ -89,6 +89,11 @@ class GuiceNettyTestDataAccess implements TestDataAccess {
   }
 
   @Override
+  public void clearFileVersionCache() {
+    simulator.clearFileVersionCache();
+  }
+
+  @Override
   public boolean shareExists(String nodeId, String userId) {
     return shareRepository.getShare(nodeId, userId).isPresent();
   }

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/RealHttpFilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/RealHttpFilesTestApp.java
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.acceptance.seam.impl;
+
+import com.zextras.carbonio.files.Simulator;
+import com.zextras.carbonio.files.TestUtils;
+import com.zextras.carbonio.files.acceptance.seam.FilesTestApp;
+import com.zextras.carbonio.files.acceptance.seam.Mocks;
+import com.zextras.carbonio.files.acceptance.seam.TestDataAccess;
+import com.zextras.carbonio.files.netty.HttpRoutingHandler;
+import com.zextras.carbonio.files.utilities.http.HttpRequest;
+import com.zextras.carbonio.files.utilities.http.HttpResponse;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpServerCodec;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link FilesTestApp} implementation that boots the REAL Netty server on an ephemeral port
+ * (transport Option B) and drives it over a genuine HTTP socket with {@link
+ * java.net.http.HttpClient}. This is the transport whose shape transfers unchanged to the future
+ * Quarkus impl: the acceptance-test bodies never learn which transport they got — they only see
+ * the neutral {@link FilesTestApp}/{@link TestDataAccess}/{@link Mocks} facades.
+ *
+ * <p>It reuses the exact same {@link Simulator} wiring as {@link GuiceNettyFilesTestApp} (Guice
+ * injector + Testcontainers + MockServer + in-process gRPC UM). The external-dependency fakes work
+ * identically over a real socket because {@code MockFilesConfig}/system-properties point the app's
+ * collaborators at the fakes regardless of how the request reaches the {@link HttpRoutingHandler}.
+ *
+ * <p>Selected via {@code -Dfiles.test.transport=http}; otherwise the default embedded
+ * {@link GuiceNettyFilesTestApp} (EmbeddedChannel) is used. See {@link GuiceNettyFilesTestAppBuilder}.
+ */
+public class RealHttpFilesTestApp implements FilesTestApp {
+
+  private final Simulator simulator;
+  private final TestDataAccess testDataAccess;
+  private final Mocks mocks;
+
+  private final EventLoopGroup bossGroup;
+  private final EventLoopGroup workerGroup;
+  private final Channel serverChannel;
+  private final HttpClient httpClient;
+  private final int port;
+
+  RealHttpFilesTestApp(Simulator simulator) {
+    this.simulator = simulator;
+    this.testDataAccess = new GuiceNettyTestDataAccess(simulator);
+    this.mocks = new GuiceNettyMocks(simulator);
+
+    // ---------------------------------------------------------------------------------------
+    // Mirror of NettyServer's pipeline (boot module); keep in sync — only HttpServerCodec +
+    // HttpRoutingHandler live here, per-route aggregators (HttpObjectAggregator/ChunkedWriteHandler)
+    // are added INSIDE HttpRoutingHandler per matched endpoint. This is the small, top-level-only
+    // drift risk the user accepted by implementing Option B as a test-only server rather than
+    // relocating NettyServer into a shared module.
+    //
+    // HttpRoutingHandler is @Sharable (see the class annotation), exactly as production relies on:
+    // NettyServer resolves it once from the injector and reuses the single instance across all
+    // channels. We do the same here. Every request closes its channel after the response
+    // (all controllers write with ChannelFutureListener.CLOSE / Connection: close), so there is no
+    // HTTP keep-alive reuse and thus no per-request pipeline-mutation clash.
+    // ---------------------------------------------------------------------------------------
+    final HttpRoutingHandler httpRoutingHandler =
+        simulator.getInjector().getInstance(HttpRoutingHandler.class);
+
+    this.bossGroup = new NioEventLoopGroup(1);
+    this.workerGroup = new NioEventLoopGroup();
+
+    try {
+      ServerBootstrap bootstrap = new ServerBootstrap();
+      bootstrap
+          .group(bossGroup, workerGroup)
+          .channel(NioServerSocketChannel.class)
+          .childHandler(
+              new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                  ChannelPipeline channelPipeline = ch.pipeline();
+                  channelPipeline.addLast(new HttpServerCodec());
+                  channelPipeline.addLast("router-handler", httpRoutingHandler);
+                }
+              })
+          .option(ChannelOption.SO_BACKLOG, 128)
+          .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+      // Bind on loopback, ephemeral port (0 → OS-assigned).
+      this.serverChannel = bootstrap.bind("localhost", 0).sync().channel();
+      this.port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      workerGroup.shutdownGracefully();
+      bossGroup.shutdownGracefully();
+      throw new IllegalStateException("Failed to bind the test Files server on an ephemeral port", e);
+    }
+
+    // Force HTTP/1.1: the Netty server speaks HTTP/1.1 only; the default HttpClient would attempt
+    // an h2c upgrade the server does not understand.
+    this.httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+  }
+
+  @Override
+  public HttpResponse send(HttpRequest request) {
+    // Match TestUtils.sendRequest: the body is wrapped as {"query":"<body>"} (queryPayload).
+    // All send() POSTs target the GraphQL endpoints, which carry this JSON body; GET requests
+    // (downloads/previews/health) ignore the request body server-side, so we send them without a
+    // body — this is behaviorally identical to the embedded path (whose wrapped GET body the
+    // download pipeline discards) and avoids splitting HttpContent past the non-aggregated
+    // download handlers over a real socket.
+    final String wrappedBody = TestUtils.queryPayload(request.getBodyPayload().orElse(""));
+    return exchange(request, wrappedBody);
+  }
+
+  @Override
+  public HttpResponse sendForm(HttpRequest request) {
+    // Match TestUtils.sendFormRequest: the pre-built application/x-www-form-urlencoded body is
+    // forwarded verbatim (NO queryPayload wrapping).
+    return exchange(request, request.getBodyPayload().orElse(""));
+  }
+
+  private HttpResponse exchange(HttpRequest request, String body) {
+    final java.net.http.HttpRequest.Builder builder =
+        java.net.http.HttpRequest.newBuilder(URI.create("http://localhost:" + port + request.getEndpoint()))
+            .timeout(Duration.ofSeconds(60));
+
+    request
+        .getHeaders()
+        .ifPresent(headers -> headers.forEach(h -> builder.header(h.getKey(), h.getValue())));
+    request.getCookie().ifPresent(cookie -> builder.header("Cookie", cookie));
+
+    final String method = request.getMethod();
+    if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+      builder.method(method, BodyPublishers.noBody());
+    } else {
+      final BodyPublisher publisher =
+          BodyPublishers.ofString(body, StandardCharsets.UTF_8);
+      builder.method(method, publisher);
+    }
+
+    try {
+      final java.net.http.HttpResponse<String> response =
+          httpClient.send(builder.build(), BodyHandlers.ofString(StandardCharsets.UTF_8));
+      return HttpResponse.of(response.statusCode(), flattenHeaders(response), response.body());
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Real-HTTP request to " + request.getMethod() + " " + request.getEndpoint() + " failed", e);
+    }
+  }
+
+  private static List<Map.Entry<String, String>> flattenHeaders(
+      java.net.http.HttpResponse<String> response) {
+    final List<Map.Entry<String, String>> entries = new ArrayList<>();
+    response
+        .headers()
+        .map()
+        .forEach((name, values) -> values.forEach(value -> entries.add(Map.entry(name, value))));
+    return entries;
+  }
+
+  @Override
+  public TestDataAccess backdoor() {
+    return testDataAccess;
+  }
+
+  @Override
+  public Mocks mocks() {
+    return mocks;
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (serverChannel != null) {
+        serverChannel.close().sync();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } finally {
+      workerGroup.shutdownGracefully();
+      bossGroup.shutdownGracefully();
+      simulator.stopAll();
+    }
+  }
+}

--- a/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/RealHttpFilesTestApp.java
+++ b/core/src/test/java/com/zextras/carbonio/files/acceptance/seam/impl/RealHttpFilesTestApp.java
@@ -136,6 +136,35 @@ public class RealHttpFilesTestApp implements FilesTestApp {
     return exchange(request, request.getBodyPayload().orElse(""));
   }
 
+  @Override
+  public HttpResponse upload(HttpRequest request) {
+    // Match TestUtils.sendUpload: raw bytes over the wire, custom headers forwarded as-is, NO
+    // queryPayload wrapping. java.net.http.HttpClient computes Content-Length itself from the
+    // BodyPublisher (Content-Length is a restricted header it will not let us set explicitly),
+    // which mirrors the embedded transport's "always computed from the real bytes" behaviour.
+    final byte[] body = request.getBinaryBody().orElse(new byte[0]);
+
+    final java.net.http.HttpRequest.Builder builder =
+        java.net.http.HttpRequest.newBuilder(URI.create("http://localhost:" + port + request.getEndpoint()))
+            .timeout(Duration.ofSeconds(60));
+
+    request
+        .getHeaders()
+        .ifPresent(headers -> headers.forEach(h -> builder.header(h.getKey(), h.getValue())));
+    request.getCookie().ifPresent(cookie -> builder.header("Cookie", cookie));
+
+    builder.method(request.getMethod(), BodyPublishers.ofByteArray(body));
+
+    try {
+      final java.net.http.HttpResponse<String> response =
+          httpClient.send(builder.build(), BodyHandlers.ofString(StandardCharsets.UTF_8));
+      return HttpResponse.of(response.statusCode(), flattenHeaders(response), response.body());
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Real-HTTP upload to " + request.getMethod() + " " + request.getEndpoint() + " failed", e);
+    }
+  }
+
   private HttpResponse exchange(HttpRequest request, String body) {
     final java.net.http.HttpRequest.Builder builder =
         java.net.http.HttpRequest.newBuilder(URI.create("http://localhost:" + port + request.getEndpoint()))

--- a/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/utilities/DatabasePopulator.java
@@ -29,15 +29,34 @@ public class DatabasePopulator {
   static LinkRepository linkRepository;
   static ShareRepository shareRepository;
 
-  public DatabasePopulator(Injector injector) {
-    nodeRepository = injector.getInstance(NodeRepository.class);
-    fileVersionRepository = injector.getInstance(FileVersionRepository.class);
-    linkRepository = injector.getInstance(LinkRepository.class);
-    shareRepository = injector.getInstance(ShareRepository.class);
+  public DatabasePopulator(
+      NodeRepository nodeRepository,
+      FileVersionRepository fileVersionRepository,
+      LinkRepository linkRepository,
+      ShareRepository shareRepository) {
+    DatabasePopulator.nodeRepository = nodeRepository;
+    DatabasePopulator.fileVersionRepository = fileVersionRepository;
+    DatabasePopulator.linkRepository = linkRepository;
+    DatabasePopulator.shareRepository = shareRepository;
   }
 
+  /**
+   * Legacy factory kept for backward compatibility with the white-box ITs that are NOT migrated
+   * to the {@code acceptance/} seam ({@code tasks/PurgeServiceIT}, {@code
+   * tasks/PurgeTombstonesJobIT}, {@code message_broker/it/*}). This is the ONLY place in this
+   * class that touches Guice; every other constructor/method is framework-neutral.
+   *
+   * @deprecated New call sites should use {@link #DatabasePopulator(NodeRepository,
+   *     FileVersionRepository, LinkRepository, ShareRepository)} (e.g. via the {@code
+   *     acceptance/seam} backdoor), which does not depend on {@link Injector}.
+   */
+  @Deprecated
   public static DatabasePopulator aNodePopulator(Injector injector) {
-    return new DatabasePopulator(injector);
+    return new DatabasePopulator(
+        injector.getInstance(NodeRepository.class),
+        injector.getInstance(FileVersionRepository.class),
+        injector.getInstance(LinkRepository.class),
+        injector.getInstance(ShareRepository.class));
   }
 
   public DatabasePopulator addNode(PopulatorNode node) {

--- a/core/src/test/java/com/zextras/carbonio/files/api/utilities/GraphqlCommandBuilder.java
+++ b/core/src/test/java/com/zextras/carbonio/files/api/utilities/GraphqlCommandBuilder.java
@@ -45,6 +45,18 @@ public class GraphqlCommandBuilder {
     return this;
   }
 
+  /**
+   * Emits a GraphQL enum argument from its raw literal name (unquoted), e.g. {@code
+   * withEnumLiteral("sort", "NAME_ASC")}. Use this instead of {@link #withEnum(String, Enum)} when
+   * the caller must not depend on a production Java enum type (e.g. the {@code sort} argument is
+   * part of the GraphQL API contract, not an internal implementation detail).
+   */
+  public GraphqlCommandBuilder withEnumLiteral(String key, String enumLiteral) {
+    query.append(key).append(": ").append(enumLiteral).append(", ");
+    this.hasArguments = true;
+    return this;
+  }
+
   public GraphqlCommandBuilder withListOfStrings(String key, String[] values) {
     query.append(key).append(": [");
     for (String value : values) {

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/MockFilesConfig.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/MockFilesConfig.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.files.utilities;
 
 import com.zextras.carbonio.files.config.FilesConfig;
+import java.util.Optional;
 
 /**
  * Here one can override the standard behaviour of FilesConfigImpl to mock or otherwise differentiate
@@ -12,6 +13,11 @@ import com.zextras.carbonio.files.config.FilesConfig;
  */
 public class MockFilesConfig extends FilesConfig {
     boolean areNotificationsEnabled = true;
+
+    // null = fall through to the real Service-Discover-backed FilesConfig behaviour.
+    private Integer maxUploadableFileSizeInMb;
+    private Integer maxDownloadableFileSizeInMb;
+    private Integer maxNumberOfFileVersion;
 
     @Override
     public String getPageTokenSecretKey() {
@@ -26,5 +32,39 @@ public class MockFilesConfig extends FilesConfig {
     // Useful for testing
     public void setAreNotificationsEnabled(boolean areNotificationsEnabled) {
         this.areNotificationsEnabled = areNotificationsEnabled;
+    }
+
+    @Override
+    public Optional<Integer> getMaxUploadableFileSizeInMb() {
+        return maxUploadableFileSizeInMb != null
+            ? Optional.of(maxUploadableFileSizeInMb)
+            : super.getMaxUploadableFileSizeInMb();
+    }
+
+    // Useful for testing. Pass null to fall back to the real Service-Discover-backed value.
+    public void setMaxUploadableFileSizeInMb(Integer maxUploadableFileSizeInMb) {
+        this.maxUploadableFileSizeInMb = maxUploadableFileSizeInMb;
+    }
+
+    @Override
+    public Optional<Integer> getMaxDownloadableFileSizeInMb() {
+        return maxDownloadableFileSizeInMb != null
+            ? Optional.of(maxDownloadableFileSizeInMb)
+            : super.getMaxDownloadableFileSizeInMb();
+    }
+
+    // Useful for testing. Pass null to fall back to the real Service-Discover-backed value.
+    public void setMaxDownloadableFileSizeInMb(Integer maxDownloadableFileSizeInMb) {
+        this.maxDownloadableFileSizeInMb = maxDownloadableFileSizeInMb;
+    }
+
+    @Override
+    public int getMaxNumberOfFileVersion() {
+        return maxNumberOfFileVersion != null ? maxNumberOfFileVersion : super.getMaxNumberOfFileVersion();
+    }
+
+    // Useful for testing. Pass null to fall back to the real Service-Discover-backed value.
+    public void setMaxNumberOfFileVersion(Integer maxNumberOfFileVersion) {
+        this.maxNumberOfFileVersion = maxNumberOfFileVersion;
     }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/MockUserManagementService.java
@@ -54,6 +54,40 @@ public class MockUserManagementService extends UserManagementServiceImplBase {
   }
 
   /**
+   * Registers (or OVERWRITES — unlike {@link #registerToken(String, String)}, which is a no-op if
+   * the token already exists) a token-to-userId mapping with explicit account status, type, and
+   * feature-flag presence. Used by acceptance tests that need to drive {@code
+   * AuthenticationHandler}'s non-happy-path branches: inactive user (status != ACTIVE), guest user
+   * (type == GUEST), and feature-disabled user (the "carbonioFeatureFilesEnabled" feature key
+   * absent from the features list, which {@code UserMyself} maps to "FALSE").
+   *
+   * @param status a raw UM status string (e.g. "active", "maintenance", "closed", "locked", ...),
+   *     matched case-insensitively against {@link com.zextras.carbonio.files.dal.dao.UserStatus}
+   *     by the production mapper ({@code UserRepositoryRest#mapStatus}).
+   * @param type INTERNAL or GUEST.
+   * @param filesFeatureEnabled whether "carbonioFeatureFilesEnabled" is present in the features
+   *     list; its absence is mapped to "FALSE" by {@code UserMyself}.
+   */
+  public void registerToken(
+      String token, String userId, String status, UserTypeProto type, boolean filesFeatureEnabled) {
+    UserInfoProto info = UserInfoProto.newBuilder()
+        .setUserId(userId)
+        .setEmail("fake-email@example.com")
+        .setFullName("Fake User")
+        .setDomain("example.com")
+        .setStatus(status)
+        .setType(type)
+        .build();
+    UserMyselfProto.Builder myselfBuilder =
+        UserMyselfProto.newBuilder().setInfo(info).setLocale("en");
+    if (filesFeatureEnabled) {
+      myselfBuilder.addFeatures("carbonioFeatureFilesEnabled");
+    }
+    tokenToMyself.put(token, UserMyselfResponse.newBuilder().setUser(myselfBuilder.build()).build());
+    userIdToInfo.put(userId, info);
+  }
+
+  /**
    * Removes a userId from the {@code getUserById} lookup map so that subsequent
    * {@code getUserById} calls for this user will return NOT_FOUND.
    */

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/StoragesMockHelper.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/StoragesMockHelper.java
@@ -15,8 +15,21 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.JsonBody;
 import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
 
 public class StoragesMockHelper {
+
+  /**
+   * A syntactically-valid {@code StoragesUploadResponse}/{@code StoragesUploadResponse}-shaped
+   * JSON body (fields read by {@code com.zextras.storages.internal.pojo.StoragesUploadResponse}
+   * via its Gson {@code @SerializedName}s: {@code digest}, {@code digest_algorithm}, {@code
+   * size}). The exact digest/size values are arbitrary and stable — production only logs and
+   * stores them (as {@code Node.size} / {@code FileVersion.digest}), it never compares them
+   * against the actual uploaded bytes.
+   */
+  private static final String UPLOAD_SUCCESS_BODY =
+      "{\"digest\":\"deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe\","
+          + "\"digest_algorithm\":\"SHA-256\",\"size\":42}";
 
   private final MockServerClient storagesMock;
 
@@ -123,5 +136,93 @@ public class StoragesMockHelper {
             HttpResponse.response()
                 .withStatusCode(200)
                 .withBody(JsonBody.json(response)));
+  }
+
+  /**
+   * Mocks the PowerStore upload endpoint (path {@code /upload}, per the {@code Filestore}
+   * Retrofit interface's {@code @POST("upload")}/{@code @PUT("upload")} — the SDK's {@code
+   * uploadPost}/{@code uploadPut} both hit the same relative path, distinguished only by HTTP
+   * method; this stub matches BOTH since either can happen depending on whether the node is a
+   * brand-new upload or an overwrite) to succeed with a syntactically-valid response.
+   *
+   * <p>ALSO stubs the plain {@code GET /download} endpoint to succeed generically (any node id/
+   * version): {@code BlobService#verifyBlobExists} re-uses the download endpoint itself to check
+   * that the just-uploaded blob is readable — there is no dedicated "exists" endpoint. Since an
+   * upload's node id is server-generated (unknown ahead of time to the caller), this download stub
+   * intentionally does not filter by node/version query parameters. Required by every upload
+   * happy-path scenario.
+   */
+  public void uploadSucceeds() {
+    storagesMock
+        .when(HttpRequest.request().withPath("/upload"))
+        .respond(HttpResponse.response().withStatusCode(200).withBody(UPLOAD_SUCCESS_BODY));
+
+    storagesMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/download"))
+        .respond(HttpResponse.response().withStatusCode(200).withBody("upload-verify-ok"));
+  }
+
+  /**
+   * Mocks the PowerStore upload endpoint to return an HTTP 500, simulating an upload failure
+   * (production wraps this in a {@code DependencyException} -> 500, and rolls back the DB row
+   * created for the new node/version).
+   */
+  public void uploadFails() {
+    storagesMock
+        .when(HttpRequest.request().withPath("/upload"))
+        .respond(HttpResponse.response().withStatusCode(500));
+  }
+
+  /**
+   * Mocks the upload itself succeeding but the post-upload existence check failing: {@code
+   * BlobService#verifyBlobExists} re-uses {@code GET /download} (there is no dedicated "exists"
+   * endpoint), so this stubs the upload endpoint to succeed and the download endpoint to report
+   * the blob missing (404) — production treats that as an upload-verification failure
+   * (-> {@code DependencyException} -> 500) and rolls back the node/version DB row.
+   */
+  public void verifyMissing() {
+    storagesMock
+        .when(HttpRequest.request().withPath("/upload"))
+        .respond(HttpResponse.response().withStatusCode(200).withBody(UPLOAD_SUCCESS_BODY));
+
+    storagesMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET.toString()).withPath("/download"))
+        .respond(HttpResponse.response().withStatusCode(404));
+  }
+
+  /**
+   * Mocks the PowerStore copy endpoint (path {@code /copy}, {@code @PUT} per the {@code
+   * Filestore} Retrofit interface — used by {@code copyFile}/{@code cloneVersion}) to succeed
+   * with a syntactically-valid response.
+   */
+  public void copySucceeds() {
+    storagesMock
+        .when(HttpRequest.request().withMethod(HttpMethod.PUT.toString()).withPath("/copy"))
+        .respond(HttpResponse.response().withStatusCode(200).withBody(UPLOAD_SUCCESS_BODY));
+  }
+
+  /**
+   * Mocks the PowerStore copy endpoint to return an HTTP 500, simulating a filestore-copy failure
+   * ({@code copyFile}/{@code cloneVersion}'s dependency-failure branch).
+   */
+  public void copyFails() {
+    storagesMock
+        .when(HttpRequest.request().withMethod(HttpMethod.PUT.toString()).withPath("/copy"))
+        .respond(HttpResponse.response().withStatusCode(500));
+  }
+
+  /**
+   * Verifies the PowerStore upload endpoint was hit exactly once for this {@code nodeId}/{@code
+   * version} (either HTTP method — new-version POST or overwrite PUT both land on the same path).
+   */
+  public void verifyUploaded(String nodeId, int version) {
+    storagesMock
+        .verify(
+            HttpRequest.request()
+                .withPath("/upload")
+                .withQueryStringParameter(Parameter.param("node", nodeId))
+                .withQueryStringParameter(Parameter.param("version", String.valueOf(version)))
+                .withQueryStringParameter(Parameter.param("type", "files")),
+            VerificationTimes.atLeast(1));
   }
 }

--- a/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpRequest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/utilities/http/HttpRequest.java
@@ -15,15 +15,22 @@ public class HttpRequest {
 
   @Nullable private final String cookie;
   @Nullable private final String bodyPayload;
+  @Nullable private final byte[] binaryBody;
   @Nullable private final List<Map.Entry<String, String>> headers;
 
   private HttpRequest(
-      String method, String endpoint, @Nullable String cookie, @Nullable List<Map.Entry<String, String>> headers, @Nullable String bodyPayload) {
+      String method,
+      String endpoint,
+      @Nullable String cookie,
+      @Nullable List<Map.Entry<String, String>> headers,
+      @Nullable String bodyPayload,
+      @Nullable byte[] binaryBody) {
     this.method = method;
     this.endpoint = endpoint;
     this.cookie = cookie;
     this.bodyPayload = bodyPayload;
     this.headers = headers;
+    this.binaryBody = binaryBody;
   }
 
   public String getMethod() {
@@ -42,17 +49,44 @@ public class HttpRequest {
     return Optional.ofNullable(bodyPayload);
   }
 
+  /**
+   * The raw bytes for a binary/streamed upload request (see {@code FilesTestApp#upload}). Empty
+   * for every other request kind, which instead carry a text {@link #getBodyPayload()}.
+   */
+  public Optional<byte[]> getBinaryBody() {
+    return Optional.ofNullable(binaryBody);
+  }
+
   public Optional<List<Map.Entry<String, String>>> getHeaders() {
     return Optional.ofNullable(headers);
   }
 
   public static HttpRequest of(
       String method, String endpoint, @Nullable String cookie, @Nullable String bodyPayload) {
-    return new HttpRequest(method, endpoint, cookie, null, bodyPayload);
+    return new HttpRequest(method, endpoint, cookie, null, bodyPayload, null);
   }
 
   public static HttpRequest of(
       String method, String endpoint, @Nullable String cookie, @Nullable List<Map.Entry<String, String>> headers, @Nullable String bodyPayload) {
-    return new HttpRequest(method, endpoint, cookie, headers, bodyPayload);
+    return new HttpRequest(method, endpoint, cookie, headers, bodyPayload, null);
+  }
+
+  /**
+   * Factory for a binary/streamed upload request (the upload routes — {@code /upload},
+   * {@code /upload-version}, {@code /internal/upload}, {@code /upload-to} — read the body as a
+   * raw byte stream, not as JSON/form text, so they cannot use {@link #of}). Paired with {@code
+   * FilesTestApp#upload(HttpRequest)}.
+   *
+   * @param body the raw bytes to upload; the Content-Length sent on the wire is always computed
+   *     from this array's length by the {@code FilesTestApp} implementations (never taken from
+   *     {@code headers}).
+   */
+  public static HttpRequest ofUpload(
+      String method,
+      String endpoint,
+      @Nullable String cookie,
+      @Nullable List<Map.Entry<String, String>> headers,
+      byte[] body) {
+    return new HttpRequest(method, endpoint, cookie, headers, null, body);
   }
 }


### PR DESCRIPTION
## What

Phase 1 of the Quarkus-migration test strategy: make the integration tests **framework-agnostic** (black-box, driven through a neutral System-Under-Test seam) so they survive the future Quarkus rewrite with only import/wiring changes — then expand acceptance coverage as far as the HTTP/GraphQL contract reachably allows.

**Test-only: zero `src/main` changes across the whole branch.** The only non-test change is a single test-scope dependency (ArchUnit) that powers the purity guard.

## Part 1 — decoupling seam

- The 31 black-box integration tests are moved into a dedicated `com.zextras.carbonio.files.acceptance` package and driven **only** through a neutral `FilesTestApp` / `TestDataAccess` / `Mocks` seam. `com.google.inject.Injector` and `org.mockserver.*` no longer appear in any test body.
- The current Guice + Netty stack becomes **one** implementation of the seam (`GuiceNettyFilesTestApp`, EmbeddedChannel). A second implementation (`RealHttpFilesTestApp`) drives the real Netty server over a real HTTP socket, selectable with `-Dfiles.test.transport=http` — the same test bodies pass on both. At Quarkus-rewrite time only a new seam implementation is written; the acceptance test bodies stay unchanged.
- An ArchUnit test (`AcceptanceSuitePurityTest`) fails the build if any framework type leaks into the acceptance package (outside `acceptance/seam/impl`).

## Part 2 — coverage expansion

- Acceptance suite grown from 31 to **479 tests**, covering every reachable endpoint / query / mutation and their branches (auth-401 matrix, validation errors, uploads, downloads, copy/version ops, collaboration links + `/invite`, `/upload-to`, config/user resolvers, purge + broker effects, multi-download ZIP internals, …).
- HTTP-reachable **branch coverage 43.9% → 77.42%** (LINE 91.6%). Net of structurally-unreachable code (dead methods, `equals/hashCode` boilerplate, ORM layer, IO-fault paths), the genuinely reachable branches are ~93–95% covered.
- All tests behaviour-preserving: assertions capture the **actual current behaviour** (so the rewrite must preserve or deliberately change it). Green on both transports.

## Findings

~27 findings were surfaced while writing assertions and are documented **as tests, not fixed** (Phase 1 forbids `src/main` changes). They include a public-GraphQL-introspection security gap, a crashing `cloneVersion` error path, an uncaught `NumberFormatException` in config, and several dead/incorrect error mappings. Happy to break these out into individual tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4mL31QnQwWBJ9C7iPJUci
