### PR TITLE
feat(internal): version-aware getNode on /internal (restore SDK version parity)

### DIFF
--- a/app/docs/openapi.json
+++ b/app/docs/openapi.json
@@ -364,6 +364,13 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "version",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -254,6 +254,11 @@ paths:
         required: true
         schema:
           type: string
+      - name: version
+        in: query
+        schema:
+          type: integer
+          format: int32
       responses:
         "200":
           description: OK

--- a/app/src/main/java/com/zextras/carbonio/files/rest/resources/InternalNodeResource.java
+++ b/app/src/main/java/com/zextras/carbonio/files/rest/resources/InternalNodeResource.java
@@ -37,6 +37,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.Optional;
@@ -56,8 +57,11 @@ import org.jboss.resteasy.reactive.RestResponse;
  * — no business logic is duplicated here:
  *
  * <ul>
- *   <li>{@code GET /internal/accounts/{userId}/nodes/{nodeId}} → {@link NodeRepository#getNode} +
- *       {@link PermissionsChecker#getPermissions}, assembled into an {@link InternalNodeDto}.
+ *   <li>{@code GET /internal/accounts/{userId}/nodes/{nodeId}[?version=N]} → {@link
+ *       NodeRepository#getNode} + {@link PermissionsChecker#getPermissions}, assembled into an
+ *       {@link InternalNodeDto}. The optional {@code version} query parameter selects a historical
+ *       file version's metadata (size/updatedAt/mimeType); when omitted the current version is
+ *       returned, replicating the retired GraphQL {@code getNode(node_id, version)} query.
  *   <li>{@code POST /internal/folders} → {@link NodeDataFetcher#createFolder} (the extracted core
  *       of the GraphQL {@code createFolder} mutation).
  *   <li>{@code POST /internal/links} → {@link LinkDataFetcher#createPublicLink} + {@link
@@ -96,7 +100,9 @@ public class InternalNodeResource {
   @Path("/accounts/{userId}/nodes/{nodeId}")
   @Blocking
   public RestResponse<InternalNodeDto> getNode(
-      @PathParam("userId") String userId, @PathParam("nodeId") String nodeId) {
+      @PathParam("userId") String userId,
+      @PathParam("nodeId") String nodeId,
+      @QueryParam("version") Integer version) {
     Optional<Node> optNode = nodeRepository.getNode(nodeId);
     if (optNode.isEmpty()) {
       return RestResponse.status(Status.NOT_FOUND);
@@ -107,18 +113,37 @@ public class InternalNodeResource {
       return RestResponse.status(Status.FORBIDDEN);
     }
 
-    return RestResponse.ok(toInternalNodeDto(optNode.get(), permissions));
+    Node node = optNode.get();
+    Optional<FileVersion> optFileVersion = Optional.empty();
+
+    if (node.getNodeType() != NodeType.FOLDER && node.getNodeType() != NodeType.ROOT) {
+      int resolvedVersion = version != null ? version : node.getCurrentVersion();
+      optFileVersion =
+          node.getFileVersions().stream()
+              .filter(fileVersion -> fileVersion.getVersion() == resolvedVersion)
+              .findFirst();
+
+      // An explicitly-requested missing version is a 404 (mirrors the GraphQL getNode
+      // fileVersionNotFound); an omitted version keeps today's tolerant current-version resolution.
+      if (version != null && optFileVersion.isEmpty()) {
+        return RestResponse.status(Status.NOT_FOUND);
+      }
+    }
+
+    return RestResponse.ok(toInternalNodeDto(node, optFileVersion, permissions));
   }
 
   /**
    * Assembles the {@link InternalNodeDto} for a node the requester can read. Mirrors the relevant
    * slice of {@code NodeDataFetcher#convertNodeToDataFetcherResult}: core fields come from {@link
    * Node}, but for a file the {@code mimeType}/{@code size}/{@code version}/{@code updatedAt}
-   * quadruplet is resolved from its current {@link FileVersion} and — CRITICALLY — {@code
+   * quadruplet is resolved from the already-selected {@link FileVersion} ({@code optFileVersion} —
+   * the requested version, or the current one when none was requested) and — CRITICALLY — {@code
    * updatedAt} is the FILE VERSION's timestamp, not the node's, replicating the GraphQL map's
    * silent same-key override (see the class javadoc of {@link InternalNodeDto}).
    */
-  private InternalNodeDto toInternalNodeDto(Node node, ACL permissions) {
+  private InternalNodeDto toInternalNodeDto(
+      Node node, Optional<FileVersion> optFileVersion, ACL permissions) {
     String extension = null;
     String mimeType = null;
     Long size = null;
@@ -127,12 +152,6 @@ public class InternalNodeResource {
 
     if (node.getNodeType() != NodeType.FOLDER && node.getNodeType() != NodeType.ROOT) {
       extension = node.getExtension().orElse(null);
-
-      Integer currentVersion = node.getCurrentVersion();
-      Optional<FileVersion> optFileVersion =
-          node.getFileVersions().stream()
-              .filter(fileVersion -> currentVersion.equals(fileVersion.getVersion()))
-              .findFirst();
 
       if (optFileVersion.isPresent()) {
         FileVersion fileVersion = optFileVersion.get();

--- a/app/src/test/java/com/zextras/carbonio/files/it/InternalNodeResourceApiIT.java
+++ b/app/src/test/java/com/zextras/carbonio/files/it/InternalNodeResourceApiIT.java
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.files.it;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.files.FilesStackTestResource;
+import com.zextras.carbonio.files.it.support.AbstractFilesIT;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Out-of-process {@code @QuarkusIntegrationTest} (on {@link AbstractFilesIT}) for the version-aware
+ * trusted-caller node-metadata endpoint {@code GET /internal/accounts/{userId}/nodes/{nodeId}}. The
+ * optional {@code version} query parameter restores parity with the retired GraphQL {@code
+ * getNode(node_id, version)} query: omitting it returns the CURRENT version's metadata (unchanged
+ * legacy behaviour), while {@code ?version=N} returns that historical version's version-scoped
+ * fields (size/updatedAt/mimeType) so a consumer opening an older version (e.g. docs-connector
+ * WOPI) sees metadata that matches the bytes {@code /download/{nodeId}/{version}} serves. Like the
+ * sibling {@link InternalBlobResourceApiIT}, none of these routes has an auth-handler (mesh mTLS is
+ * the trust boundary): the {@code userId} PATH segment alone drives whose ACLs are checked.
+ */
+class InternalNodeResourceApiIT extends AbstractFilesIT {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String REQUESTER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-token";
+
+  @BeforeAll
+  static void registerUsers() {
+    FilesStackTestResource.getUserManagementService().registerToken("fake-token", REQUESTER_ID);
+  }
+
+  /** Deliberately takes NO cookie: {@code /internal/**} has no auth-handler in its pipeline. */
+  private static Response internalGetNode(String userId, String nodeId, Integer version) {
+    var request = RestAssured.given();
+    if (version != null) {
+      request = request.queryParam("version", version);
+    }
+    return request.get("/internal/accounts/" + userId + "/nodes/" + nodeId);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asMap(Response response) throws Exception {
+    return OBJECT_MAPPER.readValue(response.getBody().asString(), Map.class);
+  }
+
+  @Test
+  void internalGetNodeShouldBeVersionAwareAcrossTwoVersionsOfDifferentSize() throws Exception {
+    // Given — a file with v1, then a differently-sized v2 (now the current version). tickClock()
+    // guarantees v2's updated_at is strictly greater than v1's, so the version-scoped updatedAt is
+    // observably distinct, not just the size.
+    byte[] v1 = "v1-small".getBytes(StandardCharsets.UTF_8); // 8 bytes
+    byte[] v2 = "v2-considerably-longer-body".getBytes(StandardCharsets.UTF_8); // 27 bytes
+    String nodeId = seedFile("versioned.txt", LOCAL_ROOT, v1, REQUESTER_COOKIE);
+    tickClock();
+    int currentVersion = seedVersion(nodeId, v2, "versioned.txt", REQUESTER_COOKIE);
+    Assertions.assertThat(currentVersion).isEqualTo(2);
+
+    // When — omitting version returns the CURRENT (v2) metadata, exactly as before.
+    Response currentResponse = internalGetNode(REQUESTER_ID, nodeId, null);
+    Assertions.assertThat(currentResponse.getStatusCode()).isEqualTo(200);
+    Map<String, Object> current = asMap(currentResponse);
+    Assertions.assertThat(((Number) current.get("version")).intValue()).isEqualTo(2);
+    Assertions.assertThat(((Number) current.get("size")).longValue()).isEqualTo(v2.length);
+    long currentUpdatedAt = ((Number) current.get("updatedAt")).longValue();
+
+    // And — an explicit ?version=1 returns v1's version-scoped metadata, NOT the current one.
+    Response v1Response = internalGetNode(REQUESTER_ID, nodeId, 1);
+    Assertions.assertThat(v1Response.getStatusCode()).isEqualTo(200);
+    Map<String, Object> versionOne = asMap(v1Response);
+    Assertions.assertThat(((Number) versionOne.get("version")).intValue()).isEqualTo(1);
+    Assertions.assertThat(((Number) versionOne.get("size")).longValue()).isEqualTo(v1.length);
+    long v1UpdatedAt = ((Number) versionOne.get("updatedAt")).longValue();
+    Assertions.assertThat(v1UpdatedAt).isLessThan(currentUpdatedAt);
+
+    // Node-level fields are identical regardless of the requested version.
+    Assertions.assertThat(versionOne.get("id")).isEqualTo(current.get("id")).isEqualTo(nodeId);
+    Assertions.assertThat(versionOne.get("name")).isEqualTo(current.get("name"));
+  }
+
+  @Test
+  void internalGetNodeWithANonExistentVersionShouldReturn404() throws Exception {
+    String nodeId =
+        seedFile(
+            "onlyOneVersion.txt",
+            LOCAL_ROOT,
+            "content".getBytes(StandardCharsets.UTF_8),
+            REQUESTER_COOKIE);
+
+    Response response = internalGetNode(REQUESTER_ID, nodeId, 99);
+
+    Assertions.assertThat(response.getStatusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void internalGetNodeOfANonExistentNodeShouldReturn404() {
+    String nonExistentId = "10000000-0000-0000-0000-00000000ffff";
+    Response response = internalGetNode(REQUESTER_ID, nonExistentId, null);
+    Assertions.assertThat(response.getStatusCode()).isEqualTo(404);
+  }
+}

--- a/app/src/test/java/com/zextras/carbonio/files/rest/resources/InternalNodeResourceTest.java
+++ b/app/src/test/java/com/zextras/carbonio/files/rest/resources/InternalNodeResourceTest.java
@@ -80,7 +80,7 @@ class InternalNodeResourceTest {
   void getNode_returns404WhenNodeNotFound() {
     when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.empty());
 
-    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID);
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, null);
 
     assertThat(response.getStatus()).isEqualTo(404);
     verify(permissionsChecker, never()).getPermissions(any(), any());
@@ -93,7 +93,7 @@ class InternalNodeResourceTest {
     when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(node));
     when(permissionsChecker.getPermissions(NODE_ID, USER_ID)).thenReturn(ACL.decode(ACL.NONE));
 
-    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID);
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, null);
 
     assertThat(response.getStatus()).isEqualTo(403);
   }
@@ -110,7 +110,7 @@ class InternalNodeResourceTest {
     when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(folder));
     when(permissionsChecker.getPermissions(NODE_ID, USER_ID)).thenReturn(ACL.decode(ACL.OWNER));
 
-    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID);
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, null);
 
     assertThat(response.getStatus()).isEqualTo(200);
     InternalNodeDto dto = response.getEntity();
@@ -152,7 +152,7 @@ class InternalNodeResourceTest {
     when(permissionsChecker.getPermissions(NODE_ID, USER_ID))
         .thenReturn(ACL.decode(SharePermission.READ_ONLY));
 
-    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID);
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, null);
 
     assertThat(response.getStatus()).isEqualTo(200);
     InternalNodeDto dto = response.getEntity();
@@ -163,6 +163,110 @@ class InternalNodeResourceTest {
     // The resolved (current, version 2) FileVersion's timestamp, NOT the node's 1000L.
     assertThat(dto.updatedAt()).isEqualTo(2000L);
     assertThat(dto.permissions().canWriteFile()).isFalse();
+  }
+
+  @Test
+  void getNode_withExplicitOlderVersion_returnsThatVersionsMetadata_notTheCurrent() {
+    // Version-aware getNode: an explicit ?version=1 must resolve version 1's size/updatedAt even
+    // though version 2 is the current one, matching the retired GraphQL getNode(node_id, version).
+    Node file = mock(Node.class);
+    when(file.getId()).thenReturn(NODE_ID);
+    when(file.getName()).thenReturn("report");
+    when(file.getNodeType()).thenReturn(NodeType.TEXT);
+    when(file.getOwnerId()).thenReturn(OWNER_ID);
+    when(file.getParentId()).thenReturn(Optional.of(PARENT_ID));
+    when(file.getExtension()).thenReturn(Optional.of("pdf"));
+
+    FileVersion versionOne =
+        new FileVersion(NODE_ID, "editor-1", 500L, 1, "application/pdf", 111L, "digest1", false);
+    FileVersion versionTwo =
+        new FileVersion(NODE_ID, "editor-2", 2000L, 2, "application/pdf", 222L, "digest2", false);
+    when(file.getFileVersions()).thenReturn(List.of(versionOne, versionTwo));
+
+    when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(file));
+    when(permissionsChecker.getPermissions(NODE_ID, USER_ID))
+        .thenReturn(ACL.decode(SharePermission.READ_ONLY));
+
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, 1);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    InternalNodeDto dto = response.getEntity();
+    assertThat(dto.version()).isEqualTo(1);
+    assertThat(dto.size()).isEqualTo(111L);
+    // Version 1's timestamp, NOT version 2's (2000L) nor the node-level fallback.
+    assertThat(dto.updatedAt()).isEqualTo(500L);
+    // getCurrentVersion() must NOT be consulted when an explicit version is requested.
+    verify(file, never()).getCurrentVersion();
+  }
+
+  @Test
+  void getNode_withExplicitCurrentVersion_matchesTheNoVersionCall() {
+    Node file = mock(Node.class);
+    when(file.getId()).thenReturn(NODE_ID);
+    when(file.getName()).thenReturn("report");
+    when(file.getNodeType()).thenReturn(NodeType.TEXT);
+    when(file.getOwnerId()).thenReturn(OWNER_ID);
+    when(file.getParentId()).thenReturn(Optional.of(PARENT_ID));
+    when(file.getExtension()).thenReturn(Optional.of("pdf"));
+
+    FileVersion versionOne =
+        new FileVersion(NODE_ID, "editor-1", 500L, 1, "application/pdf", 111L, "digest1", false);
+    FileVersion versionTwo =
+        new FileVersion(NODE_ID, "editor-2", 2000L, 2, "application/pdf", 222L, "digest2", false);
+    when(file.getFileVersions()).thenReturn(List.of(versionOne, versionTwo));
+
+    when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(file));
+    when(permissionsChecker.getPermissions(NODE_ID, USER_ID))
+        .thenReturn(ACL.decode(SharePermission.READ_ONLY));
+
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, 2);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    InternalNodeDto dto = response.getEntity();
+    assertThat(dto.version()).isEqualTo(2);
+    assertThat(dto.size()).isEqualTo(222L);
+    assertThat(dto.updatedAt()).isEqualTo(2000L);
+  }
+
+  @Test
+  void getNode_withNonExistentVersion_returns404() {
+    Node file = mock(Node.class);
+    when(file.getNodeType()).thenReturn(NodeType.TEXT);
+
+    FileVersion versionOne =
+        new FileVersion(NODE_ID, "editor-1", 500L, 1, "application/pdf", 111L, "digest1", false);
+    when(file.getFileVersions()).thenReturn(List.of(versionOne));
+
+    when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(file));
+    when(permissionsChecker.getPermissions(NODE_ID, USER_ID))
+        .thenReturn(ACL.decode(SharePermission.READ_ONLY));
+
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, 99);
+
+    assertThat(response.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void getNode_versionOnAFolderIsIgnored() {
+    // Folders carry no file versions; a stray ?version=1 must NOT 404 — it is silently ignored,
+    // exactly as the GraphQL datafetcher skipped the file-version block for FOLDER/ROOT.
+    Node folder = mock(Node.class);
+    when(folder.getId()).thenReturn(NODE_ID);
+    when(folder.getName()).thenReturn("My Folder");
+    when(folder.getNodeType()).thenReturn(NodeType.FOLDER);
+    when(folder.getOwnerId()).thenReturn(OWNER_ID);
+    when(folder.getParentId()).thenReturn(Optional.of(PARENT_ID));
+    when(folder.getUpdatedAt()).thenReturn(1000L);
+    when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(folder));
+    when(permissionsChecker.getPermissions(NODE_ID, USER_ID)).thenReturn(ACL.decode(ACL.OWNER));
+
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, 1);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    InternalNodeDto dto = response.getEntity();
+    assertThat(dto.version()).isNull();
+    assertThat(dto.size()).isNull();
+    assertThat(dto.updatedAt()).isEqualTo(1000L);
   }
 
   @Test
