### PR TITLE
ci: run 'mvn package' (skip tests) in pre-commit maven hook [quarkus-migration]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
     rev: v0.3.4
     hooks:
       - id: maven
-        args: [ 'compile' ]
+        args: [ 'package', '--', '-DskipTests' ]
 
   - repo: local
     hooks:


### PR DESCRIPTION
Backport of the pre-commit `maven` hook change (`compile` → `package`) to the **Quarkus migration** branch — targets `quarkus-migration`, not `devel`.

Uses the **same hook line as the devel PR** — `args: [ 'package', '--', '-DskipTests' ]` — so the two branches don't conflict when `quarkus-migration` is later integrated. On this branch `skip.unit.tests` / `skip.integration.tests` default to `true`, so `-DskipTests` skips all tests. Verified locally: `mvn package -DskipTests` → BUILD SUCCESS, 0 tests run.

Committed as a single-file change (hook only): the branch's `generate-thirdparties` pre-commit hook currently fails on a **pre-existing stale `THIRDPARTIES`** (quarkus-extensions `1.13.0-1` → `1.14.0-1`, `+carbonio-systemd-notify`, `−logback`) — unrelated to this change, flagged separately for the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
