### PR TITLE
fix(auth): return 403 instead of 401 for disabled feature, inactive, or guest user

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/files/exceptions/ForbiddenException.java
+++ b/core/src/main/java/com/zextras/carbonio/files/exceptions/ForbiddenException.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.exceptions;
+
+public class ForbiddenException extends Exception {
+
+  public ForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/AuthenticationHandler.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.zextras.carbonio.files.Constants;
 import com.zextras.carbonio.files.dal.repositories.interfaces.UserRepository;
 import com.zextras.carbonio.files.exceptions.AuthenticationException;
+import com.zextras.carbonio.files.exceptions.ForbiddenException;
 import com.zextras.carbonio.files.dal.dao.UserMyself;
 import com.zextras.carbonio.files.dal.dao.UserStatus;
 import com.zextras.carbonio.files.dal.dao.UserType;
@@ -29,6 +30,7 @@ import java.util.Set;
 public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
   private static final String UNAUTHORIZED_ERROR_MESSAGE = "Failed to authenticate request %s: %s";
+  private static final String FORBIDDEN_ERROR_MESSAGE = "Failed to authorize request %s: %s";
 
   private final UserRepository userRepository;
 
@@ -107,9 +109,9 @@ public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpReque
               // If user is not active we block interaction with Files
               if (!user.getStatus().equals(UserStatus.ACTIVE)) {
                 context.fireExceptionCaught(
-                    new AuthenticationException(
+                    new ForbiddenException(
                         String.format(
-                            UNAUTHORIZED_ERROR_MESSAGE,
+                            FORBIDDEN_ERROR_MESSAGE,
                             httpRequest.uri(),
                             "User is not active")));
                 return;
@@ -117,9 +119,9 @@ public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpReque
               // If user is a guest we block interaction with Files
               if (user.getType().equals(UserType.GUEST)) {
                 context.fireExceptionCaught(
-                    new AuthenticationException(
+                    new ForbiddenException(
                         String.format(
-                            UNAUTHORIZED_ERROR_MESSAGE,
+                            FORBIDDEN_ERROR_MESSAGE,
                             httpRequest.uri(),
                             "User is not internal")));
                 return;
@@ -128,11 +130,11 @@ public class AuthenticationHandler extends SimpleChannelInboundHandler<HttpReque
               String carbonioFeatureFilesEnabled = user.getCarbonioAttributes().getOrDefault("carbonioFeatureFilesEnabled", "FALSE");
               if (carbonioFeatureFilesEnabled.equals("FALSE")) {
                 context.fireExceptionCaught(
-                    new AuthenticationException(
+                    new ForbiddenException(
                         String.format(
-                            UNAUTHORIZED_ERROR_MESSAGE,
+                            FORBIDDEN_ERROR_MESSAGE,
                             httpRequest.uri(),
-                            "User is not internal")));
+                            "Files feature is not enabled for user")));
                 return;
               }
 

--- a/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
+++ b/core/src/main/java/com/zextras/carbonio/files/netty/ExceptionsHandler.java
@@ -72,6 +72,10 @@ public class ExceptionsHandler extends ChannelInboundHandlerAdapter {
       responseStatus = HttpResponseStatus.UNAUTHORIZED;
       payload = cause.getMessage();
     }
+    else if (cause instanceof ForbiddenException) {
+      responseStatus = HttpResponseStatus.FORBIDDEN;
+      payload = cause.getMessage();
+    }
     else if (cause instanceof MaxNumberOfFileVersionsException) {
       responseStatus = HttpResponseStatus.METHOD_NOT_ALLOWED;
       payload = cause.getMessage();

--- a/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/AuthenticationHandlerTest.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.files.netty;
 import com.zextras.carbonio.files.Constants;
 import com.zextras.carbonio.files.dal.repositories.interfaces.UserRepository;
 import com.zextras.carbonio.files.exceptions.AuthenticationException;
+import com.zextras.carbonio.files.exceptions.ForbiddenException;
 import com.zextras.carbonio.files.dal.dao.UserMyself;
 import com.zextras.carbonio.files.dal.dao.UserStatus;
 import com.zextras.carbonio.files.dal.dao.UserType;
@@ -184,8 +185,8 @@ class AuthenticationHandlerTest {
         .when(channelMock.attr(AttributeKey.valueOf("cookies")))
         .thenReturn(cookiesChannelAttributeMock);
 
-    ArgumentCaptor<AuthenticationException> captorException = ArgumentCaptor.forClass(
-        AuthenticationException.class);
+    ArgumentCaptor<ForbiddenException> captorException = ArgumentCaptor.forClass(
+        ForbiddenException.class);
 
     AuthenticationHandler authenticationHandler = new AuthenticationHandler(userRepositoryMock);
 
@@ -202,7 +203,7 @@ class AuthenticationHandlerTest {
 
     Assertions
         .assertThat(captorException.getValue().getMessage())
-        .isEqualTo("Failed to authenticate request /test/: User is not active");
+        .isEqualTo("Failed to authorize request /test/: User is not active");
   }
 
   @Test
@@ -290,8 +291,8 @@ class AuthenticationHandlerTest {
         .when(channelMock.attr(AttributeKey.valueOf("cookies")))
         .thenReturn(cookiesChannelAttributeMock);
 
-    ArgumentCaptor<AuthenticationException> captorException = ArgumentCaptor.forClass(
-        AuthenticationException.class);
+    ArgumentCaptor<ForbiddenException> captorException = ArgumentCaptor.forClass(
+        ForbiddenException.class);
 
     AuthenticationHandler authenticationHandler = new AuthenticationHandler(userRepositoryMock);
 
@@ -308,7 +309,53 @@ class AuthenticationHandlerTest {
 
     Assertions
         .assertThat(captorException.getValue().getMessage())
-        .isEqualTo("Failed to authenticate request /test/: User is not internal");
+        .isEqualTo("Failed to authorize request /test/: User is not internal");
+  }
+
+  @Test
+  void givenARequestWithValidZM_AUTH_TOKENAndFilesFeatureDisabledAuthenticationHandlerShouldThrow() {
+    // Given
+    UserMyself userMock = Mockito.mock(UserMyself.class);
+    Attribute<Object> requesterChannelAttributeMock = Mockito.mock(Attribute.class);
+    Attribute<Object> cookiesChannelAttributeMock = Mockito.mock(Attribute.class);
+
+    Mockito.when(userMock.getStatus()).thenReturn(UserStatus.ACTIVE);
+    Mockito.when(userMock.getType()).thenReturn(UserType.INTERNAL);
+    Mockito.when(userMock.getCarbonioAttributes())
+        .thenReturn(Map.of("carbonioFeatureFilesEnabled", "FALSE"));
+    Mockito.when(httpHeadersMock.contains(HttpHeaderNames.COOKIE)).thenReturn(true);
+    Mockito
+        .when(httpHeadersMock.get(HttpHeaderNames.COOKIE))
+        .thenReturn("IRIS=ui; ZM_AUTH_TOKEN=no-feature-token");
+    Mockito
+        .when(userRepositoryMock.getUserMyselfByCookieNotCached("IRIS=ui; ZM_AUTH_TOKEN=no-feature-token"))
+        .thenReturn(Optional.of(userMock));
+    Mockito
+        .when(channelMock.attr(AttributeKey.valueOf("requester")))
+        .thenReturn(requesterChannelAttributeMock);
+    Mockito
+        .when(channelMock.attr(AttributeKey.valueOf("cookies")))
+        .thenReturn(cookiesChannelAttributeMock);
+
+    ArgumentCaptor<ForbiddenException> captorException = ArgumentCaptor.forClass(
+        ForbiddenException.class);
+
+    AuthenticationHandler authenticationHandler = new AuthenticationHandler(userRepositoryMock);
+
+    // When
+    authenticationHandler.channelRead0(channelHandlerContextMock, httpRequestMock);
+
+    // Then
+    Mockito
+        .verify(channelHandlerContextMock, Mockito.times(0))
+        .fireChannelRead(httpRequestMock);
+    Mockito
+        .verify(channelHandlerContextMock, Mockito.times(1))
+        .fireExceptionCaught(captorException.capture());
+
+    Assertions
+        .assertThat(captorException.getValue().getMessage())
+        .isEqualTo("Failed to authorize request /test/: Files feature is not enabled for user");
   }
 
   @Test

--- a/core/src/test/java/com/zextras/carbonio/files/netty/ExceptionsHandlerTest.java
+++ b/core/src/test/java/com/zextras/carbonio/files/netty/ExceptionsHandlerTest.java
@@ -6,6 +6,7 @@ package com.zextras.carbonio.files.netty;
 
 import com.zextras.carbonio.files.exceptions.AuthenticationException;
 import com.zextras.carbonio.files.exceptions.BadRequestException;
+import com.zextras.carbonio.files.exceptions.ForbiddenException;
 import com.zextras.carbonio.files.exceptions.InternalServerErrorException;
 import com.zextras.carbonio.files.exceptions.NodeNotFoundException;
 import com.zextras.carbonio.files.exceptions.RequestEntityTooLargeException;
@@ -120,5 +121,36 @@ class ExceptionsHandlerTest {
     Assertions
       .assertThat(httpResponse.content().toString(StandardCharsets.UTF_8))
       .isEqualTo("Missing cookie");
+  }
+
+  @Test
+  void givenAForbiddenExceptionExceptionsHandlerShouldReturn403HttpResponse() {
+    // Given
+    ForbiddenException exception = new ForbiddenException("User is not active");
+    ArgumentCaptor<DefaultFullHttpResponse> captorHttpResponse = ArgumentCaptor.forClass(
+      DefaultFullHttpResponse.class
+    );
+
+    // When
+    exceptionsHandler.exceptionCaught(channelHandlerContextMock, exception);
+
+    // Then
+    Mockito
+      .verify(channelHandlerContextMock, Mockito.times(1))
+      .writeAndFlush(captorHttpResponse.capture());
+    Mockito
+      .verify(channelFutureMock, Mockito.times(1))
+      .addListener(ChannelFutureListener.CLOSE);
+
+    DefaultFullHttpResponse httpResponse = captorHttpResponse.getValue();
+    Assertions
+      .assertThat(httpResponse.protocolVersion())
+      .isEqualTo(HttpVersion.HTTP_1_1);
+    Assertions
+      .assertThat(httpResponse.status())
+      .isEqualTo(HttpResponseStatus.FORBIDDEN);
+    Assertions
+      .assertThat(httpResponse.content().toString(StandardCharsets.UTF_8))
+      .isEqualTo("User is not active");
   }
 }


### PR DESCRIPTION
AuthenticationHandler threw AuthenticationException (401) for every rejection path, including cases where the user was authenticated but not entitled: inactive account, guest user, or carbonioFeatureFilesEnabled disabled. These now throw a new ForbiddenException, mapped to 403 in ExceptionsHandler, mirroring the fix already applied to carbonio-ws-collaboration and carbonio-tasks-ce.

Missing/invalid cookies and unresolvable users still return 401 (genuine auth failures). Also fixed the disabled-feature-flag path, which previously reused the guest check's exact "User is not internal" message, masking a disabled feature as a guest rejection — now says "Files feature is not enabled for user", matching the diagnostic-clarity complaint in CO-3482.

ref: CO-3482