@@ -177,7 +281,7 @@ class InternalNodeResourceTest {
     when(nodeRepository.getNode(NODE_ID)).thenReturn(Optional.of(root));
     when(permissionsChecker.getPermissions(NODE_ID, USER_ID)).thenReturn(ACL.decode(ACL.OWNER));
 
-    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID);
+    RestResponse<InternalNodeDto> response = resource.getNode(USER_ID, NODE_ID, null);
 
     assertThat(response.getEntity().parent()).isNull();
   }

--- a/sdk/src/main/java/com/zextras/carbonio/files/sdk/FilesInternalClient.java
+++ b/sdk/src/main/java/com/zextras/carbonio/files/sdk/FilesInternalClient.java
@@ -161,14 +161,34 @@ public final class FilesInternalClient {
   // -------------------------------------------------------------------------------------- getNode
 
   /**
-   * Fetches a node's metadata, as {@code userId} sees it (permissions included).
+   * Fetches the CURRENT version's metadata of {@code nodeId}, as {@code userId} sees it
+   * (permissions included). Unchanged, backward-compatible surface: existing consumers that do not
+   * care about a historical version keep calling this two-argument method exactly as before.
    *
    * @throws FilesInternalClientException wrapping a 404 (node does not exist) or 403 (exists, but
    *     {@code userId} cannot read it) response, or any transport-level failure.
    */
   public InternalNodeDto getNode(String userId, String nodeId) {
     try {
-      return nodeApi.internalAccountsUserIdNodesNodeIdGet(nodeId, userId);
+      return nodeApi.internalAccountsUserIdNodesNodeIdGet(nodeId, userId, null);
+    } catch (ApiException e) {
+      throw mapApiException("getNode", e);
+    }
+  }
+
+  /**
+   * Fetches a SPECIFIC {@code version}'s metadata of {@code nodeId}, as {@code userId} sees it
+   * (permissions included) — the version-scoped fields (size, updatedAt, mimeType) reflect the
+   * requested version rather than the current one. Restores parity with the retired GraphQL SDK's
+   * {@code getNode(node_id, version)} for consumers (e.g. docs-connector WOPI) that open a
+   * historical version and need its metadata to match the bytes served by {@link #downloadFile}.
+   *
+   * @throws FilesInternalClientException wrapping a 404 (node does not exist, {@code userId} cannot
+   *     read it, or the node has no such {@code version}) response, or any transport-level failure.
+   */
+  public InternalNodeDto getNode(String userId, String nodeId, int version) {
+    try {
+      return nodeApi.internalAccountsUserIdNodesNodeIdGet(nodeId, userId, version);
     } catch (ApiException e) {
       throw mapApiException("getNode", e);
     }

--- a/sdk/src/test/java/com/zextras/carbonio/files/sdk/FilesInternalClientTest.java
+++ b/sdk/src/test/java/com/zextras/carbonio/files/sdk/FilesInternalClientTest.java
@@ -79,6 +79,76 @@ class FilesInternalClientTest {
   }
 
   @Test
+  void getNodeWithVersionSendsTheVersionQueryParamAndParsesThatVersionsMetadata() throws Exception {
+    AtomicReference<String> receivedRawQuery = new AtomicReference<>();
+
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/internal/accounts/user-1/nodes/node-1",
+        exchange -> {
+          try {
+            receivedRawQuery.set(exchange.getRequestURI().getRawQuery());
+            byte[] body =
+                "{\"id\":\"node-1\",\"version\":1,\"size\":111}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+              os.write(body);
+            }
+          } finally {
+            exchange.close();
+          }
+        });
+    server.start();
+
+    FilesInternalClient client =
+        FilesInternalClient.atURL("http://localhost:" + server.getAddress().getPort());
+
+    var node =
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(10), () -> client.getNode("user-1", "node-1", 1), "getNode hung");
+
+    assertEquals("version=1", receivedRawQuery.get());
+    assertEquals(1, node.getVersion());
+    assertEquals(111L, node.getSize());
+  }
+
+  @Test
+  void getNodeWithoutVersionSendsNoVersionQueryParam() throws Exception {
+    AtomicReference<String> receivedRawQuery = new AtomicReference<>();
+
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/internal/accounts/user-1/nodes/node-1",
+        exchange -> {
+          try {
+            receivedRawQuery.set(exchange.getRequestURI().getRawQuery());
+            byte[] body =
+                "{\"id\":\"node-1\",\"version\":2,\"size\":222}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+              os.write(body);
+            }
+          } finally {
+            exchange.close();
+          }
+        });
+    server.start();
+
+    FilesInternalClient client =
+        FilesInternalClient.atURL("http://localhost:" + server.getAddress().getPort());
+
+    var node =
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(10), () -> client.getNode("user-1", "node-1"), "getNode hung");
+
+    // The two-argument (current-version) call must NOT append a version query param.
+    assertTrue(receivedRawQuery.get() == null || receivedRawQuery.get().isEmpty());
+    assertEquals(2, node.getVersion());
+  }
+
+  @Test
   void uploadFileSendsRealContentLengthAndReturnsNodeId() throws Exception {
     byte[] payload = randomBytes(PAYLOAD_SIZE);
     AtomicReference<String> receivedContentLength = new AtomicReference<>();


### PR DESCRIPTION
## Summary

Restores **version parity** for the `/internal` getNode after the Quarkus migration: consumers can again fetch a **specific node version's** metadata, matching the retired GraphQL `getNode(node_id, version)`. Additive and fully backward-compatible.

- **Endpoint** (`InternalNodeResource`): `GET /internal/accounts/{userId}/nodes/{nodeId}` gains an **optional** `version` query param. Present → returns that `FileVersion`'s version-scoped fields (`mimeType`, `size`, `version`, `updatedAt`); node-level fields (`id`, `name`, `owner`, `parent`, `permissions`) are unaffected. Absent → behaviour is **byte-for-byte identical** to today (current version). An explicitly-requested missing version → **404** (mirrors the existing `/internal/download/{nodeId}/{version}` 404 and the old GraphQL `fileVersionNotFound`); a stray `?version` on a folder is ignored.
- **SDK** (`FilesInternalClient` facade): **keeps** `getNode(userId, nodeId)` intact and **adds** `getNode(userId, nodeId, version)`. Existing consumers (mailbox / videorecorder / advanced) are untouched; only version-aware callers (docs-connector WOPI historical-version viewing) use the new overload. The generated client method takes a nullable `version` (omitted when null).
- Version-scoped vs node-level split verified against the still-present GraphQL implementation in this repo (`NodeDataFetcher` → `convertFileVersionToGraphQLMap`), not just history.
- **OpenAPI** regenerated (purely additive `version` query param); committed verbatim for the "Verify Build Outputs" stage.

## Why

The migration's `/internal` getNode had no `version` param, so historical-version opens returned the **current** version's metadata while the blob download served the requested version → metadata/content mismatch in the WOPI path (size-limit gate + CheckFileInfo). This closes that gap so the SDK swap is truly seamless.

## Tests

- Unit `InternalNodeResourceTest`: 14/14 (explicit older version returns v1 size/updatedAt, never calls current; explicit current; missing version → 404; version-on-folder ignored).
- SDK `FilesInternalClientTest`: 5/5 (3-arg puts `version=N` on the wire + parses that version; 2-arg sends no version).
- New IT `InternalNodeResourceApiIT` (`@QuarkusIntegrationTest`, real postgres + mocks): 3/3 — seeds v1+v2, asserts no-version→v2, `?version=1`→v1 (smaller size + earlier updatedAt), node-level fields stable across versions, `?version=99`→404.

Follow-up to the Quarkus migration (CE 2.0.0). Once released, advanced repins + regenerates its SDK, and docs-connector adopts the version-aware call.
